### PR TITLE
Fix getting rating from Amazon.com

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -62,8 +62,10 @@ $(function () {
       $("#title").val(book.title);
     }
     $("#languages").val(uniqueLanguages.join(", "));
-    // Removed as users can't fetch ratings from metadata providers
-    // $("#rating").data("rating").setValue(Math.round(book.rating)); 
+    if (updateItems.rating) {
+      $("#rating").data("rating").setValue(Math.round(book.rating)); 
+      $("#rating").val(Math.round(book.rating));
+    }
 
     if (updateItems.cover && book.cover && $("#cover_url").length) {
       $(".cover img").attr("src", book.cover);

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -119,7 +119,7 @@
     </div>
     <div class="form-group">
       <label for="rating">{{_('Rating')}}</label>
-      <input type="number"  name="rating" id="rating" class="rating input-lg" data-clearable="" value="{% if book.ratings %}{{(book.ratings[0].rating / 2)|int}}{% endif %}">
+      <input type="number"  name="rating" id="rating" class="rating input-lg" data-clearable="" value="{% if book.ratings %}{{(book.ratings[0].rating / 2)|int}}{% endif %}"/>
     </div>
       <div class="form-group">
       <label for="comments">{{_('Description')}}</label>
@@ -311,6 +311,10 @@
         <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="seriesIndex" checked>Series Index:</dt>
         <dd class="meta_publishedDate"><%= book.series_index %></dd>
       <% } %>
+			<% if (book.rating) { %>
+				<dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="rating" checked>Rating:</dt>
+				<dd class="meta_rating"><%= book.rating %> / 5</dd>
+			<% } %>
       <% if (book.description) { %>
         <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="description" checked>Description:</dt>
         <dd class="meta_description"><%= book.description %></dd>


### PR DESCRIPTION
Adds the rating field back to the metadata fetch UI, and allows setting the rating on the book edit screen. Rating is not shown in metadata entries if not fetched from the metadata source.

Should fix #712 for Amazon after #707 is merged, and enable fixing for other metadata providers.