### PR TITLE
Update German translation for shelf creation message

### DIFF
--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -1623,7 +1623,7 @@ msgstr ""
 
 #: cps/shelf.py:207 cps/templates/layout.html:270
 msgid "Create a Shelf"
-msgstr "Anlage Bücherregal"
+msgstr "Neues Bücherregal"
 
 #: cps/shelf.py:215
 msgid "Sorry you are not allowed to edit this shelf"


### PR DESCRIPTION
Correcting last pull request #861

I did a mistake in this pull request, because "Bücherregal anlegen" is also cut-off.

To preserve the character count and maintain the meaning of the words, here is a translation that approximates the meaning without cutting anything off.

Once again, I apologize for the mistake.