### PR TITLE
[Fix]: Respect `CWA_PORT_OVERRIDE` in svc-calibre-web-automated/run for s6-notifyoncheck

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
@@ -4,5 +4,5 @@
 export CALIBRE_DBPATH=/config
 
 exec \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8083" \
+    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${CWA_PORT_OVERRIDE:-8083}" \
         cd /app/calibre-web-automated s6-setuidgid abc python3 /app/calibre-web-automated/cps.py


### PR DESCRIPTION
This update ensures that `s6-notifyoncheck` correctly uses the port defined by `CWA_PORT_OVERRIDE` when it is set, inside the svc-calibre-web-automated/run service.

Even if an invalid port is provided, it does not seems to introduce any functional issues. But, this remains likely unexpected and this PR align the `s6-notifyoncheck` with the actual port configuration used by Calibre-Web-Automated.