### PR TITLE
Fix: Kepub conversion not being passed the full path of the source file.

### DIFF
--- a/scripts/convert_library.py
+++ b/scripts/convert_library.py
@@ -163,7 +163,7 @@ class LibraryConverter:
                 continue
 
             if self.target_format == "kepub":
-                convert_successful, target_filepath = self.convert_to_kepub(filename, file_extension)
+                convert_successful, target_filepath = self.convert_to_kepub(file, file_extension)
                 if not convert_successful:
                     print_and_log(f"[convert-library]: ({self.current_book}/{len(self.to_convert)}) Conversion of {os.path.basename(file)} was unsuccessful. Moving to next book...")
                     self.current_book += 1


### PR DESCRIPTION
When converting to **.kepub** only the filename of the source was being passed, not the full path. This resulted in an error message like: `[Errno 2] No such file or directory: '<example ebook>.epub'`.

The `convert_library.py` script was updated to pass the full path.

This fixes bug #219.