### PR TITLE
Should fix issue: 509

### DIFF
--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -96,7 +96,7 @@ class HardcoverClient:
     # TODO Add option for autocreate if missing books instead of forcing it.
     def update_reading_progress(self, identifiers, progress_percent):
         ids = self.parse_identifiers(identifiers)
-        if len(ids) is not 0:
+        if len(ids) != 0:
             book = self.get_user_book(ids)
             # Book doesn't exist, add it in Reading status
             if not book:


### PR DESCRIPTION
https://github.com/crocodilestick/Calibre-Web-Automated/issues/509

By changing 'is not' to '!=' so syncing reading progress is actually executed instead of the error we're seeing in the logs:
> WARN {py.warnings:109} /app/calibre-web-automated/cps/services/hardcover.py:110: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(ids) is not 0:<