### PR TITLE
Added a fix for #427

### DIFF
--- a/root/app/calibre-web/cps/editbooks.py
+++ b/root/app/calibre-web/cps/editbooks.py
@@ -1255,6 +1255,8 @@ def edit_cc_data_value(book_id, book, c, to_save, cc_db_value, cc_string):
             new_cc = cc_class(value=to_save[cc_string], book=book_id)
             calibre_db.session.add(new_cc)
             changed = True
+        if type(to_save[cc_string]) is datetime:
+            to_save[cc_string] = to_save[cc_string].strftime("%Y-%m-%d")
     return changed, to_save
 
 


### PR DESCRIPTION
custom columns with dates where not converted to a string before the json converter and caused errors.

Before it needs to be date time for saving it in the database
Error was reported in #427

Is probably not a common problem that a user has a custom column using dates, but i have the use case so I tried to fix it and it seems to work for me with this small fix.

Feel free to change it