### PR TITLE
Narrows scope of ingest delete function

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -168,7 +168,8 @@ class NewBookProcessor:
     def delete_current_file(self) -> None:
         """Deletes file just processed from ingest folder"""
         os.remove(self.filepath) # Removes processed file
-        subprocess.run(["find", f"{self.ingest_folder}", "-mindepth", "1", "-type", "d", "-empty", "-delete"]) # Removes any now empty folders in the ingest folder
+        if os.path.dirname(self.filepath) != self.ingest_folder: # File was in ingest_folder, no directories to delete
+            subprocess.run(["find", f"{os.path.dirname(self.filepath)}", "-type", "d", "-empty", "-delete"]) # Removes any now empty folders including parent directory
 
 
     def add_book_to_library(self, book_path:str) -> None:

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -168,7 +168,7 @@ class NewBookProcessor:
     def delete_current_file(self) -> None:
         """Deletes file just processed from ingest folder"""
         os.remove(self.filepath) # Removes processed file
-        if os.path.dirname(self.filepath) != self.ingest_folder: # File was in ingest_folder, no directories to delete
+        if not os.path.samefile(os.path.dirname(self.filepath),self.ingest_folder): # File not in ingest_folder, subdirectories to delete
             subprocess.run(["find", f"{os.path.dirname(self.filepath)}", "-type", "d", "-empty", "-delete"]) # Removes any now empty folders including parent directory
 
 


### PR DESCRIPTION
Check if imported file was in ingest_folder or a subdirectory, if a subdirectory then all empty directories are removed. This prevents folders such as .stfolder for SyncThing and other non import directories from being removed.