### PR TITLE
bug issue #463. kosync plugin url

### DIFF
--- a/cps/templates/kosync_plugin.html
+++ b/cps/templates/kosync_plugin.html
@@ -199,7 +199,7 @@
 
       <div class="kosync-step">
       <ul style="margin-top: 10px;">
-        <li><strong>Server URL:</strong>&nbsp;&nbsp;&nbsp;<code>{{ request.host_url }}kosync</code></li>
+        <li><strong>Server URL:</strong>&nbsp;&nbsp;&nbsp;<code>{{ request.host_url }}</code></li>
         <li><strong>Username:</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Your Calibre-Web-Automated username</li>
         <li><strong>Password:</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Your Calibre-Web-Automated password</li>
       </ul>


### PR DESCRIPTION
Remove `/kosync` from the CWA KOSync plugin page because the plugin is automatically appending it to the url. See #463 