### PR TITLE
fix(s6-init) Resolve bug where the environment isn't being passed correctly

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
 # FROM lscio/docker-calibre-web - init-calibre-web-config.sh


### PR DESCRIPTION
I suspect this will work -- `NETWORK_SHARE_MODE` doesn't seem to be available to this script, and i believe that's because the s6 container env isn't being pushed in.