### PR TITLE
convert-library - don't copy original book when failed to convert the file | import converted book first before rm existing book | move failed import to processed_books/failed

### DIFF
--- a/scripts/convert-library.py
+++ b/scripts/convert-library.py
@@ -101,16 +101,6 @@ class LibraryConverter:
                 print_and_log(f"[convert-library]: Conversion of {os.path.basename(file)} successful! Removing old version from library...")
             except subprocess.CalledProcessError as e:
                 print_and_log(f"[convert-library]: Conversion of {os.path.basename(file)} was unsuccessful. See the following error:\n{e}")
-                shutil.copyfile(file, f"/config/processed_books/failed/{os.path.basename(file)}")
-                self.current_book += 1
-                continue
-
-            try: # Remove Book from Existing Library
-                subprocess.run(["calibredb", "remove", book_id, "--permanent", "--with-library", self.library_dir], check=True)
-
-                print_and_log(f"[convert-library]: Non-epub version of {Path(file).stem} (Book ID: {book_id}) was successfully removed from library.\nAdding converted version to library...")
-            except subprocess.CalledProcessError as e:
-                print_and_log(f"[convert-library]: Non-epub version of {Path(file).stem} couldn't be successfully removed from library. See the following error:\n{e}")
                 self.current_book += 1
                 continue
 
@@ -126,6 +116,16 @@ class LibraryConverter:
                 print_and_log(f"[convert-library]: Import of {os.path.basename(target_filepath)} successfully completed!")
             except subprocess.CalledProcessError as e:
                 print_and_log(f"[convert-library]: Import of {os.path.basename(target_filepath)} was not successfully completed. See the following error:\n{e}")
+                shutil.move(target_filepath, f"/config/processed_books/failed/{os.path.basename(target_filepath)}")
+                self.current_book += 1
+                continue
+
+            try: # Remove Book from Existing Library
+                subprocess.run(["calibredb", "remove", book_id, "--permanent", "--with-library", self.library_dir], check=True)
+
+                print_and_log(f"[convert-library]: Non-epub version of {Path(file).stem} (Book ID: {book_id}) was successfully removed from library.\nAdding converted version to library...")
+            except subprocess.CalledProcessError as e:
+                print_and_log(f"[convert-library]: Non-epub version of {Path(file).stem} couldn't be successfully removed from library. See the following error:\n{e}")
                 self.current_book += 1
                 continue
 


### PR DESCRIPTION
i have a feeling convert-library in 2.1.0 shouldn't copy failed conversions to processed_books/failed, but simply only log that book file conversion error. Makes sense for ingest folder to move failed adds to that folder, but for convert-library, it'd be wasting storage space because its just duplicating it 

convert-library also seems to have a logical bug where if importing converted book to library fails, the user is left with a calibre library where the original book is completely deleted and the converted book is just stuck in the tmp folder

For this, we could have it import converted book first, then remove the original book in the library after. So if it failed to import converted book, they at least have the book still in the library. 

And when it fails to import converted book, we can move this to processed_books/failed which it doesn't currently do, so they at least have the converted books on hand to manually import later possibly with cwa-ingest 