### PR TITLE
Fix logger

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -320,7 +320,7 @@ def _get_ingest_path(uploaded_file, prefix_parts=None):
             # Set ownership to abc:abc (uid=1000, gid=1000)
             os.chown(ingest_dir, 1000, 1000)
     except OSError as e:
-        logger.log.warning('Failed to set ownership of ingest directory %s: %s', ingest_dir, e)
+        log.warning('Failed to set ownership of ingest directory %s: %s', ingest_dir, e)
     except Exception:
         # Silently ignore any other permission-related errors
         pass


### PR DESCRIPTION
Fix 
ERROR {cps.editbooks:154} Failed to queue upload for ingest: module 'cps.logger' has no attribute 'log' when uploading books through the web ui