### PR TITLE
Update German translation for 'Create a Shelf'

### DIFF
--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -1623,7 +1623,7 @@ msgstr ""
 
 #: cps/shelf.py:207 cps/templates/layout.html:270
 msgid "Create a Shelf"
-msgstr "Bücherregal erzeugen"
+msgstr "Bücherregal anlegen"
 
 #: cps/shelf.py:215
 msgid "Sorry you are not allowed to edit this shelf"


### PR DESCRIPTION
The translation "Bücherregal erzeugen" is cut off in the web UI to "Bücherregal erzeug".

The word "erzeugen" has been replaced with "anlegen" (same meaning in this context), to prevent this.