### PR TITLE
feat: allow retaining original file after conversion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ Dockerfile
 build
 .history
 Dockerfile_calibre_not_included
+temp

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,11 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+temp/
+library/
+config/
+ingest/
+cwa-book-ingest/
+docker-compose.dev.yml
+build-no-clone.sh

--- a/root/app/calibre-web/cps/cwa_functions.py
+++ b/root/app/calibre-web/cps/cwa_functions.py
@@ -1,4 +1,14 @@
-from flask import Blueprint, redirect, flash, url_for, request, send_from_directory, abort, jsonify, current_app
+from flask import (
+    Blueprint,
+    redirect,
+    flash,
+    url_for,
+    request,
+    send_from_directory,
+    abort,
+    jsonify,
+    current_app,
+)
 from flask_babel import gettext as _
 
 from . import logger, config, constants, csrf
@@ -24,17 +34,18 @@ from werkzeug.utils import secure_filename
 from .web import cwa_get_num_books_in_library
 
 import sys
-sys.path.insert(1, '/app/calibre-web-automated/scripts/')
+
+sys.path.insert(1, "/app/calibre-web-automated/scripts/")
 from cwa_db import CWA_DB
 
-switch_theme = Blueprint('switch_theme', __name__)
-library_refresh = Blueprint('library_refresh', __name__)
-convert_library = Blueprint('convert_library', __name__)
-epub_fixer = Blueprint('epub_fixer', __name__)
-cwa_stats = Blueprint('cwa_stats', __name__)
-cwa_check_status = Blueprint('cwa_check_status', __name__)
-cwa_settings = Blueprint('cwa_settings', __name__)
-cwa_logs = Blueprint('cwa_logs', __name__)
+switch_theme = Blueprint("switch_theme", __name__)
+library_refresh = Blueprint("library_refresh", __name__)
+convert_library = Blueprint("convert_library", __name__)
+epub_fixer = Blueprint("epub_fixer", __name__)
+cwa_stats = Blueprint("cwa_stats", __name__)
+cwa_check_status = Blueprint("cwa_check_status", __name__)
+cwa_settings = Blueprint("cwa_settings", __name__)
+cwa_logs = Blueprint("cwa_logs", __name__)
 
 ##——————————————————————————————GLOBAL VARIABLES——————————————————————————————##
 
@@ -50,30 +61,34 @@ DIRS_JSON = "/app/calibre-web-automated/dirs.json"
 ##                                                                            ##
 ##————————————————————————————————————————————————————————————————————————————##
 
+
 @switch_theme.route("/cwa-switch-theme", methods=["GET", "POST"])
 @login_required_if_no_ano
 def cwa_switch_theme():
     con = sqlite3.connect("/config/app.db")
     cur = con.cursor()
-    current_theme = cur.execute('SELECT config_theme FROM settings;').fetchone()[0]
+    current_theme = cur.execute("SELECT config_theme FROM settings;").fetchone()[0]
 
     if current_theme == 1:
         new_theme = 0
     else:
         new_theme = 1
 
-    to_save = {"config_theme":new_theme}
+    to_save = {"config_theme": new_theme}
 
     config.set_from_dictionary(to_save, "config_theme", int)
     config.config_default_role = constants.selected_roles(to_save)
     config.config_default_role &= ~constants.ROLE_ANONYMOUS
 
-    config.config_default_show = sum(int(k[5:]) for k in to_save if k.startswith('show_'))
+    config.config_default_show = sum(
+        int(k[5:]) for k in to_save if k.startswith("show_")
+    )
     if "Show_detail_random" in to_save:
         config.config_default_show |= constants.DETAIL_RANDOM
 
     config.save()
     return redirect(url_for("web.index"), code=302)
+
 
 ##————————————————————————————————————————————————————————————————————————————##
 ##                                                                            ##
@@ -81,15 +96,23 @@ def cwa_switch_theme():
 ##                                                                            ##
 ##————————————————————————————————————————————————————————————————————————————##
 
+
 def get_ingest_dir():
-    with open(DIRS_JSON, 'r') as f:
+    with open(DIRS_JSON, "r") as f:
         dirs = json.load(f)
-        return dirs['ingest_folder']
+        return dirs["ingest_folder"]
+
 
 def refresh_library(app):
     with app.app_context():  # Create app context for session
         ingest_dir = get_ingest_dir()
-        result = subprocess.run(['python3', '/app/calibre-web-automated/scripts/ingest_processor.py', ingest_dir])
+        result = subprocess.run(
+            [
+                "python3",
+                "/app/calibre-web-automated/scripts/ingest_processor.py",
+                ingest_dir,
+            ]
+        )
         return_code = result.returncode
 
         # Add empty list for messages in app context if a list doesn't already exist
@@ -99,14 +122,19 @@ def refresh_library(app):
         if return_code == 2:
             message = "Library Refresh 🔄 The book ingest service is already running ✋ Please wait until it has finished before trying again ⌛"
         elif return_code == 0:
-            message = "Library Refresh 🔄 Library refreshed & ingest process complete! ✅"
+            message = (
+                "Library Refresh 🔄 Library refreshed & ingest process complete! ✅"
+            )
         else:
-            message = "Library Refresh 🔄 An unexpected error occurred, check the logs ⛔"
-        
+            message = (
+                "Library Refresh 🔄 An unexpected error occurred, check the logs ⛔"
+            )
+
         # Display message to user in Web UI
         current_app.config["library_refresh_messages"].append(message)
         # Print result to docker log
-        print(message.replace('Library Refresh 🔄', '[library-refresh]'), flush=True)
+        print(message.replace("Library Refresh 🔄", "[library-refresh]"), flush=True)
+
 
 @csrf.exempt
 @library_refresh.route("/cwa-library-refresh", methods=["GET", "POST"])
@@ -121,7 +149,15 @@ def cwa_library_refresh():
     library_refresh_thread = Thread(target=refresh_library, args=(app,))
     library_refresh_thread.start()
 
-    return jsonify({"message": "Library Refresh 🔄 Checking for any books that may have been missed, please wait..."}), 200
+    return (
+        jsonify(
+            {
+                "message": "Library Refresh 🔄 Checking for any books that may have been missed, please wait..."
+            }
+        ),
+        200,
+    )
+
 
 @csrf.exempt
 @library_refresh.route("/cwa-library-refresh/messages", methods=["GET"])
@@ -134,81 +170,147 @@ def get_library_refresh_messages():
 
     return jsonify({"messages": messages})
 
+
 ##————————————————————————————————————————————————————————————————————————————##
 ##                                                                            ##
 ##                              CWA SETTINGS PAGE                             ##
 ##                                                                            ##
 ##————————————————————————————————————————————————————————————————————————————##
 
+
 @csrf.exempt
 @cwa_settings.route("/cwa-settings", methods=["GET", "POST"])
 @login_required_if_no_ano
 @admin_required
 def set_cwa_settings():
+    """Sets the CWA settings based on the user's input"""
     cwa_db = CWA_DB()
     cwa_default_settings = cwa_db.cwa_default_settings
     cwa_settings = cwa_db.cwa_settings
 
-    ignorable_formats = ['azw', 'azw3', 'azw4', 'cbz',
-                        'cbr', 'cb7', 'cbc', 'chm',
-                        'djvu', 'docx', 'epub', 'fb2',
-                        'fbz', 'html', 'htmlz', 'kepub', 'lit',
-                        'lrf', 'mobi', 'odt', 'pdf',
-                        'prc', 'pdb', 'pml', 'rb',
-                        'rtf', 'snb', 'tcr', 'txt', 'txtz']
-    target_formats = ['epub', 'azw3', 'kepub', 'mobi', 'pdf']
+    ignorable_formats = [
+        "azw",
+        "azw3",
+        "azw4",
+        "cbz",
+        "cbr",
+        "cb7",
+        "cbc",
+        "chm",
+        "djvu",
+        "docx",
+        "epub",
+        "fb2",
+        "fbz",
+        "html",
+        "htmlz",
+        "kepub",
+        "lit",
+        "lrf",
+        "mobi",
+        "odt",
+        "pdf",
+        "prc",
+        "pdb",
+        "pml",
+        "rb",
+        "rtf",
+        "snb",
+        "tcr",
+        "txt",
+        "txtz",
+    ]
+    target_formats = ["epub", "azw3", "kepub", "mobi", "pdf"]
 
     boolean_settings = []
     string_settings = []
     list_settings = []
     for setting in cwa_default_settings:
-        if type(cwa_default_settings[setting]) == int:
+        if isinstance(cwa_default_settings[setting], int):
             boolean_settings.append(setting)
-        elif type(cwa_default_settings[setting]) == str and cwa_default_settings[setting] != "":
+        elif (
+            isinstance(cwa_default_settings[setting], str)
+            and cwa_default_settings[setting] != ""
+        ):
             string_settings.append(setting)
         else:
             list_settings.append(setting)
 
-    for format in ignorable_formats:
-        string_settings.append(f"ignore_ingest_{format}")
-        string_settings.append(f"ignore_convert_{format}")
+    for _format in ignorable_formats:
+        string_settings.append(f"ignore_ingest_{_format}")
+        string_settings.append(f"ignore_convert_{_format}")
+        string_settings.append(f"convert_retained_{_format}")
 
