### PR TITLE
Full Text Search

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -315,7 +315,7 @@ Copyright (C) 2024-2026 Calibre-Web Automated contributors
 - zhiyue (1 commits)
 # Fork Contributors (crocodilestick/calibre-web-automated)
 
-- crocodilestick (989 commits)
+- crocodilestick (991 commits)
 - jmarmstrong1207 (73 commits)
 - demitrix (30 commits)
 - sirwolfgang (29 commits)

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -28,6 +28,9 @@
         {% endif %}
       {% endif %}
       <div class="filterheader hidden-xs"><!-- ToDo: Implement filter for search results -->
+        {% if page == 'search' %}
+          <a id="relevance" data-toggle="tooltip" title="{{_('Sort by relevance')}}" class="btn btn-primary{% if order == "stored" %} active{% endif%}" href="{{url_for('web.books_list', data=page, sort_param='stored', query=query)}}"><span class="glyphicon glyphicon-search"></span></a>
+        {% endif %}
         <a id="new" data-toggle="tooltip" title="{{_('Sort according to book date, newest first')}}" class="btn btn-primary{% if order == "new" %} active{% endif%}" href="{{url_for('web.books_list', data=page, sort_param='new', query=query)}}"><span class="glyphicon glyphicon-sort-by-order"></span></a>
         <a id="old" data-toggle="tooltip" title="{{_('Sort according to book date, oldest first')}}" class="btn btn-primary{% if order == "old" %} active{% endif%}" href="{{url_for('web.books_list', data=page, sort_param='old', query=query)}}"><span class="glyphicon glyphicon-sort-by-order-alt"></span></a>
         <a id="asc" data-toggle="tooltip" title="{{_('Sort title in alphabetical order')}}" class="btn btn-primary{% if order == "abc" %} active{% endif%}" href="{{url_for('web.books_list', data=page, sort_param='abc', query=query)}}"><span class="glyphicon glyphicon-font"></span><span class="glyphicon glyphicon-sort-by-alphabet"></span></a>


### PR DESCRIPTION
I had to pull the FTS changes from the upcoming release. The latest version still has a few blocking issues that would ship broken behaviour:

- The FTS SQL orders by rank but never selects a rank field, so the query errors and FTS silently falls back. That means relevance never actually works.
- The FTS query dropped common_filters(True), which can expose books that users shouldn’t see (archived/restricted).
- The merge logic combines already‑paginated base results with full FTS results, then paginates again. That makes counts and paging wrong.

Because of those, I reverted it from main and kept it on a separate full-text-search branch/PR so it can be finished safely.

What still needs fixing & tested before it’s ready:

- Restore a valid FTS ranking query (or select a rank column) so relevance sorting actually works.
- Re‑apply common_filters(True) to keep permissions/visibility correct.
- Fix pagination/counts by paginating after merging full result sets, or fetch unpaginated base results when merging.
- Verify extension loading is correct on Python/SQLite (enable load extension before load_extension).