### PR TITLE
Remove adds from 'litres' metadata provider

### DIFF
--- a/cps/metadata_provider/litres.py
+++ b/cps/metadata_provider/litres.py
@@ -308,12 +308,15 @@ class Litres(Metadata):
         else:
             raw_html = item.get("annotation") or item.get("description") or item.get("lead") or ""
 
-        if not raw_html:
-            return ""
+        description = raw_html or ""
 
-        pattern = r'<p\b[^>]*>(?:(?!</p>).)*?(?:epub|pdf|fb2|mobi)(?:(?!</p>).)*?</p>'
+        patterns =  [
+            r'<p\b[^>]*>(?:(?!</p>).)*?(?:покупк|скачать|загрузить|предоставляется|формат|epub|pdf|fb2|mobi)(?:(?!</p>).)*?</p>',
+            r'<p><br/></p>'
+        ]
 
-        description = re.sub(pattern, '', raw_html, flags=re.IGNORECASE | re.DOTALL)
+        for pattern in patterns:
+            description = re.sub(pattern, '', description, flags=re.IGNORECASE | re.DOTALL)
 
         return description
 


### PR DESCRIPTION
Hello there, added some improvements to litres metadata providers: remove adds from title and description

_you can translate examples for undestand context if you want_ 

Example **title**:

```
Тестирование программного обеспечения. Контекстно ориентированный подход (pdf+epub) // unused (pdf+epub) text - delete
```


Example **description**:

```
В этой книге вы найдете ключевые принципы, алгоритмы и компромиссы, без которых не обойтись при разработке высоконагруженных систем для работы с данными. Материал рассматривается на примере внутреннего устройства популярных программных пакетов и фреймворков. В книге три основные части, посвященные, прежде всего, теоретическим аспектам работы с распределенными системами и базами данных. От читателя требуются базовые знания SQL и принципов работы баз данных.

После покупки предоставляется дополнительная возможность скачать книгу в формате epub. // this paragraph is adds - delete
```
