### PR TITLE
Support secrets in files via env variables

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -18,6 +18,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from . import logger
 from . import constants
+from . import helper
 from .cli import CliParameter
 from .reverseproxy import ReverseProxied
 from .server import WebServer
@@ -197,7 +198,7 @@ def create_app():
     log.info('Starting Calibre Web...')
     Principal(app)
     lm.init_app(app)
-    app.secret_key = os.getenv('SECRET_KEY', config_sql.get_flask_session_key(ub.session))
+    app.secret_key = helper.get_secret('SECRET_KEY', config_sql.get_flask_session_key(ub.session))
 
     web_server.init_app(app, config)
     from .cw_babel import babel, get_locale

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -215,8 +215,8 @@ def trigger_hardcover_auto_fetch():
         # Check if token is available
         from os import getenv
         token_available = bool(
-            getattr(config, "config_hardcover_token", None) or 
-            getenv("HARDCOVER_TOKEN")
+            getattr(config, "config_hardcover_token", None) or
+            helper.get_secret("HARDCOVER_TOKEN")
         )
         
         if not token_available:

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -872,10 +872,9 @@ def set_cwa_settings():
         cwa_settings = cwa_db.get_cwa_settings()
 
     # Check if Hardcover token is available
-    from os import getenv
     hardcover_token_available = bool(
-        getattr(config, "config_hardcover_token", None) or 
-        getenv("HARDCOVER_TOKEN")
+        getattr(config, "config_hardcover_token", None) or
+        helper.get_secret("HARDCOVER_TOKEN")
     )
 
 

--- a/cps/metadata_provider/hardcover.py
+++ b/cps/metadata_provider/hardcover.py
@@ -13,8 +13,8 @@
 from typing import Dict, List, Optional, Union
 
 import requests
-from os import getenv
 
+from cps import helper
 # Import text similarity utilities
 try:
     from cps.utils.text_similarity import (
@@ -157,7 +157,7 @@ class Hardcover(Metadata):
         token = (
             getattr(current_user, "hardcover_token", None)
             or getattr(config, "config_hardcover_token", None)
-            or getenv("HARDCOVER_TOKEN")
+            or helper.get_secret("HARDCOVER_TOKEN")
         )
         if not token:
             log.warning("Hardcover token missing; set a user token or global token to enable results.")
@@ -524,7 +524,7 @@ if __name__ == "__main__":
     parser.add_argument("--cover", dest="generic_cover", default="", help="Generic cover URL fallback")
     args = parser.parse_args()
 
-    token = args.token or getenv("HARDCOVER_TOKEN")
+    token = args.token or helper.get_secret("HARDCOVER_TOKEN")
     if token:
         try:
             setattr(config, "config_hardcover_token", token)

--- a/cps/schedule.py
+++ b/cps/schedule.py
@@ -7,7 +7,7 @@
 
 import datetime
 
-from . import config, constants
+from . import config, constants, helper
 from .services.background_scheduler import BackgroundScheduler, CronTrigger, IntervalTrigger, use_APScheduler, DateTrigger
 from .tasks.database import TaskReconnectDatabase, TaskCleanArchivedBooks
 from .tasks.clean import TaskClean
@@ -243,7 +243,6 @@ def _schedule_hardcover_auto_fetch(scheduler, timezone_info):
             _sys.path.insert(1, '/app/calibre-web-automated/scripts/')
         from cwa_db import CWA_DB
         from .tasks.auto_hardcover_id import TaskAutoHardcoverID
-        from os import getenv
 
         db = CWA_DB()
         cwa_settings = db.get_cwa_settings()
@@ -251,8 +250,8 @@ def _schedule_hardcover_auto_fetch(scheduler, timezone_info):
         # Check if enabled and token available
         enabled = bool(cwa_settings.get('hardcover_auto_fetch_enabled', False))
         token_available = bool(
-            getattr(config, "config_hardcover_token", None) or 
-            getenv("HARDCOVER_TOKEN")
+            getattr(config, "config_hardcover_token", None) or
+            helper.get_secret("HARDCOVER_TOKEN")
         )
         
         if not enabled or not token_available:

--- a/cps/tasks/auto_hardcover_id.py
+++ b/cps/tasks/auto_hardcover_id.py
@@ -8,10 +8,9 @@
 import json
 import time
 from datetime import datetime
-from os import getenv
 from typing import List, Optional
 
-from cps import config, db, logger, ub
+from cps import config, db, logger, ub, helper
 from cps.services.worker import CalibreTask, STAT_FAIL, STAT_FINISH_SUCCESS, STAT_CANCELLED, STAT_ENDED
 from flask_babel import lazy_gettext as N_
 from sqlalchemy import not_
@@ -178,7 +177,7 @@ class TaskAutoHardcoverID(CalibreTask):
         """Get Hardcover token from environment or config"""
         token = (
             getattr(config, "config_hardcover_token", None)
-            or getenv("HARDCOVER_TOKEN")
+            or helper.get_secret("HARDCOVER_TOKEN")
         )
         return token
 


### PR DESCRIPTION
Closes #783 

Adds support for providing secrets (API tokens, passwords etc.) using the standard Docker compose notation where secret $PASSWORD can be also read from a file specified in $PASSWORD_FILE.

See https://docs.docker.com/engine/swarm/secrets/#use-secrets-in-compose

I have added a helper function get_secret() that replaces getenv() in places where it makes sense to handle a secret:

- HARDCOVER_TOKEN
- SECRET_KEY

Instances where I didn't replace it because I am not sure of the function/it seems to be internal use:

- GITHUB_TOKEN
- GOOGLE_SITE_VERIFICATION
