### PR TITLE
Fix incorrect kepubify package for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ARG VERSION
 ARG CALIBREWEB_RELEASE=0.6.24
 ARG LSCW_RELEASE=0.6.24-ls304
 ARG UNIVERSAL_CALIBRE_RELEASE=7.16.0
+ARG KEPUBIFY_RELEASE=v4.0.4
 LABEL build_version="Version:- ${VERSION}"
 LABEL build_date="${BUILD_DATE}" 
 LABEL CW-Stock-version="${CALIBREWEB_RELEASE}"
@@ -89,14 +90,20 @@ RUN \
     requirements.txt -r \
     optional-requirements.txt && \
   # STEP 1.8 - Installs the latest release of kepubify
-  echo "***install kepubify" && \
-  if [ -z ${KEPUBIFY_RELEASE+x} ]; then \
+  echo "**** install kepubify ****" && \
+  if [[ $KEPUBIFY_RELEASE == 'newest' ]]; then \
     KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/pgaskin/kepubify/releases/latest" \
     | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
-  curl -o \
-    /usr/bin/kepubify -L \
-    https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit && \
+  if [ "$(uname -m)" == "x86_64" ]; then \
+    curl -o \
+      /usr/bin/kepubify -L \
+      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit && \
+  elif [ "$(uname -m)" == "aarch64" ]; then \
+    curl -o \
+      /usr/bin/kepubify -L \
+      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64 && \
+  fi && \
 # STEP 2 - Install Calibre-Web Automated
   echo "~~~~ CWA Install - installing additional required packages ~~~~" && \
   # STEP 2.1 - Install additional required packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,11 +98,11 @@ RUN \
   if [ "$(uname -m)" == "x86_64" ]; then \
     curl -o \
       /usr/bin/kepubify -L \
-      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit && \
+      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit; \
   elif [ "$(uname -m)" == "aarch64" ]; then \
     curl -o \
       /usr/bin/kepubify -L \
-      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64 && \
+      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64; \
   fi && \
 # STEP 2 - Install Calibre-Web Automated
   echo "~~~~ CWA Install - installing additional required packages ~~~~" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN \
   pip install -U --no-cache-dir --find-links https://wheel-index.linuxserver.io/ubuntu/ -r \
     requirements.txt -r \
     optional-requirements.txt && \
-  # STEP 1.8 - Installs the latest release of kepubify
+  # STEP 1.8 - Installs kepubify
   echo "**** install kepubify ****" && \
   if [[ $KEPUBIFY_RELEASE == 'newest' ]]; then \
     KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/pgaskin/kepubify/releases/latest" \

--- a/Dockerfile_calibre_not_included
+++ b/Dockerfile_calibre_not_included
@@ -27,6 +27,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG CALIBREWEB_RELEASE=0.6.23
 ARG LSCW_RELEASE=0.6.23-ls291
+ARG KEPUBIFY_RELEASE=v4.0.4
 LABEL build_version="Version:- ${VERSION}"
 LABEL build_date="${BUILD_DATE}" 
 LABEL CW-Stock-version="${CALIBREWEB_RELEASE}"
@@ -87,15 +88,21 @@ RUN \
   pip install -U --no-cache-dir --find-links https://wheel-index.linuxserver.io/ubuntu/ -r \
     requirements.txt -r \
     optional-requirements.txt && \
-  # STEP 1.8 - Installs the latest release of kepubify
-  echo "***install kepubify" && \
-  if [ -z ${KEPUBIFY_RELEASE+x} ]; then \
+  # STEP 1.8 - Installs kepubify
+  echo "**** install kepubify ****" && \
+  if [[ $KEPUBIFY_RELEASE == 'newest' ]]; then \
     KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/pgaskin/kepubify/releases/latest" \
     | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
-  curl -o \
-    /usr/bin/kepubify -L \
-    https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit && \
+  if [ "$(uname -m)" == "x86_64" ]; then \
+    curl -o \
+      /usr/bin/kepubify -L \
+      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit; \
+  elif [ "$(uname -m)" == "aarch64" ]; then \
+    curl -o \
+      /usr/bin/kepubify -L \
+      https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64; \
+  fi && \
 # STEP 2 - Install Calibre-Web Automated
   echo "~~~~ CWA Install - installing additional required packages ~~~~" && \
   # STEP 2.1 - Install additional required packages


### PR DESCRIPTION
Fixes #267 

Additionally allows specifying kepubify version in args.

Tested on RPI, it now converts fine:
![obraz](https://github.com/user-attachments/assets/96158ef8-b340-47b1-a919-14cbe3ec5960)
