### PR TITLE
feat: Add health check endpoint

### DIFF
--- a/root/app/calibre-web/cps/web.py
+++ b/root/app/calibre-web/cps/web.py
@@ -28,6 +28,7 @@ import importlib
 # CWA Imports
 import sqlite3
 import json
+import time
 
 from flask import Blueprint, jsonify
 from flask import request, redirect, send_from_directory, make_response, flash, abort, url_for, Response
@@ -94,6 +95,7 @@ except ImportError:
 sql_version = importlib.metadata.version("sqlalchemy")
 sqlalchemy_version2 = ([int(x) for x in sql_version.split('.')] >= [2, 0, 0])
 
+_start_time = time.time()
 
 @app.after_request
 def add_security_headers(resp):
@@ -830,6 +832,26 @@ def render_archived_books(page, sort_param):
     page_name = "archived"
     return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
                                  title=name, page=page_name, order=sort_param[1])
+
+
+web.route("/health")
+def health_check():
+    uptime = time.time() - _start_time
+
+    try:
+        db_path = cwa_get_library_location() + "metadata.db"
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1")
+        db_up = True
+    except Exception:
+        db_up = False
+    
+    return jsonify({
+        "status": "ok" if db_up else "degraded",
+        "uptime": uptime,
+        "version": f"CWA/{constants.VERSION}",
+    }), 200 if db_up else 503
 
 
 # ################################### View Books list ##################################################################


### PR DESCRIPTION
## Description

This adds a healthcheck at `/health` which allows admins who are using health monitoring tools like Uptime Kuma to have a specific endpoint which they can check.

The response which `/health` sends is:

If everything is ok and the database is accessible (HTTP code: 200 ok):
```json
{
  "status": "ok",
  "uptime": 41895.45,
  "version": "CWA/(VERSION)"
}
```

If the database is not accessible (HTTP code: 503 Service unavailable)
```json
{
  "status": "degraded",
  "uptime": 41895.45,
  "version": "CWA/(VERSION)"
}
```

## Additional Notes

This PR is a modified version of https://github.com/gelbphoenix/autocaliweb/blob/e3534730528b5b420ea02179f71b38b3522d53a7/cps/web.py#L849-L869
Fixes #171 