### PR TITLE
Add script to quickly build docker image and run container | Improve table of contents linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   - [Docker-Compose](#using-docker-compose-recommended) 🐋⭐(Recommended)
   - [For Developers](#for-developers) 🚀
 - [Usage](#usage-)
-- [Further Development](https://github.com/crocodilestick/Calibre-Web-Automated?tab=readme-ov-file#method-2-using-the-script-install-method-with-clean-calibre-web-base-image--not-recommended) 🏗️
+- [Further Development](#further-development-️) 🏗️
 - [Support / Buy me a Coffee](https://ko-fi.com/crocodilestick) ☕
 
 ## Why does it exist? 🔓

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [How to Install](#how-to-install-): 📖
   - [Quick Install](#quick-install-) 🚀
   - [Docker-Compose](#using-docker-compose-recommended) 🐋⭐(Recommended)
-  - [For Developers](#for-developers) 🚀
+  - [For Developers](#for-developers--building-custom-docker-image) 🚀
 - [Usage](#usage-)
 - [Further Development](#further-development-️) 🏗️
 - [Support / Buy me a Coffee](https://ko-fi.com/crocodilestick) ☕
@@ -161,7 +161,7 @@ And that's you off to the races! 🥳 HOWEVER to avoid potential problems and en
 
 ### 1. Setup the container using the Docker Compose template below: 🐋📜
 
-```
+```yml
 ---
 services:
   calibre-web-automated:
@@ -196,11 +196,12 @@ services:
 ### And just like that, Calibre-Web Automated should be up and running!
 
 ---
-## For Developers
-If you want to contribute to this project, you can build a docker file by running `build.sh` in the repository.
-This will build the docker image of the cloned repository with the modifications you have made>
+## For Developers - Building Custom Docker Image
+If you want to contribute to this project, you can build the docker file by running `build.sh` in the repository.
+This will build the docker image of the cloned repository with the modifications you have made. the `build/` folder
+will be made, containing the the development docker-compose.yml and the mountpoints. Add a test library if necessary>
 
-```
+```bash
 $ chmod +x build.sh
 $ ./build.sh
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [How to Install](#how-to-install-): 📖
   - [Quick Install](#quick-install-) 🚀
   - [Docker-Compose](#using-docker-compose-recommended) 🐋⭐(Recommended)
-  - [For Developers](#for-developers--building-custom-docker-image) 🚀
+  - [For Developers](#for-developers---building-custom-docker-image) 🚀
 - [Usage](#usage-)
 - [Further Development](#further-development-️) 🏗️
 - [Support / Buy me a Coffee](https://ko-fi.com/crocodilestick) ☕

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   - [Quick Install](#quick-install-) 🚀
   - [Docker-Compose](#using-docker-compose-recommended) 🐋⭐(Recommended)
   - [For Developers](#for-developers---building-custom-docker-image) 🚀
+- [Post-Install Tasks](#post-install-tasks)
+- [Usage](#usage-)
 - [Usage](#usage-)
 - [Further Development](#further-development-️) 🏗️
 - [Support / Buy me a Coffee](https://ko-fi.com/crocodilestick) ☕
@@ -154,7 +156,7 @@ curl -OL https://raw.githubusercontent.com/crocodilestick/calibre-web-automated/
 docker compose up -d
 ```
 
-And that's you off to the races! 🥳 HOWEVER to avoid potential problems and ensure maximum functionality, we recommend carrying out these [Post-Install Tasks Here](#recommended-post-install-tasks).
+And that's you off to the races! 🥳 HOWEVER to avoid potential problems and ensure maximum functionality, we recommend carrying out these [Post-Install Tasks Here](#post-install-tasks).
 
 ---
 ## Using Docker Compose 🐋⭐(Recommended)
@@ -194,7 +196,7 @@ services:
   - `/app/calibre-web/gmail.json` _(Optional)_ - This is used to setup Calibre-Web and/or CWA with your gmail account for sending books via email. Follow the guide [here](https://github.com/janeczku/calibre-web/wiki/Setup-Mailserver#gmail) if this is something you're interested in but be warned it can be a very fiddly process, I would personally recommend a simple SMTP Server
 
 And just like that, Calibre-Web Automated should be up and running! HOWEVER to avoid potential problems and ensure maximum functionality,
-we recommend carrying out these [Post-Install Tasks Here](#recommended-post-install-tasks).
+we recommend carrying out these [Post-Install Tasks Here](#post-install-tasks).
 
 <!-- - By default, `/cwa-book-ingest` is the ingest folder bound to the ingest folder you entered in the Docker Compose template however should you want to change any of the default directories, use the `cwa-change-dirs` command from within the container to edit the default paths -->
 ---
@@ -208,11 +210,11 @@ $ chmod +x build.sh
 $ ./build.sh
 ```
 
-Check out [Post-Install Tasks Here](#recommended-post-install-tasks) when necessary.
+Check out [Post-Install Tasks Here](#post-install-tasks) when necessary.
 
 ---
 
-# Recommended Post-Install Tasks:
+# Post-Install Tasks:
 
 ## _Calibre-Web Quick Start Guide_
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@
 
 ## _Quick Access_
 
-- [Features](https://github.com/crocodilestick/Calibre-Web-Automated?tab=readme-ov-file#what-does-it-do-) 🪄
+- [Features](#what-does-it-do-) 🪄
 - [Releases](https://github.com/crocodilestick/Calibre-Web-Automated/releases) 🆕
-- [Roadmap](https://github.com/crocodilestick/Calibre-Web-Automated?tab=readme-ov-file#under-active-development-%EF%B8%8F) 🛣️
-- [How to Install](https://github.com/crocodilestick/Calibre-Web-Automated?tab=readme-ov-file#how-to-install-): 📖
-  - [Docker-Compose](https://github.com/crocodilestick/Calibre-Web-Automated?tab=readme-ov-file#method-1-using-docker-compose--recommended) 🐋⭐(Recommended)
-  - [Quick Install](https://github.com/crocodilestick/Calibre-Web-Automated/tree/main?tab=readme-ov-file#quick-install-) 🚀
-- [Usage](https://github.com/crocodilestick/Calibre-Web-Automated?tab=readme-ov-file#method-2-using-the-script-install-method-with-clean-calibre-web-base-image--not-recommended) 🔧
+- [Roadmap](#under-active-development-%EF%B8%8F) 🛣️
+- [How to Install](#how-to-install-): 📖
+  - [Quick Install](#quick-install-) 🚀
+  - [Docker-Compose](#using-docker-compose-recommended) 🐋⭐(Recommended)
+  - [For Developers](#for-developers) 🚀
+- [Usage](#usage-)
 - [Further Development](https://github.com/crocodilestick/Calibre-Web-Automated?tab=readme-ov-file#method-2-using-the-script-install-method-with-clean-calibre-web-base-image--not-recommended) 🏗️
 - [Support / Buy me a Coffee](https://ko-fi.com/crocodilestick) ☕
 
@@ -193,6 +194,16 @@ services:
   - `/app/calibre-web/gmail.json` _(Optional)_ - This is used to setup Calibre-Web and/or CWA with your gmail account for sending books via email. Follow the guide [here](https://github.com/janeczku/calibre-web/wiki/Setup-Mailserver#gmail) if this is something you're interested in but be warned it can be a very fiddly process, I would personally recommend a simple SMTP Server
 
 ### And just like that, Calibre-Web Automated should be up and running!
+
+---
+## For Developers
+If you want to contribute to this project, you can build a docker file by running `build.sh` in the repository.
+This will build the docker image of the cloned repository with the modifications you have made>
+
+```
+$ chmod +x build.sh
+$ ./build.sh
+```
 
 <!-- - By default, `/cwa-book-ingest` is the ingest folder bound to the ingest folder you entered in the Docker Compose template however should you want to change any of the default directories, use the `cwa-change-dirs` command from within the container to edit the default paths -->
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ curl -OL https://raw.githubusercontent.com/crocodilestick/calibre-web-automated/
 docker compose up -d
 ```
 
-And that's you off to the races! 🥳 HOWEVER to avoid potential problems and ensure maximum functionality, we recommend carrying out these [Post-Install Tasks Here](#3-recommended-post-install-tasks).
+And that's you off to the races! 🥳 HOWEVER to avoid potential problems and ensure maximum functionality, we recommend carrying out these [Post-Install Tasks Here](#recommended-post-install-tasks).
 
 ---
 ## Using Docker Compose 🐋⭐(Recommended)
@@ -193,8 +193,10 @@ services:
   - `/books` _(Optional)_ - This is purely optional, I personally bind /books to where I store my downloaded books so that they accessible from within the container but CWA doesn't require this
   - `/app/calibre-web/gmail.json` _(Optional)_ - This is used to setup Calibre-Web and/or CWA with your gmail account for sending books via email. Follow the guide [here](https://github.com/janeczku/calibre-web/wiki/Setup-Mailserver#gmail) if this is something you're interested in but be warned it can be a very fiddly process, I would personally recommend a simple SMTP Server
 
-### And just like that, Calibre-Web Automated should be up and running!
+And just like that, Calibre-Web Automated should be up and running! HOWEVER to avoid potential problems and ensure maximum functionality,
+we recommend carrying out these [Post-Install Tasks Here](#recommended-post-install-tasks).
 
+<!-- - By default, `/cwa-book-ingest` is the ingest folder bound to the ingest folder you entered in the Docker Compose template however should you want to change any of the default directories, use the `cwa-change-dirs` command from within the container to edit the default paths -->
 ---
 ## For Developers - Building Custom Docker Image
 If you want to contribute to this project, you can build the docker file by running `build.sh` in the repository.
@@ -206,11 +208,13 @@ $ chmod +x build.sh
 $ ./build.sh
 ```
 
-<!-- - By default, `/cwa-book-ingest` is the ingest folder bound to the ingest folder you entered in the Docker Compose template however should you want to change any of the default directories, use the `cwa-change-dirs` command from within the container to edit the default paths -->
+Check out [Post-Install Tasks Here](#recommended-post-install-tasks) when necessary.
 
-### 2. **_Recommended Post-Install Tasks:_**
+---
 
-#### _Calibre-Web Quick Start Guide_
+# Recommended Post-Install Tasks:
+
+## _Calibre-Web Quick Start Guide_
 
 1. Open your browser and navigate to http://localhost:8084 or http://localhost:8084/opds for the OPDS catalog
 2. Log in with the default admin credentials (_below_)
@@ -226,12 +230,12 @@ $ ./build.sh
 
 - _Downloading files directly into `/cwa-book-ingest` is not supported. It can cause duplicate imports and potentially a corrupt database. It is recommended to first download the books completely, then transfer them to `/cwa-book-ingest` to avoid any issues_
 
-#### Default Admin Login:
+## Default Admin Login:
 
 > **Username:** admin\
 > **Password:** admin123
 
-#### Configuring CWA ⚙️
+## Configuring CWA ⚙️
 
 - If your Calibre Library contains any ebooks not in the `.epub` format, from within the container run the `convert-library` command.
   - Calibre-Web Automated's extra features only work with epubs and so **failure to complete this step could result in unforeseen errors and general unreliability**

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker build --tag crocodilestick/calibre-web-automated:master 
+# optional: --build-arg="BUILD_DATE=27-09-2024 12:06" --build-arg="VERSION=2.1.0-test-5" .
+
+mkdir -p build
+

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
-docker build --tag crocodilestick/calibre-web-automated:master 
-# optional: --build-arg="BUILD_DATE=27-09-2024 12:06" --build-arg="VERSION=2.1.0-test-5" .
-
+docker build --tag cwa-dev .
 mkdir -p build
+cp docker-compose.yml.dev build/docker-compose.yml
+cd build/
+docker compose up -d
+
+
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 docker build --tag cwa-dev .
 mkdir -p build
-cp docker-compose.yml.dev build/docker-compose.yml
+cp -n docker-compose.yml.dev build/docker-compose.yml
 cd build/
 docker compose up -d
 

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -1,0 +1,19 @@
+---
+services:
+  calibre-web-automated:
+    image: cwa-dev
+    container_name: cwa-dev
+    environment:
+      - PUID=1000
+      - PGID=100
+      - TZ=UTC
+      - DOCKER_MODS=lscr.io/linuxserver/mods:universal-calibre-v7.16.0
+    volumes:
+      - ./folder:/config
+      - ./cwa-book-ingest:/cwa-book-ingest
+      - ./calibre-library:/calibre-library
+      #- ./books:/books #Optional
+      #- gmail.json.json:/app/calibre-web/gmail.json #Optional
+    ports:
+      - 8084:8083 # Change the first number to change the port you want to access the Web UI, not the second
+    restart: unless-stopped


### PR DESCRIPTION
I improved the table of contents linking by making them local rather than linking directly to crocodilestick/calibre-web-automated.

Also added syntax hightlighting to the code blocks in the README