### PR TITLE
Fix overly-permissive empty `src` `<img>` regex

### DIFF
--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -753,7 +753,7 @@ class EPUBFixer:
                         self.files[filename] = dom.toxml()
                 else:
                     no_src_pattern = re.compile(r'<img\b(?![^>]*\bsrc\s*=)[^>]*>', re.IGNORECASE)
-                    empty_src_pattern = re.compile(r'<img\b[^>]*\bsrc\s*=\s*["\']?\s*["\'][^>]*>', re.IGNORECASE)
+                    empty_src_pattern = re.compile(r'<img\b[^>]*\bsrc\s*=\s*(?:"\s*"|\'\s*\')[^>]*>', re.IGNORECASE)
 
                     updated = empty_src_pattern.sub('', content)
                     updated = no_src_pattern.sub('', updated)


### PR DESCRIPTION
## Fix overly-permissive empty `src` `<img>` regex

### Summary
This PR fixes an issue where valid `<img>` tags were being removed from EPUB XHTML files due to an overly permissive regular expression used to detect empty `src` attributes.

The previous regex allowed the opening quote of a valid `src` value to be treated as optional, which caused tags like:

```html
<img alt="" class="fit" src="../Images/p001.jpg"/>
````

to be incorrectly classified as “empty” and removed.

### What changed

Replaced the empty-`src` detection regex with a stricter pattern that:

* requires a matching quote pair
* only matches truly empty or whitespace-only `src` values
* does not affect valid relative paths

### Before

```
empty_src_pattern = re.compile(r'<img\b[^>]*\bsrc\s*=\s*["\']?\s*["\'][^>]*>', re.IGNORECASE)
```

### After

```
empty_src_pattern = re.compile(r'<img\b[^>]*\bsrc\s*=\s*(?:"\s*"|\'\s*\')[^>]*>', re.IGNORECASE)
```

### Impact

* Prevents valid images from being stripped during EPUB processing
* Fixes image-only pages (common in manga/light novels)
* No behavior change for truly empty `src` attributes

### Related issue

Closes #1028