### PR TITLE
Fix koreader plugin collision bug

### DIFF
--- a/cps/templates/kosync_plugin.html
+++ b/cps/templates/kosync_plugin.html
@@ -159,15 +159,17 @@
 
   <div class="kosync-container">
     <div class="kosync-section">
-      <h3 class="kosync-heading">🔌&nbsp;&nbsp;&nbsp;Enabling the Plugin</h3>
+      <h3 class="kosync-heading">🔌&nbsp;&nbsp;&nbsp;Accessing the Plugin</h3>
 
       <div class="kosync-info" style="margin-top: 3rem; margin-bottom: 3rem;">
-        <strong>Good news!</strong> The CWA Sync plugin should automatically enable after installation and restarting KOReader.
-        However, if it doesn't appear or isn't working, follow these steps:
-        <div class="kosync-warning">
-          <strong>Important:</strong> We recommend disabling the stock "Progress sync" plugin to avoid conflicts.
-          Look for it in the plugin management list and disable it.
-        </div>
+        <strong>Where to find it:</strong> After installation and restarting KOReader, tap the
+        <strong>Navigation menu icon (<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.1" width="48" height="48" viewBox="0 0 48 48" enable-background="new 0 0 24.00 24.00" xml:space="preserve" id="svg4" sodipodi:docname="appbar.page.corner.bookmark.svg" inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)" inkscape:export-xdpi="96" inkscape:export-ydpi="96"><sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1914" inkscape:window-height="968" id="namedview7" showgrid="true" inkscape:zoom="1" inkscape:cx="24" inkscape:cy="24" inkscape:window-x="0" inkscape:window-y="90" inkscape:window-maximized="0" inkscape:current-layer="svg4" inkscape:document-rotation="0"><inkscape:grid type="xygrid" id="grid893" originx="0" originy="0"/></sodipodi:namedview><metadata id="metadata10"><rdf:RDF><cc:Work rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/><dc:title/></cc:Work></rdf:RDF></metadata><defs id="defs8"/>
+
+<rect style="fill:none;stroke:#000000;stroke-width:2;stroke-linejoin:round" id="rect1443" width="26" height="36" x="11" y="6" ry="3.0857143"/><path id="path895" style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 23,6 V 18.333333 L 28,15 33,18.333333 V 6" sodipodi:nodetypes="ccccc"/></svg>)</strong> at the top of the screen to open the
+        <strong>Navigation</strong> menu. Look for <strong>"CWA Progress Sync"</strong> in the menu list.
+        If you have many plugins installed, you may need to scroll down or check the second page of menu items.
+      </div>      <div class="kosync-warning">
+        <strong>Note:</strong> If the plugin doesn't appear after restarting, follow these steps to manually enable it:
       </div>
 
       <table class="kosync-table">

--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -22,8 +22,8 @@ end
 
 local CWASync = WidgetContainer:extend{
     name = "cwasync",
-    is_doc_only = true,
     title = _("Login to CWA Server"),
+    version = "1.0.1",  -- Plugin version
 
     push_timestamp = nil,
     pull_timestamp = nil,
@@ -179,7 +179,7 @@ function CWASync:onReaderReady()
 end
 
 function CWASync:addToMainMenu(menu_items)
-    menu_items.progress_sync = {
+    menu_items.cwa_progress_sync = {
         text = _("CWA Progress Sync"),
         sub_item_table = {
             {
@@ -362,6 +362,15 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                     self:getProgress(true, true)
                 end,
                 separator = true,
+            },
+            {
+                text = T(_("Plugin version: %1"), self.version),
+                keep_menu_open = true,
+                callback = function()
+                    UIManager:show(InfoMessage:new{
+                        text = T(_("CWA Progress Sync Plugin\nVersion: %1\n\nThis plugin syncs your reading progress to Calibre-Web Automated."), self.version),
+                    })
+                end,
             },
         }
     }


### PR DESCRIPTION
This fixes the issue where it conflicted with the default sync process plugin and moves it to the main menu so it's easier to find. 

At some point, someone can figure out how to make it auto-add OPDS, and the location change will make more sense.