### PR TITLE
fix: error when github does not respond with expected data.

### DIFF
--- a/root/app/calibre-web/cps/render_template.py
+++ b/root/app/calibre-web/cps/render_template.py
@@ -116,7 +116,7 @@ def cwa_update_available() -> tuple[bool, str, str]:
     with open("/app/CWA_RELEASE", 'r') as f:
         current_version = f.read().strip()
     response = requests.get("https://api.github.com/repos/crocodilestick/calibre-web-automated/releases/latest")
-    tag_name = response.json()['tag_name']
+    tag_name = response.json().get('tag_name', current_version)
     return (tag_name != current_version), current_version, tag_name
 
 # Gets the date the last cwa update notification was displayed


### PR DESCRIPTION
In case of a ratelimit github does not answer with the expected `tag_name` resulting in an error and therefore making the UI unusable.

I propose to make it so that if the expected `tag_name` key is not present replace it by the current version so that it does not result in an error and does not trigger update notification.