### PR TITLE
Add configurable setting for ingest automerge parameter 

### DIFF
--- a/root/app/calibre-web/cps/cwa_functions.py
+++ b/root/app/calibre-web/cps/cwa_functions.py
@@ -157,6 +157,7 @@ def set_cwa_settings():
                         'prc', 'pdb', 'pml', 'rb',
                         'rtf', 'snb', 'tcr', 'txt', 'txtz']
     target_formats = ['epub', 'azw3', 'kepub', 'mobi', 'pdf']
+    automerge_options = ['ignore', 'overwrite', 'new_record']
 
     boolean_settings = []
     string_settings = []
@@ -231,7 +232,7 @@ def set_cwa_settings():
 
     return render_title_template("cwa_settings.html", title=_("Calibre-Web Automated User Settings"), page="cwa-settings",
                                     cwa_settings=cwa_settings, ignorable_formats=ignorable_formats,
-                                    target_formats=target_formats)
+                                    target_formats=target_formats, automerge_options=automerge_options)
 
 ##————————————————————————————————————————————————————————————————————————————##
 ##                                                                            ##

--- a/root/app/calibre-web/cps/templates/cwa_settings.html
+++ b/root/app/calibre-web/cps/templates/cwa_settings.html
@@ -196,6 +196,35 @@
       </div>
     </div>
 
+    <div class="settings-container">
+      <h4 class="settings-section-header">CWA Auto-Ingest Automerge</h4>
+
+      <p class="cwa-settings-explanation settings-explanation">
+        CalibreDB can detect duplicate book titles on import and depending on the automerge setting, delete either of the instances
+        or keep both (default).
+      </p>
+      <label for="auto_ingest_automerge" style="padding-right: 10px; margin-bottom: 16px !important;">Choose how to handle duplicates:</label>
+      <select class="cwa-settings-select" name="auto_ingest_automerge" id="auto_ingest_automerge">
+        {% for automerge in automerge_options -%}
+          {% if cwa_settings['auto_ingest_automerge'] == automerge %}
+            <option value="{{ automerge }}" selected>{{ automerge }}</option>
+          {% else %}
+            <option value="{{ automerge }}">{{ automerge }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
+
+      <p>Possible values:</p>
+      <dl>
+        <dt>ignore</dt>
+        <dd style="margin-left: revert;">Discard duplicate import, keep library copy</dd>
+        <dt>overwrite</dt>
+        <dd style="margin-left: revert;">Overwrite library copy with newly imported file</dd>
+        <dt>new_record (default)</dt>
+        <dd style="margin-left: revert;">Create a duplicate record, keeping both copies</dd>
+      </dl>
+    </div>
+
     <br>
     <div class="row form-group" style="text-align-last: justify;">
       <input type="submit" name="submit_button" value="Submit" class="btn btn-default">

--- a/scripts/cwa_schema.sql
+++ b/scripts/cwa_schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS cwa_settings(
     auto_convert_target_format TEXT DEFAULT "epub" NOT NULL,
     auto_convert_ignored_formats TEXT DEFAULT "" NOT NULL,
     auto_ingest_ignored_formats TEXT DEFAULT "" NOT NULL,
+    auto_ingest_automerge TEXT DEFAULT "new_record" NOT NULL,
     auto_metadata_enforcement SMALLINT DEFAULT 1 NOT NULL,
     kindle_epub_fixer SMALLINT DEFAULT 1 NOT NULL,
     auto_backup_epub_fixes SMALLINT DEFAULT 1 NOT NULL

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -222,7 +222,7 @@ class NewBookProcessor:
         import_path = Path(book_path)
         import_filename = os.path.basename(book_path)
         try:
-            subprocess.run(["calibredb", "add", book_path, "--automerge", "new_record", f"--library-path={self.library_dir}"], env=self.calibre_env, check=True)
+            subprocess.run(["calibredb", "add", book_path, "--automerge", self.cwa_settings['auto_ingest_automerge'], f"--library-path={self.library_dir}"], env=self.calibre_env, check=True)
             print(f"[ingest-processor] Added {import_path.stem} to Calibre database", flush=True)
 
             if self.cwa_settings['auto_backup_imports']:


### PR DESCRIPTION
This is an attempt to address #340 #334 #208 as well as my own desire to overwrite duplicate books on import by adding a new setting that matches the three possible values of [calibredb's `--automerge` parameter](https://manual.calibre-ebook.com/generated/en/calibredb.html#cmdoption-calibredb-add-automerge). This replaces the hardcoded `new_record` value in [`add_book_to_library`](scripts/ingest_processor.py). The default value matches the previous behaviour.

I have done my best to keep this fairly minimal and to match any existing patterns where I was able to identify them. Please let me know your thoughts on a feature like this in general as well as this PR.