### PR TITLE
Fix two settings not being saved

### DIFF
--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -660,7 +660,6 @@ def set_cwa_settings():
                 elif setting == "auto_convert_target_format":
                     if value is None:
                         value = cwa_db.cwa_settings['auto_convert_target_format']
-                    value = cwa_db.cwa_settings['auto_convert_target_format']
 
                 result |= {setting:value}
             
@@ -798,7 +797,7 @@ def set_cwa_settings():
     return render_title_template("cwa_settings.html", title=_("Calibre-Web Automated User Settings"), page="cwa-settings",
                                     cwa_settings=cwa_settings, ignorable_formats=ignorable_formats, target_formats=target_formats,
                                     automerge_options=automerge_options, autoingest_options=autoingest_options,
-                                    next_duplicate_scan_run=next_scan_run)
+                                    next_duplicate_scan_run=next_scan_run, config=config)
 
 
 def get_next_duplicate_scan_run(settings):

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -385,7 +385,7 @@
         {{_('When disabled, you will no longer receive notifications in the Web UI when using a language other than English if the translations for your chosen language are not complete.')}}
       </p>
 
-      {% if config.config_kobo_sync_magic_shelves %}
+      {% if config['config_kobo_sync_magic_shelves'] %}
       <input type="checkbox" id="config_kobo_sync_magic_shelves" name="config_kobo_sync_magic_shelves" value="True" checked style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Requires Kobo Sync to be enabled in Basic Configuration">
       {% else %}
       <input type="checkbox" id="config_kobo_sync_magic_shelves" name="config_kobo_sync_magic_shelves" value="True" style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Requires Kobo Sync to be enabled in Basic Configuration">


### PR DESCRIPTION
Target format and sync magic shelves to kobo settings were not being saved due to bugs.
Closes #880
Closes #704 