### PR TITLE
Always ignore .crdownload during ingestion

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -44,6 +44,7 @@ class NewBookProcessor:
         self.auto_convert_on = self.cwa_settings['auto_convert']
         self.target_format = self.cwa_settings['auto_convert_target_format']
         self.ingest_ignored_formats = self.cwa_settings['auto_ingest_ignored_formats']
+        self.ingest_ignored_formats.append(".crdownload")
         self.convert_ignored_formats = self.cwa_settings['auto_convert_ignored_formats']
         self.is_kindle_epub_fixer = self.cwa_settings['kindle_epub_fixer']
 


### PR DESCRIPTION
This change updates the ingestion process to ignore files with the `.crdownload` extension.
Since browsers like Chrome use `.crdownload` for files in progress, this prevents partially downloaded files from being processed, which could lead to issues.