### PR TITLE
fix(amazon): Fix Amazon book search. Again.

### DIFF
--- a/cps/metadata_provider/amazon.py
+++ b/cps/metadata_provider/amazon.py
@@ -112,7 +112,7 @@ class Amazon(Metadata):
                 except (AttributeError, ValueError, TypeError):
                     match.rating = 0
                 try:
-                    asin = soup2.find("input", attrs={"type": "hidden", "name": "asin"})["value"]
+                    asin = soup2.find("input", attrs={"type": "hidden", "name": lambda x: x and x.lower()=="asin"})["value"]
                     match.identifiers = {"amazon": asin, "mobi-asin": asin}
                 except (AttributeError, TypeError):
                     match.identifiers = {}


### PR DESCRIPTION
Once again, fix Amazon metadata search returning HTTP 503. I really hope this isn't going to become a cat-and-mouse game with Amazon.