-    if request.method == 'POST':
-        if request.form['submit_button'] == "Submit":
-            result = {"auto_convert_ignored_formats":[], "auto_ingest_ignored_formats":[]}
+    if request.method == "POST":
+        if request.form["submit_button"] == "Submit":
+            result = {
+                "auto_convert_ignored_formats": [],
+                "auto_ingest_ignored_formats": [],
+                "auto_convert_retained_formats": [],
+            }
             # set boolean_settings
             for setting in boolean_settings:
                 value = request.form.get(setting)
-                if value == None:
+                if value is None:
                     value = 0
                 else:
                     value = 1
-                result |= {setting:value}
+                result |= {setting: value}
             # set string settings
             for setting in string_settings:
                 value = request.form.get(setting)
-                if setting[:14] == "ignore_convert":
-                    if value == None:
-                        continue
-                    else:
+                if setting.startswith("ignore_convert"):
+                    if value is not None:
                         result["auto_convert_ignored_formats"].append(value)
-                        continue
-                elif setting[:13] == "ignore_ingest":
-                    if value == None:
-                        continue
-                    else:
+                    continue
+                elif setting.startswith("ignore_ingest"):
+                    if value is not None:
                         result["auto_ingest_ignored_formats"].append(value)
-                        continue
-                elif setting == "auto_convert_target_format" and value == None:
-                    value = cwa_db.cwa_settings['auto_convert_target_format']
+                    continue
+                elif setting.startswith("convert_retained"):
+                    if value is not None:
+                        result["auto_convert_retained_formats"].append(value)
+                    continue
+                elif setting == "auto_convert_target_format":
+                    value = cwa_db.cwa_settings["auto_convert_target_format"]
 
-                result |= {setting:value}
-            
+                result |= {setting: value}
+
             # Prevent ignoring of target format
-            if result['auto_convert_target_format'] in result['auto_convert_ignored_formats']:
-                result['auto_convert_ignored_formats'].remove(result['auto_convert_target_format'])
-            if result['auto_convert_target_format'] in result['auto_ingest_ignored_formats']:
-                result['auto_ingest_ignored_formats'].remove(result['auto_convert_target_format'])
+            if (
+                result["auto_convert_target_format"]
+                in result["auto_convert_ignored_formats"]
+            ):
+                result["auto_convert_ignored_formats"].remove(
+                    result["auto_convert_target_format"]
+                )
+
+            # Prevent ignoring of target format in ingest
+            if (
+                result["auto_convert_target_format"]
+                in result["auto_ingest_ignored_formats"]
+            ):
+                result["auto_ingest_ignored_formats"].remove(
+                    result["auto_convert_target_format"]
+                )
+
+            # Prevent retaining of ignored ingest formats
+            if (
+                result["auto_ingest_ignored_formats"]
+                in result["auto_convert_retained_formats"]
+            ):
+                result["auto_convert_retained_formats"].remove(
+                    result["auto_ingest_ignored_formats"]
+                )
+
+            # Force target format to be retained
+            if (
+                result["auto_convert_target_format"]
+                not in result["auto_convert_retained_formats"]
+            ):
+                result["auto_convert_retained_formats"].append(
+                    result["auto_convert_target_format"]
+                )
 
             # DEBUGGING
             # with open("/config/post_request" ,"w") as f:
@@ -221,17 +323,23 @@ def set_cwa_settings():
             cwa_db.update_cwa_settings(result)
             cwa_settings = cwa_db.get_cwa_settings()
 
-        elif request.form['submit_button'] == "Apply Default Settings":
+        elif request.form["submit_button"] == "Apply Default Settings":
             cwa_db = CWA_DB()
             cwa_db.set_default_settings(force=True)
             cwa_settings = cwa_db.get_cwa_settings()
 
-    elif request.method == 'GET':
+    elif request.method == "GET":
         ...
 
-    return render_title_template("cwa_settings.html", title=_("Calibre-Web Automated User Settings"), page="cwa-settings",
-                                    cwa_settings=cwa_settings, ignorable_formats=ignorable_formats,
-                                    target_formats=target_formats)
+    return render_title_template(
+        "cwa_settings.html",
+        title=_("Calibre-Web Automated User Settings"),
+        page="cwa-settings",
+        cwa_settings=cwa_settings,
+        ignorable_formats=ignorable_formats,
+        target_formats=target_formats,
+    )
+
 
 ##————————————————————————————————————————————————————————————————————————————##
 ##                                                                            ##
@@ -239,33 +347,48 @@ def set_cwa_settings():
 ##                                                                            ##
 ##————————————————————————————————————————————————————————————————————————————##
 
-def get_cwa_stats() -> dict[str,int]:
+
+def get_cwa_stats() -> dict[str, int]:
     """Returns CWA stat totals as a dict (keys are table names except for total_books)"""
     cwa_db = CWA_DB()
     totals = cwa_db.get_stat_totals()
-    totals["total_books"] = cwa_get_num_books_in_library() # from web.py
+    totals["total_books"] = cwa_get_num_books_in_library()  # from web.py
 
     return totals
 
+
 ### TABLE HEADERS
 headers = {
-    "enforcement":{
-        "no_paths":[
-            "Timestamp", "Book ID", "Book Title", "Book Author", "Trigger Type"],
-        "with_paths":[
-            "Timestamp","Book ID", "Filepath"]
-        },
-    "epub_fixer":{
-        "no_fixes":[
-            "Timestamp", "Filename", "Manual?", "No. Fixes", "Original Backed Up?"],
-        "with_fixes":[
-            "Timestamp", "Filename", "Filepath", "Fixes Applied"]
-        },
-    "imports":[
-        "Timestamp", "Filename", "Original Backed Up?"],
-    "conversions":[
-        "Timestamp", "Filename", "Original Format", "End Format", "Original Backed Up?"],
+    "enforcement": {
+        "no_paths": [
+            "Timestamp",
+            "Book ID",
+            "Book Title",
+            "Book Author",
+            "Trigger Type",
+        ],
+        "with_paths": ["Timestamp", "Book ID", "Filepath"],
+    },
+    "epub_fixer": {
+        "no_fixes": [
+            "Timestamp",
+            "Filename",
+            "Manual?",
+            "No. Fixes",
+            "Original Backed Up?",
+        ],
+        "with_fixes": ["Timestamp", "Filename", "Filepath", "Fixes Applied"],
+    },
+    "imports": ["Timestamp", "Filename", "Original Backed Up?"],
+    "conversions": [
+        "Timestamp",
+        "Filename",
+        "Original Format",
+        "End Format",
+        "Original Backed Up?",
+    ],
 }
+
 
 @cwa_stats.route("/cwa-stats-show", methods=["GET", "POST"])
 @login_required_if_no_ano
