### PR TITLE
Prefix /send_selected/ request with correct path

### DIFF
--- a/cps/static/js/email_selection.js
+++ b/cps/static/js/email_selection.js
@@ -115,7 +115,7 @@ $(document).ready(function() {
 
         // Send AJAX request to endpoint
         $.ajax({
-            url: '/send_selected/' + currentBookId,
+            url: getPath() + '/send_selected/' + currentBookId,
             method: 'POST',
             data: {
                 'csrf_token': $('input[name="csrf_token"]').val(),


### PR DESCRIPTION
Send to eReader links didn't work when behind a reverse proxy when it sent an X-Script-Name header.
This fixes it by prefixing with the getPath() function as used elsewhere.