### PR TITLE
Fix auto-send and auto-metadata fetching

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -165,8 +165,8 @@ def create_app():
     lm.anonymous_user = ub.Anonymous
     lm.session_protection = 'strong' if config.config_session == 1 else "basic"
 
-    db.CalibreDB.update_config(config)
-    db.CalibreDB.setup_db(config.config_calibre_dir, cli_param.settings_path)
+    from .calibre_init import init_calibre_db_from_config
+    init_calibre_db_from_config(config, cli_param.settings_path)
     calibre_db.init_db()
 
     updater_thread.init_updater(config, web_server)
@@ -271,5 +271,4 @@ def create_app():
     register_startup_tasks()
 
     return app
-
 

--- a/cps/calibre_init.py
+++ b/cps/calibre_init.py
@@ -1,0 +1,50 @@
+import sqlite3
+
+from cps import db, logger
+
+log = logger.create()
+
+DEFAULT_TITLE_SORT_REGEX = (
+    r'^(A|The|An|Der|Die|Das|Den|Ein|Eine|Einen|Dem|Des|Einem|Eines|Le|La|Les|L\'|Un|Une)\s+'
+)
+
+
+class _MinimalConfig:
+    def __init__(self, title_regex, calibre_dir):
+        self.config_title_regex = title_regex
+        self.config_calibre_dir = calibre_dir
+
+
+def init_calibre_db_from_config(config, settings_path):
+    """Initialize CalibreDB using an already-loaded config object."""
+    if db.CalibreDB.session_factory and getattr(db.CalibreDB.config, "config_title_regex", None):
+        return True
+    db.CalibreDB.update_config(config)
+    db.CalibreDB.setup_db(config.config_calibre_dir, settings_path)
+    return db.CalibreDB.session_factory is not None
+
+
+def init_calibre_db_from_app_db(app_db_path="/config/app.db"):
+    """Initialize CalibreDB by reading config from app.db (for background workers)."""
+    if db.CalibreDB.session_factory and getattr(db.CalibreDB.config, "config_title_regex", None):
+        return True
+    calibre_dir = None
+    title_regex = None
+    try:
+        with sqlite3.connect(app_db_path, timeout=30) as con:
+            cur = con.cursor()
+            row = cur.execute(
+                "SELECT config_calibre_dir, config_title_regex FROM settings LIMIT 1"
+            ).fetchone()
+            if row:
+                calibre_dir, title_regex = row[0], row[1]
+    except Exception as e:
+        log.error(f"Failed to read calibre settings from {app_db_path}: {e}")
+        return False
+    if not calibre_dir:
+        log.error("Calibre library path missing in app.db; cannot initialize CalibreDB")
+        return False
+    title_regex = title_regex or DEFAULT_TITLE_SORT_REGEX
+    db.CalibreDB.update_config(_MinimalConfig(title_regex, calibre_dir))
+    db.CalibreDB.setup_db(calibre_dir, app_db_path)
+    return db.CalibreDB.session_factory is not None

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -185,6 +185,7 @@ class ConfigSQL(object):
     # pylint: disable=no-member
     def __init__(self):
         self.__dict__["dirty"] = list()
+        self.cli = None
 
     def init_config(self, session, secret_key, cli):
         self._session = session
@@ -235,21 +236,25 @@ class ConfigSQL(object):
         return self._settings
 
     def get_config_certfile(self):
-        if self.cli.certfilepath:
-            return self.cli.certfilepath
-        if self.cli.certfilepath == "":
-            return None
+        if self.cli:
+            if self.cli.certfilepath:
+                return self.cli.certfilepath
+            if self.cli.certfilepath == "":
+                return None
         return self.config_certfile
 
     def get_config_keyfile(self):
-        if self.cli.keyfilepath:
-            return self.cli.keyfilepath
-        if self.cli.certfilepath == "":
-            return None
+        if self.cli:
+            if self.cli.keyfilepath:
+                return self.cli.keyfilepath
+            if self.cli.certfilepath == "":
+                return None
         return self.config_keyfile
 
     def get_config_ipaddress(self):
