### PR TITLE
Copy uploaded files to ingest directory instead of processing them

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -102,8 +102,6 @@ def upload():
              log.info('Copying %s to cwa ingest directory', requested_file)
              copyfile(meta.file_path, os.path.join(get_ingest_dir(), os.path.basename(meta.file_path) + '.' + meta.extension))
 
-             return Response(json.dumps({"location": url_for("web.index")}), mimetype='application/json')
-
         return Response(json.dumps({"location": url_for("web.index")}), mimetype='application/json')
     abort(404)
 


### PR DESCRIPTION
On upload, copy the file(s) to the ingest directory instead of processing them manually.

Note: this is kind of a hack, I would not accept this PR as part of my day job. The better way would be to refactor the ingestion code so it can be called directly on upload, but I don't have a real dev environment setup for this and that seemed too hard over putty and nano.