### PR TITLE
Solve sync failing by supporting POST in route for notebooks

### DIFF
--- a/root/app/calibre-web/cps/kobo.py
+++ b/root/app/calibre-web/cps/kobo.py
@@ -960,7 +960,7 @@ def HandleBookDeletionRequest(book_uuid):
 
 # TODO: Implement the following routes
 @csrf.exempt
-@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET"])
+@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET", "POST"])
 def HandleUnimplementedRequest(dummy=None):
     log.debug("Unimplemented Library Request received: %s (request is forwarded to kobo if configured)",
               request.base_url)


### PR DESCRIPTION
Add support for native notebook syncing. This solution was proposed and proven effective following this thread. Allows using Calibre-Web-Automated sync while still being able to backup notebooks to Kobo. https://github.com/janeczku/calibre-web/issues/2849#issuecomment-2613986184