-        return self.cli.ip_address or ""
+        if self.cli:
+            return self.cli.ip_address or ""
+        return ""
 
     def _has_role(self, role_flag):
         return constants.has_flag(self.config_default_role, role_flag)

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -224,7 +224,7 @@ def send_mail(book_id, book_format, convert, ereader_mail, calibrepath, user_id,
     for entry in iter(book.data):
         if entry.format.upper() == book_format.upper():
             converted_file_name = entry.name + '.' + book_format.lower()
-            link = '<a href="{}">{}</a>'.format(url_for('web.show_book', book_id=book_id), escape(book.title))
+            link = '<a href="/book/{}">{}</a>'.format(book_id, escape(book.title))
             email_text = N_("%(book)s send to eReader", book=link)
             for email in ereader_mail.split(','):
                 email = strip_whitespaces(email)

--- a/cps/metadata_provider/ibdb.py
+++ b/cps/metadata_provider/ibdb.py
@@ -25,7 +25,7 @@ class IBDb(Metadata):
     DESCRIPTION = "Internet Book Database"
     META_URL = "https://ibdb.dev/"
     BOOK_URL = "https://ibdb.dev/book/"
-    SEARCH_URL = "https://ibdb.dev/search?q="
+    SEARCH_URL = "https://ibdb.dev/api/search?q="
 
     def search(
         self, query: str, generic_cover: str = "", locale: str = "en"
@@ -40,6 +40,13 @@ class IBDb(Metadata):
             try:
                 results = requests.get(IBDb.SEARCH_URL + query, timeout=15)
                 results.raise_for_status()
+            except requests.HTTPError as e:
+                status_code = getattr(e.response, "status_code", None)
+                if status_code == 501:
+                    log.debug("IBDb search not implemented (501); skipping provider.")
+                    return []
+                log.warning(e)
+                return []
             except Exception as e:
                 log.warning(e)
                 return []

--- a/cps/schedule.py
+++ b/cps/schedule.py
@@ -97,6 +97,7 @@ def register_startup_tasks():
             from datetime import datetime, timezone
 
             db = CWA_DB()
+            delay_minutes = int(db.cwa_settings.get('auto_send_delay_minutes', 0) or 0)
             pending = db.scheduled_get_pending_autosend()
             for row in pending:
                 try:
@@ -117,7 +118,7 @@ def register_startup_tasks():
                         except Exception:
                             pass
                         if should_enqueue and bid is not None and uid is not None:
-                            WorkerThread.add(u, TaskAutoSend(f"Auto-sending '{t}' to user's eReader(s)", bid, uid, config.auto_send_delay_minutes), hidden=False)
+                            WorkerThread.add(u, TaskAutoSend(f"Auto-sending '{t}' to user's eReader(s)", bid, uid, delay_minutes), hidden=False)
 
                     job = scheduler.schedule(func=_rehydrate_enqueue, trigger=DateTrigger(run_date=run_at_local), name=f"rehydrated auto-send {schedule_id}")
                     try:
@@ -197,4 +198,3 @@ def should_task_be_running(start, duration):
 def calclulate_end_time(start, duration):
     start_time = datetime.datetime.now().replace(hour=start, minute=0)
     return start_time + datetime.timedelta(hours=duration // 60, minutes=duration % 60)
-

--- a/cps/static/js/table.js
+++ b/cps/static/js/table.js
@@ -44,6 +44,22 @@ $(function() {
             });
         }, 1000);
     }
+    if ($('#upcomingtable').length) {
+        $('#upcomingtable').bootstrapTable({
+            formatNoMatches: function () {
+                return '';
+            },
+            striped: true
+        });
+    }
+    if ($('#upcomingopstable').length) {
+        $('#upcomingopstable').bootstrapTable({
+            formatNoMatches: function () {
+                return '';
+            },
+            striped: true
+        });
+    }
 
     $(document).on('click', '#select_all', function() {
         $('#books-table').bootstrapTable('checkAll');

--- a/cps/tasks/auto_send.py
+++ b/cps/tasks/auto_send.py
@@ -93,7 +93,9 @@ class TaskAutoSend(CalibreTask):
             self._handleError(f"Auto-send task failed: {str(e)}")
         finally:
             if 'calibre_db_instance' in locals():
-                calibre_db_instance.session.close()
+                session = getattr(calibre_db_instance, "session", None)
+                if session:
+                    session.close()
 
     @property
     def name(self):


### PR DESCRIPTION
# PR Details

## Summary
Centralize CalibreDB initialization for background workers, tighten ingest/auto-send behavior, and improve metadata/search handling while keeping the runtime flow consistent with existing patterns.

## Key Changes
- Added shared CalibreDB init helpers for web and background contexts (`cps/calibre_init.py`) and wired them into app startup and ingest workers.
- Simplified auto-send task flow now that email generation no longer relies on Flask request context.
- Improved ingest robustness: parse added book IDs across “Added/Merged/Updated” output, fallback to latest modified book ID, register `title_sort` for overwrite timestamp updates, and add internal request headers for localhost-only endpoints.
- Metadata updates: fixed model constructor usage, ensured provider enablement parsing without heavy imports, and improved error logging detail.
- IBDb provider now uses the documented `/api/search` endpoint and gracefully skips 501 responses.
- UI: initialize upcoming task tables with consistent bootstrap-table config.
- Config: tolerate missing CLI config values for cert/key/ipaddress accessors.

## Files Touched
- `cps/calibre_init.py`
- `cps/__init__.py`
- `cps/config_sql.py`
- `cps/db.py`
- `cps/helper.py`
- `cps/metadata_helper.py`
- `cps/metadata_provider/ibdb.py`
- `cps/schedule.py`
- `cps/static/js/table.js`
- `cps/tasks/auto_send.py`
- `scripts/ingest_processor.py`

## Testing
- Manual ingest: `cp ~/Test.epub /opt/cwa/ingest`, waited 70s, verified docker logs show successful ingest, metadata fetch, and auto-send scheduling/execution, no warnings/errors.
- App log checked: no errors.
