### PR TITLE
[bug] kindle_epub_fixer used as function name and as boolean

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -51,7 +51,7 @@ class NewBookProcessor:
         self.target_format = self.cwa_settings['auto_convert_target_format']
         self.ingest_ignored_formats = self.cwa_settings['auto_ingest_ignored_formats']
         self.convert_ignored_formats = self.cwa_settings['auto_convert_ignored_formats']
-        self.kindle_epub_fixer = self.cwa_settings['kindle_epub_fixer']
+        self.is_kindle_epub_fixer = self.cwa_settings['kindle_epub_fixer']
 
         self.supported_book_formats = {'azw', 'azw3', 'azw4', 'cbz', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'docx', 'epub', 'fb2', 'fbz', 'html', 'htmlz', 'lit', 'lrf', 'mobi', 'odt', 'pdf', 'prc', 'pdb', 'pml', 'rb', 'rtf', 'snb', 'tcr', 'txtz', 'txt', 'kepub'}
         self.hierarchy_of_success = {'epub', 'lit', 'mobi', 'azw', 'epub', 'azw3', 'fb2', 'fbz', 'azw4',  'prc', 'odt', 'lrf', 'pdb',  'cbz', 'pml', 'rb', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'snb', 'tcr', 'pdf', 'docx', 'rtf', 'html', 'htmlz', 'txtz', 'txt'}
@@ -163,7 +163,7 @@ class NewBookProcessor:
 
 
     def add_book_to_library(self, book_path:str) -> None:
-        if self.target_format == "epub" and self.kindle_epub_fixer:
+        if self.target_format == "epub" and self.is_kindle_epub_fixer:
             self.kindle_epub_fixer(book_path)
 
         print("[ingest-processor]: Importing new book to CWA...")


### PR DESCRIPTION
When `kindle_epub_fixer` is `true`, we try to call the function in the same class `kindle_epub_fixer`, but since it got overwrite by init to be a bool, we fail with 

```
[ingest-processor]: No conversion needed for ebook.epub, importing now...
Traceback (most recent call last):
  File "/app/calibre-web-automated/scripts/ingest_processor.py", line 257, in <module>
    main()
  File "/app/calibre-web-automated/scripts/ingest_processor.py", line 229, in main
    nbp.add_book_to_library(filepath)
  File "/app/calibre-web-automated/scripts/ingest_processor.py", line 167, in add_book_to_library
    self.kindle_epub_fixer(book_path)
```

This PR renames the bool to avoid the issue