### PR TITLE
Update kosync_plugin.html to removed iOS reference

### DIFF
--- a/cps/templates/kosync_plugin.html
+++ b/cps/templates/kosync_plugin.html
@@ -116,7 +116,7 @@
       </p>
 
       <div class="kosync-info">
-        <strong>Compatible with:</strong> KOReader on Android, iOS, Kindle, Kobo, and other supported devices
+        <strong>Compatible with:</strong> KOReader on Android, Kindle, Kobo, and other supported devices
       </div>
 
       <div class="text-center">

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -567,113 +567,111 @@ msgstr "Benutzer '%(nick)s' aktualisiert"
 
 #: cps/constants.py:200
 msgid "Czech"
-msgstr ""
+msgstr "Tschechisch"
 
 #: cps/constants.py:201
 msgid "German"
-msgstr ""
+msgstr "Deutsch"
 
 #: cps/constants.py:202
 msgid "Greek"
-msgstr ""
+msgstr "Griechisch"
 
 #: cps/constants.py:203
 msgid "Spanish"
-msgstr ""
+msgstr "Spanisch"
 
 #: cps/constants.py:204
-#, fuzzy
 msgid "Finnish"
-msgstr "Fertiggestellt"
+msgstr "Finnisch"
 
 #: cps/constants.py:205
 msgid "French"
-msgstr ""
+msgstr "Französisch"
 
 #: cps/constants.py:206
 msgid "Galician"
-msgstr ""
+msgstr "Galizisch"
 
 #: cps/constants.py:207
 msgid "Hungarian"
-msgstr ""
+msgstr "Ungarisch"
 
 #: cps/constants.py:208
 msgid "Indonesian"
-msgstr ""
+msgstr "Indonesisch"
 
 #: cps/constants.py:209
 msgid "Italian"
-msgstr ""
+msgstr "Italienisch"
 
 #: cps/constants.py:210
 msgid "Japanese"
-msgstr ""
+msgstr "Japanisch"
 
 #: cps/constants.py:211
 msgid "Khmer"
-msgstr ""
+msgstr "Khmer"
 
 #: cps/constants.py:212
 msgid "Korean"
-msgstr ""
+msgstr "Koreanisch"
 
 #: cps/constants.py:213
 msgid "Dutch"
-msgstr ""
+msgstr "Niederländisch"
 
 #: cps/constants.py:214
 msgid "Norwegian"
-msgstr ""
+msgstr "Norwegisch"
 
 #: cps/constants.py:215
-#, fuzzy
 msgid "Polish"
-msgstr "Herausgeber"
+msgstr "Polnisch"
 
 #: cps/constants.py:216
 msgid "Portuguese"
-msgstr ""
+msgstr "Portugisisch"
 
 #: cps/constants.py:217
 msgid "Portuguese (Brazil)"
-msgstr ""
+msgstr "Portugizisch (Brasilien)"
 
 #: cps/constants.py:218
 msgid "Russian"
-msgstr ""
+msgstr "Russisch"
 
 #: cps/constants.py:219
 msgid "Slovak"
-msgstr ""
+msgstr "Slovakisch"
 
 #: cps/constants.py:220
 msgid "Slovenian"
-msgstr ""
+msgstr "Slovenisch"
 
 #: cps/constants.py:221
 msgid "Swedish"
-msgstr ""
+msgstr "Schwedisch"
 
 #: cps/constants.py:222
 msgid "Turkish"
-msgstr ""
+msgstr "Türkisch"
 
 #: cps/constants.py:223
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukrainisch"
 
 #: cps/constants.py:224
 msgid "Vietnamese"
-msgstr ""
+msgstr "Vietnamesisch"
 
 #: cps/constants.py:225
 msgid "Chinese (Simplified, China)"
-msgstr ""
+msgstr "Chinesisch (vereinfacht, China)"
 
 #: cps/constants.py:226
 msgid "Chinese (Traditional, Taiwan)"
-msgstr ""
+msgstr "Chinesisch (traditionell, Taiwan"
 
 #: cps/converter.py:31
 msgid "not installed"


### PR DESCRIPTION
I removed the reference to iOS as koreader is not availible there (and no reader kompatible to kosync to my knowledge)