@@ -273,29 +396,50 @@ headers = {
 def cwa_stats_show():
     cwa_db = CWA_DB()
     data_enforcement = cwa_db.enforce_show(paths=False, verbose=False, web_ui=True)
-    data_enforcement_with_paths = cwa_db.enforce_show(paths=True, verbose=False, web_ui=True)
+    data_enforcement_with_paths = cwa_db.enforce_show(
+        paths=True, verbose=False, web_ui=True
+    )
     data_imports = cwa_db.get_import_history(verbose=False)
     data_conversions = cwa_db.get_conversion_history(verbose=False)
     data_epub_fixer = cwa_db.get_epub_fixer_history(fixes=False, verbose=False)
-    data_epub_fixer_with_fixes = cwa_db.get_epub_fixer_history(fixes=True, verbose=False)
+    data_epub_fixer_with_fixes = cwa_db.get_epub_fixer_history(
+        fixes=True, verbose=False
+    )
 
-    return render_title_template("cwa_stats.html", title=_("Calibre-Web Automated Sever Stats & Archive"), page="cwa-stats",
-                                cwa_stats=get_cwa_stats(),
-                                data_enforcement=data_enforcement, headers_enforcement=headers["enforcement"]["no_paths"], 
-                                data_enforcement_with_paths=data_enforcement_with_paths,headers_enforcement_with_paths=headers["enforcement"]["with_paths"], 
-                                data_imports=data_imports, headers_import=headers["imports"],
-                                data_conversions=data_conversions, headers_conversion=headers["conversions"],
-                                data_epub_fixer=data_epub_fixer, headers_epub_fixer=headers["epub_fixer"]["no_fixes"],
-                                data_epub_fixer_with_fixes=data_epub_fixer_with_fixes, headers_epub_fixer_with_fixes=headers["epub_fixer"]["with_fixes"])
-                                    
+    return render_title_template(
+        "cwa_stats.html",
+        title=_("Calibre-Web Automated Sever Stats & Archive"),
+        page="cwa-stats",
+        cwa_stats=get_cwa_stats(),
+        data_enforcement=data_enforcement,
+        headers_enforcement=headers["enforcement"]["no_paths"],
+        data_enforcement_with_paths=data_enforcement_with_paths,
+        headers_enforcement_with_paths=headers["enforcement"]["with_paths"],
+        data_imports=data_imports,
+        headers_import=headers["imports"],
+        data_conversions=data_conversions,
+        headers_conversion=headers["conversions"],
+        data_epub_fixer=data_epub_fixer,
+        headers_epub_fixer=headers["epub_fixer"]["no_fixes"],
+        data_epub_fixer_with_fixes=data_epub_fixer_with_fixes,
+        headers_epub_fixer_with_fixes=headers["epub_fixer"]["with_fixes"],
+    )
+
+
 @cwa_stats.route("/cwa-stats-show/full-enforcement", methods=["GET", "POST"])
 @login_required_if_no_ano
 @admin_required
 def show_full_enforcement():
     cwa_db = CWA_DB()
     data = cwa_db.enforce_show(paths=False, verbose=True, web_ui=True)
-    return render_title_template("cwa_stats_full.html", title=_("Calibre-Web Automated - Full Enforcement History"), page="cwa-stats-full",
-                                    table_headers=headers["enforcement"]["no_paths"], data=data)
+    return render_title_template(
+        "cwa_stats_full.html",
+        title=_("Calibre-Web Automated - Full Enforcement History"),
+        page="cwa-stats-full",
+        table_headers=headers["enforcement"]["no_paths"],
+        data=data,
+    )
+
 
 @cwa_stats.route("/cwa-stats-show/full-enforcement-with-paths", methods=["GET", "POST"])
 @login_required_if_no_ano
@@ -303,8 +447,14 @@ def show_full_enforcement():
 def show_full_enforcement_path():
     cwa_db = CWA_DB()
     data = cwa_db.enforce_show(paths=True, verbose=True, web_ui=True)
-    return render_title_template("cwa_stats_full.html", title=_("Calibre-Web Automated - Full Enforcement History (w/ Paths)"), page="cwa-stats-full",
-                                    table_headers=headers["enforcement"]["with_paths"], data=data)
+    return render_title_template(
+        "cwa_stats_full.html",
+        title=_("Calibre-Web Automated - Full Enforcement History (w/ Paths)"),
+        page="cwa-stats-full",
+        table_headers=headers["enforcement"]["with_paths"],
+        data=data,
+    )
+
 
 @cwa_stats.route("/cwa-stats-show/full-imports", methods=["GET", "POST"])
 @login_required_if_no_ano
@@ -312,8 +462,14 @@ def show_full_enforcement_path():
 def show_full_imports():
     cwa_db = CWA_DB()
     data = cwa_db.get_import_history(verbose=True)
-    return render_title_template("cwa_stats_full.html", title=_("Calibre-Web Automated - Full Import History"), page="cwa-stats-full",
-                                    table_headers=headers["imports"], data=data)
+    return render_title_template(
+        "cwa_stats_full.html",
+        title=_("Calibre-Web Automated - Full Import History"),
+        page="cwa-stats-full",
+        table_headers=headers["imports"],
+        data=data,
+    )
+
 
 @cwa_stats.route("/cwa-stats-show/full-conversions", methods=["GET", "POST"])
 @login_required_if_no_ano
@@ -321,8 +477,14 @@ def show_full_imports():
 def show_full_conversions():
     cwa_db = CWA_DB()
     data = cwa_db.get_conversion_history(verbose=True)
-    return render_title_template("cwa_stats_full.html", title=_("Calibre-Web Automated - Full Conversion History"), page="cwa-stats-full",
-                                    table_headers=headers["conversions"], data=data)
+    return render_title_template(
+        "cwa_stats_full.html",
+        title=_("Calibre-Web Automated - Full Conversion History"),
+        page="cwa-stats-full",
+        table_headers=headers["conversions"],
+        data=data,
+    )
+
 
 @cwa_stats.route("/cwa-stats-show/full-epub-fixer", methods=["GET", "POST"])
 @login_required_if_no_ano
@@ -330,17 +492,33 @@ def show_full_conversions():
 def show_full_epub_fixer():
     cwa_db = CWA_DB()
     data = cwa_db.get_epub_fixer_history(fixes=False, verbose=True)
-    return render_title_template("cwa_stats_full.html", title=_("Calibre-Web Automated - Full EPUB Fixer History (w/out Paths & Fixes)"), page="cwa-stats-full",
-                                    table_headers=headers["epub_fixer"]["no_fixes"], data=data)
+    return render_title_template(
+        "cwa_stats_full.html",
+        title=_(
+            "Calibre-Web Automated - Full EPUB Fixer History (w/out Paths & Fixes)"
+        ),
+        page="cwa-stats-full",
+        table_headers=headers["epub_fixer"]["no_fixes"],
+        data=data,
+    )
 
-@cwa_stats.route("/cwa-stats-show/full-epub-fixer-with-paths-fixes", methods=["GET", "POST"])
+
+@cwa_stats.route(
+    "/cwa-stats-show/full-epub-fixer-with-paths-fixes", methods=["GET", "POST"]
+)
 @login_required_if_no_ano
 @admin_required
 def show_full_epub_fixer_with_paths_fixes():
     cwa_db = CWA_DB()
     data = cwa_db.get_epub_fixer_history(fixes=True, verbose=True)
-    return render_title_template("cwa_stats_full.html", title=_("Calibre-Web Automated - Full EPUB Fixer History (w/ Paths & Fixes)"), page="cwa-stats-full",
-                                    table_headers=headers["epub_fixer"]["with_fixes"], data=data)
+    return render_title_template(
+        "cwa_stats_full.html",
+        title=_("Calibre-Web Automated - Full EPUB Fixer History (w/ Paths & Fixes)"),
+        page="cwa-stats-full",
+        table_headers=headers["epub_fixer"]["with_fixes"],
+        data=data,
+    )
+
 
 ##————————————————————————————————————————————————————————————————————————————##
 ##                                                                            ##
@@ -348,26 +526,48 @@ def show_full_epub_fixer_with_paths_fixes():
 ##                                                                            ##
 ##————————————————————————————————————————————————————————————————————————————##
 
+
 @cwa_check_status.route("/cwa-check-monitoring", methods=["GET", "POST"])
 @login_required_if_no_ano
 @admin_required
 def cwa_flash_status():
-    result = subprocess.run(['/app/calibre-web-automated/scripts/check-cwa-services.sh'])
+    result = subprocess.run(
+        ["/app/calibre-web-automated/scripts/check-cwa-services.sh"]
+    )
     services_status = result.returncode
 
     match services_status:
         case 0:
-            flash(_("✅ All Monitoring Services are running as intended! 👍"), category="cwa_refresh")
+            flash(
+                _("✅ All Monitoring Services are running as intended! 👍"),
+                category="cwa_refresh",
+            )
         case 1:
-            flash(_("🔴 The Ingest Service is running but the Metadata Change Detector is not"), category="cwa_refresh")
+            flash(
+                _(
+                    "🔴 The Ingest Service is running but the Metadata Change Detector is not"
+                ),
+                category="cwa_refresh",
+            )
         case 2:
-            flash(_("🔴 The Metadata Change Detector is running but the Ingest Service is not"), category="cwa_refresh")
+            flash(
+                _(
+                    "🔴 The Metadata Change Detector is running but the Ingest Service is not"
+                ),
+                category="cwa_refresh",
+            )
         case 3:
-            flash(_("⛔ Neither the Ingest Service or the Metadata Change Detector are running"), category="cwa_refresh")
+            flash(
+                _(
+                    "⛔ Neither the Ingest Service or the Metadata Change Detector are running"
+                ),
+                category="cwa_refresh",
+            )
         case _:
             flash(_("An Error has occurred"), category="cwa_refresh")
 
-    return redirect(url_for('admin.admin'))
+    return redirect(url_for("admin.admin"))
+
 
 ##————————————————————————————————————————————————————————————————————————————##
 ##                                                                            ##
@@ -375,15 +575,16 @@ def cwa_flash_status():
 ##                                                                            ##
 ##————————————————————————————————————————————————————————————————————————————##
 
-@cwa_logs.route('/cwa-logs/download/<log_filename>')
+
+@cwa_logs.route("/cwa-logs/download/<log_filename>")
 def download_log(log_filename):
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
         safe_filename = secure_filename(log_filename)
-        
+
         # Join the logs directory with the filename and get the absolute path
         file_path = os.path.abspath(os.path.join(LOG_ARCHIVE, safe_filename))
-        
+
         # Check if the file path is within the allowed directory
         if not file_path.startswith(os.path.abspath(LOG_ARCHIVE)):
             abort(403)  # Forbidden if it's not within the logs directory
@@ -394,20 +595,21 @@ def download_log(log_filename):
 
         # Send the file as an attachment (to trigger a download)
         return send_from_directory(LOG_ARCHIVE, safe_filename, as_attachment=True)
-    
+
     except Exception as e:
         # Handle any other errors
         abort(400)  # Bad request for malformed or unsafe file paths
 
-@cwa_logs.route('/cwa-logs/read/<log_filename>')
+
+@cwa_logs.route("/cwa-logs/read/<log_filename>")
 def read_log(log_filename):
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
         safe_filename = secure_filename(log_filename)
-        
+
         # Join the logs directory with the filename and get the absolute path
         file_path = os.path.abspath(os.path.join(LOG_ARCHIVE, safe_filename))
-        
+
         # Check if the file path is within the allowed directory
         if not file_path.startswith(os.path.abspath(LOG_ARCHIVE)):
             abort(403)  # Forbidden if it's not within the logs directory
@@ -417,15 +619,21 @@ def read_log(log_filename):
             abort(404)  # Return a 404 if the file does not exist
 
         # Send the file as an attachment (to trigger a download)
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             log = f.read()
 
-        return render_title_template('cwa_read_log.html', title=_(f"Calibre-Web Automated - Log Archive - Read Log - {log_filename}"), page="cwa-log-read",
-                                    log_filename=log_filename, log=log)
-    
+        return render_title_template(
+            "cwa_read_log.html",
+            title=_(f"Calibre-Web Automated - Log Archive - Read Log - {log_filename}"),
+            page="cwa-log-read",
+            log_filename=log_filename,
+            log=log,
+        )
+
     except Exception as e:
         # Handle any other errors
         abort(400)  # Bad request for malformed or unsafe file paths
+
 
 ##————————————————————————————————————————————————————————————————————————————##
 ##                                                                            ##
@@ -435,56 +643,75 @@ def read_log(log_filename):
 
 ##————————————————————————SHARED VARIABLES & FUNCTIONS————————————————————————##
 
+
 def extract_progress(log_content):
     """Analyses a log's given contents & returns the processes current progress as a dict"""
     # Regex to find all progress matches (e.g., "n/n")
-    matches = re.findall(r'(\d+)/(\d+)', log_content)
+    matches = re.findall(r"(\d+)/(\d+)", log_content)
     if matches:
         # Convert the matches to integers and take the last one
         current, total = map(int, matches[-1])
         return {"current": current, "total": total}
     return {"current": 0, "total": 0}
 
+
 def archive_run_log(log_path):
     try:
-        log_name = Path(log_path).stem + f"-{datetime.now().strftime('%Y-%m-%d-%H%M%S')}.log"
+        log_name = (
+            Path(log_path).stem + f"-{datetime.now().strftime('%Y-%m-%d-%H%M%S')}.log"
+        )
         shutil.copy2(log_path, f"{LOG_ARCHIVE}/{log_name}")
-        print(f"[cwa-functions] Log '{log_path}' has been successfully archived as {log_name} in '{LOG_ARCHIVE}'")
+        print(
+            f"[cwa-functions] Log '{log_path}' has been successfully archived as {log_name} in '{LOG_ARCHIVE}'"
+        )
     except Exception as e:
-        print(f"[cwa-functions] The following error occurred when trying to back up {log_path} at {datetime.now()}:\n{e}")
+        print(
+            f"[cwa-functions] The following error occurred when trying to back up {log_path} at {datetime.now()}:\n{e}"
+        )
 
-def get_logs_from_archive(log_name) -> dict[str,str]:
+
+def get_logs_from_archive(log_name) -> dict[str, str]:
     logs = {}
-    logs_in_archive = [os.path.join(dirpath,f) for (dirpath, dirnames, filenames) in os.walk(LOG_ARCHIVE) for f in filenames]
+    logs_in_archive = [
+        os.path.join(dirpath, f)
+        for (dirpath, dirnames, filenames) in os.walk(LOG_ARCHIVE)
+        for f in filenames
+    ]
     for log in logs_in_archive:
         if log_name in log:
-            logs |= {os.path.basename(log):log}
+            logs |= {os.path.basename(log): log}
 
     return logs
 
-def get_log_dates(logs) -> dict[str,str]:
+
+def get_log_dates(logs) -> dict[str, str]:
     log_dates = {}
     for log in logs:
         log_date, time = re.findall(r"([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]+)+", log)[0]
         log_time = f"{time[:2]}:{time[2:4]}:{time[-2:]}"
-        log_dates |= {log:{"date":log_date,
-                            "time":log_time}}
+        log_dates |= {log: {"date": log_date, "time": log_time}}
     return log_dates
+
 
 ##———————————————————END OF SHARED VARIABLES & FUNCTIONS———————————————————————##
 
+
 def convert_library_start(queue):
-    cl_process = subprocess.Popen(['python3', '/app/calibre-web-automated/scripts/convert_library.py'])
+    cl_process = subprocess.Popen(
+        ["python3", "/app/calibre-web-automated/scripts/convert_library.py"]
+    )
     queue.put(cl_process)
+
 
 def get_tmp_conversion_dir() -> str:
     dirs_json_path = "/app/calibre-web-automated/dirs.json"
     dirs = {}
-    with open(dirs_json_path, 'r') as f:
+    with open(dirs_json_path, "r") as f:
         dirs: dict[str, str] = json.load(f)
     tmp_conversion_dir = f"{dirs['tmp_conversion_dir']}/"
 
     return tmp_conversion_dir
+
 
 def empty_tmp_con_dir(tmp_conversion_dir) -> None:
     try:
@@ -494,28 +721,32 @@ def empty_tmp_con_dir(tmp_conversion_dir) -> None:
             if os.path.isfile(file_path):
                 os.remove(file_path)
     except Exception as e:
-        print(f"[cwa-functions]: An error occurred while emptying {tmp_conversion_dir}. See the following error: {e}")
+        print(
+            f"[cwa-functions]: An error occurred while emptying {tmp_conversion_dir}. See the following error: {e}"
+        )
+
 
 def is_convert_library_finished() -> bool:
     log_path = "/config/convert-library.log"
-    with open(log_path, 'r') as log:
+    with open(log_path, "r") as log:
         if "CWA Convert Library Service - Run Ended: " in log.read():
             return True
         else:
             return False
 
+
 def kill_convert_library(queue):
     trigger_file = Path(tempfile.gettempdir() + "/.kill_convert_library_trigger")
     log_path = "/config/convert-library.log"
     while True:
-        sleep(0.05) # Required to prevent high cpu usage
+        sleep(0.05)  # Required to prevent high cpu usage
         if trigger_file.exists():
             # Kill the convert_library process
             cl_process = queue.get()
             cl_process.terminate()
             # Remove any potentially left over lock files
             try:
-                os.remove(tempfile.gettempdir() + '/convert_library.lock')
+                os.remove(tempfile.gettempdir() + "/convert_library.lock")
             except FileNotFoundError:
                 ...
             # Empty tmp conversion dir of half finished files
@@ -526,8 +757,10 @@ def kill_convert_library(queue):
             except FileNotFoundError:
                 ...
             # Add string to log to notify user of successful cancellation and to stop the JS update script
-            with open(log_path, 'a') as f:
-                f.write(f"\nCONVERT LIBRARY PROCESS TERMINATED BY USER AT {datetime.now()}")
+            with open(log_path, "a") as f:
+                f.write(
+                    f"\nCONVERT LIBRARY PROCESS TERMINATED BY USER AT {datetime.now()}"
+                )
             # Add run log to log_archive
             archive_run_log(log_path)
             break
@@ -535,29 +768,41 @@ def kill_convert_library(queue):
             archive_run_log(log_path)
             break
 
-@convert_library.route('/cwa-convert-library-overview', methods=["GET"])
+
+@convert_library.route("/cwa-convert-library-overview", methods=["GET"])
 def show_convert_library_page():
-    return render_title_template('cwa_convert_library.html', title=_("Calibre-Web Automated - Convert Library"), page="cwa-library-convert",
-                                target_format=CWA_DB().cwa_settings['auto_convert_target_format'].upper())
+    return render_title_template(
+        "cwa_convert_library.html",
+        title=_("Calibre-Web Automated - Convert Library"),
+        page="cwa-library-convert",
+        target_format=CWA_DB().cwa_settings["auto_convert_target_format"].upper(),
+    )
 
-@convert_library.route('/cwa-convert-library/log-archive', methods=["GET"])
+
+@convert_library.route("/cwa-convert-library/log-archive", methods=["GET"])
 def show_convert_library_logs():
-    logs=get_logs_from_archive("convert-library")
+    logs = get_logs_from_archive("convert-library")
     log_dates = get_log_dates(logs)
-    return render_title_template('cwa_list_logs.html', title=_("Calibre-Web Automated - Convert Library"), page="cwa-library-convert-logs",
-                                logs=logs, log_dates=log_dates)
+    return render_title_template(
+        "cwa_list_logs.html",
+        title=_("Calibre-Web Automated - Convert Library"),
+        page="cwa-library-convert-logs",
+        logs=logs,
+        log_dates=log_dates,
+    )
 
-@convert_library.route('/cwa-convert-library/download-current-log/<log_filename>')
+
+@convert_library.route("/cwa-convert-library/download-current-log/<log_filename>")
 def download_current_log(log_filename):
     log_filename = "convert-library.log"
     LOG_DIR = "/config"
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
         safe_filename = secure_filename(log_filename)
-        
+
         # Join the logs directory with the filename and get the absolute path
         file_path = os.path.abspath(os.path.join(LOG_DIR, safe_filename))
-        
+
         # Check if the file path is within the allowed directory
         if not file_path.startswith(os.path.abspath(LOG_DIR)):
             abort(403)  # Forbidden if it's not within the logs directory
@@ -568,15 +813,16 @@ def download_current_log(log_filename):
 
         # Send the file as an attachment (to trigger a download)
         return send_from_directory(LOG_DIR, safe_filename, as_attachment=True)
-    
+
     except Exception as e:
         # Handle any other errors
         abort(400)  # Bad request for malformed or unsafe file paths
 
-@convert_library.route('/cwa-convert-library-start', methods=["GET"])
+
+@convert_library.route("/cwa-convert-library-start", methods=["GET"])
 def start_conversion():
     # Wipe conversion log from previous runs
-    open('/config/convert-library.log', 'w').close()
+    open("/config/convert-library.log", "w").close()
     # Remove any left over kill file
     try:
         os.remove(tempfile.gettempdir() + "/.kill_convert_library_trigger")
@@ -590,21 +836,22 @@ def start_conversion():
     # Create and start the kill thread
     cl_kill_thread = Thread(target=kill_convert_library, args=(process_queue,))
     cl_kill_thread.start()
-    return redirect(url_for('convert_library.show_convert_library_page'))
+    return redirect(url_for("convert_library.show_convert_library_page"))
 
-@convert_library.route('/convert-library-cancel', methods=["GET"])
+
+@convert_library.route("/convert-library-cancel", methods=["GET"])
 def cancel_convert_library():
     # Create kill trigger file
-    open(tempfile.gettempdir() + "/.kill_convert_library_trigger", 'w').close()
-    return redirect(url_for('convert_library.show_convert_library_page'))
+    open(tempfile.gettempdir() + "/.kill_convert_library_trigger", "w").close()
+    return redirect(url_for("convert_library.show_convert_library_page"))
 
-@convert_library.route('/convert-library-status', methods=["GET"])
+
+@convert_library.route("/convert-library-status", methods=["GET"])
 def get_status():
-    with open("/config/convert-library.log", 'r') as f:
+    with open("/config/convert-library.log", "r") as f:
         status = f.read()
     progress = extract_progress(status)
-    statusList = {'status':status,
-                  'progress':progress}
+    statusList = {"status": status, "progress": progress}
     return json.dumps(statusList)
 
 
@@ -614,30 +861,35 @@ def get_status():
 ##                                                                            ##
 ##————————————————————————————————————————————————————————————————————————————##
 
+
 def epub_fixer_start(queue):
-    ef_process = subprocess.Popen(['python3', '/app/calibre-web-automated/scripts/kindle_epub_fixer.py', '--all'])
+    ef_process = subprocess.Popen(
+        ["python3", "/app/calibre-web-automated/scripts/kindle_epub_fixer.py", "--all"]
+    )
     queue.put(ef_process)
+
 
 def is_epub_fixer_finished() -> bool:
     log_path = "/config/epub-fixer.log"
-    with open(log_path, 'r') as log:
+    with open(log_path, "r") as log:
         if "CWA Kindle EPUB Fixer Service - Run Ended: " in log.read():
             return True
         else:
             return False
 
+
 def kill_epub_fixer(queue):
     trigger_file = Path(tempfile.gettempdir() + "/.kill_epub_fixer_trigger")
     log_path = "/config/epub-fixer.log"
     while True:
-        sleep(0.05) # Required to prevent high cpu usage
+        sleep(0.05)  # Required to prevent high cpu usage
         if trigger_file.exists():
             # Kill the epub_fixer process
             fl_process = queue.get()
             fl_process.terminate()
             # Remove any potentially left over lock files
             try:
-                os.remove(tempfile.gettempdir() + '/kindle_epub_fixer.lock')
+                os.remove(tempfile.gettempdir() + "/kindle_epub_fixer.lock")
             except FileNotFoundError:
                 ...
             # Remove the trigger file that triggered this block
@@ -646,8 +898,10 @@ def kill_epub_fixer(queue):
             except FileNotFoundError:
                 ...
             # Add string to log to notify user of successful cancellation and to stop the JS update script
-            with open(log_path, 'a') as f:
-                f.write(f"\nCWA EPUB FIXER PROCESS TERMINATED BY USER AT {datetime.now()}")
+            with open(log_path, "a") as f:
+                f.write(
+                    f"\nCWA EPUB FIXER PROCESS TERMINATED BY USER AT {datetime.now()}"
+                )
             # Add run log to log_archive
             archive_run_log(log_path)
             break
@@ -655,28 +909,40 @@ def kill_epub_fixer(queue):
             archive_run_log(log_path)
             break
 
-@epub_fixer.route('/cwa-epub-fixer-overview', methods=["GET"])
-def show_epub_fixer_page():
-    return render_title_template('cwa_epub_fixer.html', title=_("Calibre-Web Automated - Send-to-Kindle EPUB Fixer Service"), page="cwa-epub-fixer")
 
-@epub_fixer.route('/cwa-epub-fixer/log-archive', methods=["GET"])
+@epub_fixer.route("/cwa-epub-fixer-overview", methods=["GET"])
+def show_epub_fixer_page():
+    return render_title_template(
+        "cwa_epub_fixer.html",
+        title=_("Calibre-Web Automated - Send-to-Kindle EPUB Fixer Service"),
+        page="cwa-epub-fixer",
+    )
+
+
+@epub_fixer.route("/cwa-epub-fixer/log-archive", methods=["GET"])
 def show_epub_fixer_logs():
     logs = get_logs_from_archive("epub-fixer")
     log_dates = get_log_dates(logs)
-    return render_title_template('cwa_list_logs.html', title=_("Calibre-Web Automated - Send-to-Kindle EPUB Fixer Service"), page="cwa-epub-fixer-logs",
-                                logs=logs, log_dates=log_dates)
+    return render_title_template(
+        "cwa_list_logs.html",
+        title=_("Calibre-Web Automated - Send-to-Kindle EPUB Fixer Service"),
+        page="cwa-epub-fixer-logs",
+        logs=logs,
+        log_dates=log_dates,
+    )
 
-@epub_fixer.route('/cwa-epub-fixer/download-current-log/<log_filename>')
+
+@epub_fixer.route("/cwa-epub-fixer/download-current-log/<log_filename>")
 def download_current_log(log_filename):
     log_filename = "epub-fixer.log"
     LOG_DIR = "/config"
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
         safe_filename = secure_filename(log_filename)
-        
+
         # Join the logs directory with the filename and get the absolute path
         file_path = os.path.abspath(os.path.join(LOG_DIR, safe_filename))
-        
+
         # Check if the file path is within the allowed directory
         if not file_path.startswith(os.path.abspath(LOG_DIR)):
             abort(403)  # Forbidden if it's not within the logs directory
@@ -687,15 +953,16 @@ def download_current_log(log_filename):
 
         # Send the file as an attachment (to trigger a download)
         return send_from_directory(LOG_DIR, safe_filename, as_attachment=True)
-    
+
     except Exception as e:
         # Handle any other errors
         abort(400)  # Bad request for malformed or unsafe file paths
 
-@epub_fixer.route('/cwa-epub-fixer-start', methods=["GET"])
+
+@epub_fixer.route("/cwa-epub-fixer-start", methods=["GET"])
 def start_epub_fixer():
     # Wipe conversion log from previous runs
-    open('/config/epub-fixer.log', 'w').close()
+    open("/config/epub-fixer.log", "w").close()
     # Remove any left over kill file
     try:
         os.remove(tempfile.gettempdir() + "/.kill_epub_fixer_trigger")
@@ -709,19 +976,20 @@ def start_epub_fixer():
     # Create and start the kill thread
     ef_kill_thread = Thread(target=kill_epub_fixer, args=(process_queue,))
     ef_kill_thread.start()
-    return redirect(url_for('epub_fixer.show_epub_fixer_page'))
+    return redirect(url_for("epub_fixer.show_epub_fixer_page"))
 
-@epub_fixer.route('/epub-fixer-cancel', methods=["GET"])
+
+@epub_fixer.route("/epub-fixer-cancel", methods=["GET"])
 def cancel_epub_fixer():
     # Create kill trigger file
-    open(tempfile.gettempdir() + "/.kill_epub_fixer_trigger", 'w').close()
-    return redirect(url_for('epub_fixer.show_epub_fixer_page'))
+    open(tempfile.gettempdir() + "/.kill_epub_fixer_trigger", "w").close()
+    return redirect(url_for("epub_fixer.show_epub_fixer_page"))
 
-@epub_fixer.route('/epub-fixer-status', methods=["GET"])
+
+@epub_fixer.route("/epub-fixer-status", methods=["GET"])
 def get_status():
-    with open("/config/epub-fixer.log", 'r') as f:
+    with open("/config/epub-fixer.log", "r") as f:
         status = f.read()
     progress = extract_progress(status)
-    statusList = {'status':status,
-                  'progress':progress}
+    statusList = {"status": status, "progress": progress}
     return json.dumps(statusList)

--- a/root/app/calibre-web/cps/templates/cwa_settings.html
+++ b/root/app/calibre-web/cps/templates/cwa_settings.html
@@ -168,6 +168,33 @@
       </div>
     </div>
 
+    <div class="settings-container">
+      <h4 class="settings-section-header">CWA Auto-Convert - Retained Formats</h4>
+      <p class="cwa-settings-explanation settings-explanation">
+        The formats selected here will always be added to the library, even after they have been converted. However, if the format is in the "CWA Auto-Ingest - Ignored Formats" list, it will not be imported. Note that the target format is always retained.
+      </p>
+      <div style="max-width: 90rem; padding-left: 30px;">
+        {% for format in ignorable_formats -%}
+          <label for="convert_retained_{{ format }}" style="width: 75px; padding-right: 6px;">
+            {% if format in cwa_settings['auto_convert_retained_formats'] %}
+              {% if format in cwa_settings['auto_ingest_ignored_formats'] %}
+                <input type="checkbox" id="convert_retained_{{ format }}" name="convert_retained_{{ format }}" value="{{ format }}" disabled style="vertical-align: middle; accent-color: var(--color-secondary);">
+              {% else %}
+                <input type="checkbox" id="convert_retained_{{ format }}" name="convert_retained_{{ format }}" value="{{ format }}" checked style="vertical-align: middle; accent-color: var(--color-secondary);">
+              {% endif %}
+            {% else %}
+              {% if format in cwa_settings['auto_ingest_ignored_formats'] %}
+                <input type="checkbox" id="convert_retained_{{ format }}" name="convert_retained_{{ format }}" value="{{ format }}" disabled style="vertical-align: middle; accent-color: var(--color-secondary);">
+              {% else %}
+                <input type="checkbox" id="convert_retained_{{ format }}" name="convert_retained_{{ format }}" value="{{ format }}" style="vertical-align: middle; accent-color: var(--color-secondary);">
+              {% endif %}
+            {% endif %}
+            <span style="padding-left: 4px; vertical-align: middle;">{{ format }}</span>
+          </label>
+        {% endfor %}
+      </div>
+    </div>
+
     <div class="settings-container" style="margin-bottom: 0.8rem !important;">
       <h4 class="settings-section-header">CWA Auto-Ingest - Ignored Formats</h4>
       <p class="cwa-settings-explanation settings-explanation">

--- a/scripts/check-cwa-services.sh
+++ b/scripts/check-cwa-services.sh
@@ -4,7 +4,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
-# Print promt title
+# Print prompt title
 echo "====== Calibre-Web Automated -- Status of Monitoring Services ======"
 echo ""
 

--- a/scripts/cwa_schema.sql
+++ b/scripts/cwa_schema.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS cwa_enforcement(
-    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, 
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     timestamp TEXT NOT NULL,
-    book_id INTEGER NOT NULL, 
+    book_id INTEGER NOT NULL,
     book_title TEXT NOT NULL,
-    author TEXT NOT NULL, 
-    file_path TEXT NOT NULL, 
+    author TEXT NOT NULL,
+    file_path TEXT NOT NULL,
     trigger_type TEXT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS cwa_import(
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS cwa_settings(
     auto_convert_target_format TEXT DEFAULT "epub" NOT NULL,
     auto_convert_ignored_formats TEXT DEFAULT "" NOT NULL,
     auto_ingest_ignored_formats TEXT DEFAULT "" NOT NULL,
+    auto_convert_retained_formats TEXT DEFAULT "" NOT NULL,
     auto_metadata_enforcement SMALLINT DEFAULT 1 NOT NULL,
     kindle_epub_fixer SMALLINT DEFAULT 1 NOT NULL,
     auto_backup_epub_fixes SMALLINT DEFAULT 1 NOT NULL

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -16,53 +16,124 @@ from kindle_epub_fixer import EPUBFixer
 # already running, then the script is closed, the user is notified and the program
 # exits with code 2
 try:
-    lock = open(tempfile.gettempdir() + '/ingest_processor.lock', 'x')
+    lock = open(tempfile.gettempdir() + "/ingest_processor.lock", "x")
     lock.close()
 except FileExistsError:
-    print("[ingest-processor] CANCELLING... ingest-processor initiated but is already running")
+    print(
+        "[ingest-processor] CANCELLING... ingest-processor initiated but is already running"
+    )
     sys.exit(2)
+
 
 # Defining function to delete the lock on script exit
 def removeLock():
-    os.remove(tempfile.gettempdir() + '/ingest_processor.lock')
+    """Deletes the lock file on script exit"""
+    os.remove(tempfile.gettempdir() + "/ingest_processor.lock")
+
 
 # Will automatically run when the script exits
 atexit.register(removeLock)
 
 # Generates dictionary of available backup directories and their paths
 backup_destinations = {
-        entry.name: entry.path
-        for entry in os.scandir("/config/processed_books")
-        if entry.is_dir()
-    }
+    entry.name: entry.path
+    for entry in os.scandir("/config/processed_books")
+    if entry.is_dir()
+}
+
 
 class NewBookProcessor:
+    """Processes a new book"""
     def __init__(self, filepath: str):
         self.db = CWA_DB()
         self.cwa_settings = self.db.cwa_settings
 
-        self.auto_convert_on = self.cwa_settings['auto_convert']
-        self.target_format = self.cwa_settings['auto_convert_target_format']
-        self.ingest_ignored_formats = self.cwa_settings['auto_ingest_ignored_formats']
-        self.convert_ignored_formats = self.cwa_settings['auto_convert_ignored_formats']
-        self.is_kindle_epub_fixer = self.cwa_settings['kindle_epub_fixer']
+        self.auto_convert_on = self.cwa_settings["auto_convert"]
+        self.target_format = self.cwa_settings["auto_convert_target_format"]
+        self.ingest_ignored_formats = self.cwa_settings["auto_ingest_ignored_formats"]
+        self.convert_retained_formats = self.cwa_settings["auto_convert_retained_formats"]
+        self.convert_ignored_formats = self.cwa_settings["auto_convert_ignored_formats"]
+        self.is_kindle_epub_fixer = self.cwa_settings["kindle_epub_fixer"]
 
-        self.supported_book_formats = {'azw', 'azw3', 'azw4', 'cbz', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'docx', 'epub', 'fb2', 'fbz', 'html', 'htmlz', 'lit', 'lrf', 'mobi', 'odt', 'pdf', 'prc', 'pdb', 'pml', 'rb', 'rtf', 'snb', 'tcr', 'txtz', 'txt', 'kepub'}
-        self.hierarchy_of_success = {'epub', 'lit', 'mobi', 'azw', 'epub', 'azw3', 'fb2', 'fbz', 'azw4',  'prc', 'odt', 'lrf', 'pdb',  'cbz', 'pml', 'rb', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'snb', 'tcr', 'pdf', 'docx', 'rtf', 'html', 'htmlz', 'txtz', 'txt'}
-        self.ingest_folder, self.library_dir, self.tmp_conversion_dir = self.get_dirs("/app/calibre-web-automated/dirs.json")
+        self.supported_book_formats = {
+            "azw",
+            "azw3",
+            "azw4",
+            "cbz",
+            "cbr",
+            "cb7",
+            "cbc",
+            "chm",
+            "djvu",
+            "docx",
+            "epub",
+            "fb2",
+            "fbz",
+            "html",
+            "htmlz",
+            "lit",
+            "lrf",
+            "mobi",
+            "odt",
+            "pdf",
+            "prc",
+            "pdb",
+            "pml",
+            "rb",
+            "rtf",
+            "snb",
+            "tcr",
+            "txtz",
+            "txt",
+            "kepub",
+        }
+        self.hierarchy_of_success = {
+            "epub",
+            "lit",
+            "mobi",
+            "azw",
+            "epub",
+            "azw3",
+            "fb2",
+            "fbz",
+            "azw4",
+            "prc",
+            "odt",
+            "lrf",
+            "pdb",
+            "cbz",
+            "pml",
+            "rb",
+            "cbr",
+            "cb7",
+            "cbc",
+            "chm",
+            "djvu",
+            "snb",
+            "tcr",
+            "pdf",
+            "docx",
+            "rtf",
+            "html",
+            "htmlz",
+            "txtz",
+            "txt",
+        }
+        self.ingest_folder, self.library_dir, self.tmp_conversion_dir = self.get_dirs(
+            "/app/calibre-web-automated/dirs.json"
+        )
 
         # Create the tmp_conversion_dir if it does not already exist
         Path(self.tmp_conversion_dir).mkdir(exist_ok=True)
-        
-        self.filepath = filepath # path of the book we're targeting
+
+        self.filepath = filepath  # path of the book we're targeting
         self.filename = os.path.basename(filepath)
         self.is_target_format = bool(self.filepath.endswith(self.target_format))
         self.can_convert, self.input_format = self.can_convert_check()
 
-
     def get_dirs(self, dirs_json_path: str) -> tuple[str, str, str]:
         dirs = {}
-        with open(dirs_json_path, 'r') as f:
+        with open(dirs_json_path, "r") as f:
             dirs: dict[str, str] = json.load(f)
 
         ingest_folder = f"{dirs['ingest_folder']}/"
@@ -71,110 +142,182 @@ class NewBookProcessor:
 
         return ingest_folder, library_dir, tmp_conversion_dir
 
-
     def can_convert_check(self) -> tuple[bool, str]:
-        """When the current filepath isn't of the target format, this function will check if the file is able to be converted to the target format,
-        returning a can_convert bool with the answer"""
+        """Checks if the file is supported by calibre
+
+        When the current filepath isn't of the target format, this function 
+        will check if the file is able to be converted to the target format,
+        returning a can_convert bool with the answer
+        """
         can_convert = False
         input_format = Path(self.filepath).suffix[1:]
         if input_format in self.supported_book_formats:
             can_convert = True
         return can_convert, input_format
 
-    def backup(self, input_file, backup_type):
+    def backup(self, input_file: str, backup_type: str):
+        """Backs up a file to the backup_destinations directory"""
         try:
             output_path = backup_destinations[backup_type]
         except Exception as e:
-            print(f"[ingest-processor] The following error occurred when trying to fetch the available backup dirs in /config/processed_books:\n{e}")
+            print(
+                f"[ingest-processor] The following error occurred when trying to fetch the available backup dirs in /config/processed_books:\n{e}"
+            )
         try:
             shutil.copy2(input_file, output_path)
         except Exception as e:
-            print(f"[ingest-processor]: ERROR - The following error occurred when trying to copy {input_file} to {output_path}:\n{e}")
+            print(
+                f"[ingest-processor]: ERROR - The following error occurred when trying to copy {input_file} to {output_path}:\n{e}"
+            )
 
+    def convert_book(self, end_format: str | None = None) -> tuple[bool, str]:
+        """Converts a book to the target format using the calibre converter tool
+        
+        Uses the following terminal command to convert the books provided using the calibre converter tool:\n\n--- ebook-convert myfile.input_format myfile.output_format\n\nAnd then saves the resulting files to the calibre-web import folder."""
+        print(
+            f"[ingest-processor]: Starting conversion process for {self.filename}...",
+            flush=True,
+        )
+        print(
+            f"[ingest-processor]: Converting file from {self.input_format} to {self.target_format} format...\n",
+            flush=True,
+        )
+        print(
+            f"\n[ingest-processor]: START_CON: Converting {self.filename}...\n",
+            flush=True,
+        )
 
-    def convert_book(self, end_format=None) -> tuple[bool, str]:
-        """Uses the following terminal command to convert the books provided using the calibre converter tool:\n\n--- ebook-convert myfile.input_format myfile.output_format\n\nAnd then saves the resulting files to the calibre-web import folder."""
-        print(f"[ingest-processor]: Starting conversion process for {self.filename}...", flush=True)
-        print(f"[ingest-processor]: Converting file from {self.input_format} to {self.target_format} format...\n", flush=True)
-        print(f"\n[ingest-processor]: START_CON: Converting {self.filename}...\n", flush=True)
-
-        if end_format == None:
-            end_format = self.target_format # If end_format isn't given, the file is converted to the target format specified in the CWA Settings page
+        if end_format is None:
+            end_format = (
+                self.target_format
+            )  # If end_format isn't given, the file is converted to the target format specified in the CWA Settings page
 
         original_filepath = Path(self.filepath)
-        target_filepath = f"{self.tmp_conversion_dir}{original_filepath.stem}.{end_format}"
+        target_filepath = (
+            f"{self.tmp_conversion_dir}{original_filepath.stem}.{end_format}"
+        )
         try:
             t_convert_book_start = time.time()
-            subprocess.run(['ebook-convert', self.filepath, target_filepath], check=True)
+            subprocess.run(
+                ["ebook-convert", self.filepath, target_filepath], check=True
+            )
             t_convert_book_end = time.time()
             time_book_conversion = t_convert_book_end - t_convert_book_start
-            print(f"\n[ingest-processor]: END_CON: Conversion of {self.filename} complete in {time_book_conversion:.2f} seconds.\n", flush=True)
+            print(
+                f"\n[ingest-processor]: END_CON: Conversion of {self.filename} complete in {time_book_conversion:.2f} seconds.\n",
+                flush=True,
+            )
 
-            if self.cwa_settings['auto_backup_conversions']:
+            if self.cwa_settings["auto_backup_conversions"]:
                 self.backup(self.filepath, backup_type="converted")
 
-            self.db.conversion_add_entry(original_filepath.stem,
-                                        self.input_format,
-                                        self.target_format,
-                                        str(self.cwa_settings["auto_backup_conversions"]))
+            self.db.conversion_add_entry(
+                original_filepath.stem,
+                self.input_format,
+                self.target_format,
+                str(self.cwa_settings["auto_backup_conversions"]),
+            )
 
             return True, target_filepath
 
         except subprocess.CalledProcessError as e:
-            print(f"\n[ingest-processor]: CON_ERROR: {self.filename} could not be converted to {end_format} due to the following error:\nEXIT/ERROR CODE: {e.returncode}\n{e.stderr}", flush=True)
+            print(
+                f"\n[ingest-processor]: CON_ERROR: {self.filename} could not be converted to {end_format} due to the following error:\nEXIT/ERROR CODE: {e.returncode}\n{e.stderr}",
+                flush=True,
+            )
             self.backup(self.filepath, backup_type="failed")
             return False, ""
 
-
     # Kepubify can only convert EPUBs to Kepubs
-    def convert_to_kepub(self) -> tuple[bool,str]:
+    def convert_to_kepub(self) -> tuple[bool, str]:
         """Kepubify is limited in that it can only convert from epub to kepub, therefore any files not already in epub need to first be converted to epub, and then to kepub"""
         if self.input_format == "epub":
-            print(f"[ingest-processor]: File in epub format, converting directly to kepub...", flush=True)
+            print(
+                f"[ingest-processor]: File in epub format, converting directly to kepub...",
+                flush=True,
+            )
             converted_filepath = self.filepath
             convert_successful = True
         else:
-            print("\n[ingest-processor]: *** NOTICE TO USER: Kepubify is limited in that it can only convert from epubs. To get around this, CWA will automatically convert other"
-            "supported formats to epub using the Calibre's conversion tools & then use Kepubify to produce your desired kepubs. Obviously multi-step conversions aren't ideal"
-            "so if you notice issues with your converted files, bare in mind starting with epubs will ensure the best possible results***\n", flush=True)
-            convert_successful, converted_filepath = self.convert_book(self.input_format, end_format="epub") # type: ignore
-            
+            print(
+                "\n[ingest-processor]: *** NOTICE TO USER: Kepubify is limited in that it can only convert from epubs. To get around this, CWA will automatically convert other"
+                "supported formats to epub using the Calibre's conversion tools & then use Kepubify to produce your desired kepubs. Obviously multi-step conversions aren't ideal"
+                "so if you notice issues with your converted files, bare in mind starting with epubs will ensure the best possible results***\n",
+                flush=True,
+            )
+            convert_successful, converted_filepath = self.convert_book(self.input_format, end_format="epub")  # type: ignore
+
         if convert_successful:
             converted_filepath = Path(converted_filepath)
-            target_filepath = f"{self.tmp_conversion_dir}{converted_filepath.stem}.kepub"
+            target_filepath = (
+                f"{self.tmp_conversion_dir}{converted_filepath.stem}.kepub"
+            )
             try:
-                subprocess.run(['kepubify', '--inplace', '--calibre', '--output', self.tmp_conversion_dir, converted_filepath], check=True)
-                if self.cwa_settings['auto_backup_conversions']:
+                subprocess.run(
+                    [
+                        "kepubify",
+                        "--inplace",
+                        "--calibre",
+                        "--output",
+                        self.tmp_conversion_dir,
+                        converted_filepath,
+                    ],
+                    check=True,
+                )
+                if self.cwa_settings["auto_backup_conversions"]:
                     self.backup(self.filepath, backup_type="converted")
 
-                self.db.conversion_add_entry(converted_filepath.stem,
-                                            self.input_format,
-                                            self.target_format,
-                                            str(self.cwa_settings["auto_backup_conversions"]))
+                self.db.conversion_add_entry(
+                    converted_filepath.stem,
+                    self.input_format,
+                    self.target_format,
+                    str(self.cwa_settings["auto_backup_conversions"]),
+                )
 
                 return True, target_filepath
 
             except subprocess.CalledProcessError as e:
-                print(f"[ingest-processor]: CON_ERROR: {self.filename} could not be converted to kepub due to the following error:\nEXIT/ERROR CODE: {e.returncode}\n{e.stderr}", flush=True)
+                print(
+                    f"[ingest-processor]: CON_ERROR: {self.filename} could not be converted to kepub due to the following error:\nEXIT/ERROR CODE: {e.returncode}\n{e.stderr}",
+                    flush=True,
+                )
                 self.backup(converted_filepath, backup_type="failed")
                 return False, ""
             except Exception as e:
-                print(f"[ingest-processor] ingest-processor ran into the following error:\n{e}", flush=True)
+                print(
+                    f"[ingest-processor] ingest-processor ran into the following error:\n{e}",
+                    flush=True,
+                )
         else:
-            print(f"[ingest-processor]: An error occurred when converting the original {self.input_format} to epub. Cancelling kepub conversion...", flush=True)
+            print(
+                f"[ingest-processor]: An error occurred when converting the original {self.input_format} to epub. Cancelling kepub conversion...",
+                flush=True,
+            )
             return False, ""
-
 
     def delete_current_file(self) -> None:
         """Deletes file just processed from ingest folder"""
-        os.remove(self.filepath) # Removes processed file
-        subprocess.run(["find", f"{self.ingest_folder}", "-mindepth", "1", "-type", "d", "-empty", "-delete"]) # Removes any now empty folders in the ingest folder
+        os.remove(self.filepath)  # Removes processed file
+        subprocess.run(
+            [
+                "find",
+                f"{self.ingest_folder}",
+                "-mindepth",
+                "1",
+                "-type",
+                "d",
+                "-empty",
+                "-delete",
+            ]
+        )  # Removes any now empty folders in the ingest folder
 
-
-    def add_book_to_library(self, book_path:str) -> None:
+    def add_book_to_library(self, book_path: str) -> None:
+        """Adds a book to the Calibre library"""
         if self.target_format == "epub" and self.is_kindle_epub_fixer:
             self.run_kindle_epub_fixer(book_path, dest=self.tmp_conversion_dir)
-            fixed_epub_path = str(self.empty_tmp_con_dir) + str(os.path.basename(book_path))
+            fixed_epub_path = str(self.empty_tmp_con_dir) + str(
+                os.path.basename(book_path)
+            )
             if Path(fixed_epub_path).exists():
                 book_path = self.empty_tmp_con_dir + os.path.basename(book_path)
 
@@ -182,31 +325,54 @@ class NewBookProcessor:
         import_path = Path(book_path)
         import_filename = os.path.basename(book_path)
         try:
-            subprocess.run(["calibredb", "add", book_path, "--automerge", "new_record", f"--library-path={self.library_dir}"], check=True)
-            print(f"[ingest-processor] Added {import_path.stem} to Calibre database", flush=True)
+            subprocess.run(
+                [
+                    "calibredb",
+                    "add",
+                    book_path,
+                    "--automerge",
+                    "new_record",
+                    f"--library-path={self.library_dir}",
+                ],
+                check=True,
+            )
+            print(
+                f"[ingest-processor] Added {import_path.stem} to Calibre database",
+                flush=True,
+            )
 
-            if self.cwa_settings['auto_backup_imports']:
+            if self.cwa_settings["auto_backup_imports"]:
                 self.backup(book_path, backup_type="imported")
 
-            self.db.import_add_entry(import_path.stem,
-                                    str(self.cwa_settings["auto_backup_imports"]))
+            self.db.import_add_entry(
+                import_path.stem, str(self.cwa_settings["auto_backup_imports"])
+            )
 
         except subprocess.CalledProcessError as e:
-            print(f"[ingest-processor] {import_path.stem} was not able to be added to the Calibre Library due to the following error:\nCALIBREDB EXIT/ERROR CODE: {e.returncode}\n{e.stderr}", flush=True)
+            print(
+                f"[ingest-processor] {import_path.stem} was not able to be added to the Calibre Library due to the following error:\nCALIBREDB EXIT/ERROR CODE: {e.returncode}\n{e.stderr}",
+                flush=True,
+            )
             self.backup(book_path, backup_type="failed")
         except Exception as e:
-            print(f"[ingest-processor] ingest-processor ran into the following error:\n{e}", flush=True)
+            print(
+                f"[ingest-processor] ingest-processor ran into the following error:\n{e}",
+                flush=True,
+            )
 
-
-    def run_kindle_epub_fixer(self, filepath:str, dest=None) -> None:
+    def run_kindle_epub_fixer(self, filepath: str, dest=None) -> None:
         try:
             EPUBFixer().process(input_path=filepath, output_path=dest)
-            print(f"[ingest-processor] {os.path.basename(filepath)} successfully processed with the cwa-kindle-epub-fixer!")
+            print(
+                f"[ingest-processor] {os.path.basename(filepath)} successfully processed with the cwa-kindle-epub-fixer!"
+            )
         except Exception as e:
-            print(f"[ingest-processor] An error occurred while processing {os.path.basename(filepath)} with the kindle-epub-fixer. See the following error:\n{e}")
-
+            print(
+                f"[ingest-processor] An error occurred while processing {os.path.basename(filepath)} with the kindle-epub-fixer. See the following error:\n{e}"
+            )
 
     def empty_tmp_con_dir(self):
+        """Empties the tmp_conversion_dir"""
         try:
             files = os.listdir(self.tmp_conversion_dir)
             for file in files:
@@ -214,18 +380,26 @@ class NewBookProcessor:
                 if os.path.isfile(file_path):
                     os.remove(file_path)
         except OSError:
-            print(f"[ingest-processor] An error occurred while emptying {self.tmp_conversion_dir}.", flush=True)
+            print(
+                f"[ingest-processor] An error occurred while emptying {self.tmp_conversion_dir}.",
+                flush=True,
+            )
 
     def set_library_permissions(self):
+        """Sets the ownership of the library_dir to abc:abc"""
         try:
             subprocess.run(["chown", "-R", "abc:abc", self.library_dir], check=True)
         except subprocess.CalledProcessError as e:
-            print(f"[ingest-processor] An error occurred while attempting to recursively set ownership of {self.library_dir} to abc:abc. See the following error:\n{e}", flush=True)
+            print(
+                f"[ingest-processor] An error occurred while attempting to recursively set ownership of {self.library_dir} to abc:abc. See the following error:\n{e}",
+                flush=True,
+            )
 
 
 def main(filepath=sys.argv[1]):
     """Checks if filepath is a directory. If it is, main will be ran on every file in the given directory
-    Inotifywait won't detect files inside folders if the folder was moved rather than copied"""
+    Inotifywait won't detect files inside folders if the folder was moved rather than copied
+    """
     if os.path.isdir(filepath) and Path(filepath).exists():
         # print(os.listdir(filepath))
         for filename in os.listdir(filepath):
@@ -240,34 +414,62 @@ def main(filepath=sys.argv[1]):
     if Path(nbp.filename).suffix in nbp.ingest_ignored_formats:
         pass
     else:
-        if nbp.is_target_format: # File can just be imported
-            print(f"\n[ingest-processor]: No conversion needed for {nbp.filename}, importing now...", flush=True)
+        if nbp.is_target_format:  # File can just be imported
+            print(
+                f"\n[ingest-processor]: No conversion needed for {nbp.filename}, importing now...",
+                flush=True,
+            )
             nbp.add_book_to_library(filepath)
         else:
-            if nbp.auto_convert_on and nbp.can_convert: # File can be converted to target format and Auto-Converter is on
+            if (
+                nbp.auto_convert_on and nbp.can_convert
+            ):  # File can be converted to target format and Auto-Converter is on
 
-                if nbp.input_format in nbp.convert_ignored_formats: # File could be converted & the converter is activated but the user has specified files of this format should not be converted
-                    print(f"\n[ingest-processor]: {nbp.filename} not in target format but user has told CWA not to convert this format so importing the file anyway...", flush=True)
+                if (
+                    nbp.input_format in nbp.convert_ignored_formats
+                ):  # File could be converted & the converter is activated but the user has specified files of this format should not be converted
+                    print(
+                        f"\n[ingest-processor]: {nbp.filename} not in target format but user has told CWA not to convert this format so importing the file anyway...",
+                        flush=True,
+                    )
                     nbp.add_book_to_library(filepath)
                     convert_successful = False
-                elif nbp.target_format == "kepub": # File is not in the convert ignore list and target is kepub, so we start the kepub conversion process
+                elif (
+                    nbp.target_format == "kepub"
+                ):  # File is not in the convert ignore list and target is kepub, so we start the kepub conversion process
                     convert_successful, converted_filepath = nbp.convert_to_kepub()
-                else: # File is not in the convert ignore list and target is not kepub, so we start the regular conversion process
+                else:  # File is not in the convert ignore list and target is not kepub, so we start the regular conversion process
                     convert_successful, converted_filepath = nbp.convert_book()
                     
-                if convert_successful: # If previous conversion process was successful, remove tmp files and import into library
-                    nbp.add_book_to_library(converted_filepath) # type: ignore
+                if (
+                    convert_successful
+                ):  # If previous conversion process was successful, remove tmp files and import into library
+                    nbp.add_book_to_library(converted_filepath)  # type: ignore
+                    
+                    # If the file is in the ingest retained formats, also add 
+                    # the original file to the library without converting
+                    if nbp.input_format in nbp.convert_retained_formats:
+                        nbp.add_book_to_library(filepath)
 
-            elif nbp.can_convert and not nbp.auto_convert_on: # Books not in target format but Auto-Converter is off so files are imported anyway
-                print(f"\n[ingest-processor]: {nbp.filename} not in target format but CWA Auto-Convert is deactivated so importing the file anyway...", flush=True)
+            elif (
+                nbp.can_convert and not nbp.auto_convert_on
+            ):  # Books not in target format but Auto-Converter is off so files are imported anyway
+                print(
+                    f"\n[ingest-processor]: {nbp.filename} not in target format but CWA Auto-Convert is deactivated so importing the file anyway...",
+                    flush=True,
+                )
                 nbp.add_book_to_library(filepath)
             else:
-                print(f"[ingest-processor]: Cannot convert {nbp.filepath}. {nbp.input_format} is currently unsupported / is not a known ebook format.", flush=True)
+                print(
+                    f"[ingest-processor]: Cannot convert {nbp.filepath}. {nbp.input_format} is currently unsupported / is not a known ebook format.",
+                    flush=True,
+                )
 
         nbp.empty_tmp_con_dir()
         nbp.set_library_permissions()
         nbp.delete_current_file()
-        del nbp # New in Version 2.0.0, should drastically reduce memory usage with large ingests
+        del nbp  # New in Version 2.0.0, should drastically reduce memory usage with large ingests
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Added a new setting to allow retaining original book format in auto-ingestion. Formats enabled in that option will also be added to the library even if it has been converted to the target format. 

1. The target format will automatically be enabled. 
2. The format will be ignored if it has been enabled in the ignore ingest settings. 

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/3336aca5-37ce-4de9-9d4d-0ce314ce3385" />

Fixes #269 
