### PR TITLE
Add libasound2t64 to Dockerfile as a runtime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,6 +209,7 @@ RUN \
   nano \
   sqlite3 \
   zip \
+  libasound2t64 \
   libxtst6 \
   libxrandr2 \
   libxkbfile1 \


### PR DESCRIPTION
libasound2t64 appears to be a runtime dependency.  This change should fix the error message below when trying to launch the CWA container.
```
Failed to import PyQt module: PyQt6.QtWebEngineCore with error: libasound.so.2: cannot open shared object file: No such file or directory
```