### PR TITLE
Fix for older kernels (E.G. synology) - Remove the ABI tag from the extracted libQt6* files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,8 @@ RUN \
     libxdamage1 \
     libgl1 \
     libglx-mesa0 \
-    xz-utils && \
+    xz-utils \
+    binutils && \
   # STEP 3.2 - Make the /app/calibre directory for the installed files
   mkdir -p \
   /app/calibre && \
@@ -175,6 +176,8 @@ RUN \
   tar xf \
       /calibre.txz -C \
       /app/calibre && \
+  # STEP 3.4.1 - Remove the ABI tag from the extracted libQt6* files to allow them to be used on older kernels
+  strip --remove-section=.note.ABI-tag /app/calibre/lib/libQt6* && \
   # STEP 3.5 - Delete the extracted calibre.txz to save space in final image
   rm /calibre.txz && \
   # STEP 3.6 - Store the UNIVERSAL_CALIBRE_RELEASE in the root of the image in CALIBRE_RELEASE


### PR DESCRIPTION
- Add `binutils` to install `strip` for calibre-included Dockerfile.
- strip `libQt6*.so` files of the `ABI` tag so that they can work with older kernels (harmless for newer kernels).
  - These libraries appear to still contain fallbacks for any missing syscalls that calibre might use.
- add .gitattributes to enforce LF checkout on `.sh` files (useful for those who build on windows)