### PR TITLE
fix(epub-progress): use kosync progress in restore progress for browser reader

### DIFF
--- a/cps/static/js/reading/epub-progress.js
+++ b/cps/static/js/reading/epub-progress.js
@@ -3,12 +3,13 @@
  * @param callback
  */
 function qFinished(callback){
-    let timeout=setInterval(()=>{
+    clearProgress();
+    let bookLoadingInterval=setInterval(()=>{
         if (reader && reader.rendition && reader.rendition.q && reader.rendition.q.running === undefined) {
-            clearInterval(timeout);
+            clearInterval(bookLoadingInterval);
             callback();
         }
-        },300
+    },300
     )
 }
 
@@ -17,10 +18,36 @@ function calculateProgress(){
         return 0;
     }
     let data=reader.rendition.location.end;
+    console.log("last location on page: " + data.cfi);
+    console.log("epub.locations.length(): " + epub.locations.length());
     if (!data || !data.cfi || !epub || !epub.locations) {
         return 0;
     }
-    return Math.round(epub.locations.percentageFromCfi(data.cfi)*100);
+    let percentageFromCfi = epub.locations.percentageFromCfi(data.cfi);
+    // console.log("percentageFromCfi: " + percentageFromCfi);
+    let progress = Math.round(epub.locations.percentageFromCfi(data.cfi) * 100);
+    // console.log("progress: " + progress);
+    return progress;
+}
+
+function clearProgress() {
+    if (progressDiv) {
+        progressDiv.textContent="";
+    }
+}
+
+function updateCurrentPosition() {
+    let newPos = calculateProgress();
+    if (progressDiv) {
+        progressDiv.textContent = newPos ? newPos+"%" : "";
+    }
+    // Save progress to localStorage per book
+    if (window.calibre && window.calibre.bookUrl && newPos && newPos > 0) {
+        // Use bookUrl as a unique key, or use bookid if available
+        console.log("Storing progress: " + newPos);
+        let bookKey = window.calibre.bookUrl;
+        localStorage.setItem("calibre.reader.progress." + bookKey, newPos);
+    }
 }
 
 // register new event emitter locationchange that fires on urlchange
@@ -46,42 +73,93 @@ function calculateProgress(){
 })();
 
 window.addEventListener('locationchange',()=>{
-    let newPos=calculateProgress();
-    if (progressDiv) {
-        progressDiv.textContent=newPos+"%";
+    // If location changes, abort attempt to restore progress.
+    clearInterval(restoreProgressInterval);
+    if (!epub.locations.isReady) {
+        clearProgress();
+        return;
     }
-    // Save progress to localStorage per book
-    if (window.calibre && window.calibre.bookUrl) {
-        // Use bookUrl as a unique key, or use bookid if available
-        let bookKey = window.calibre.bookUrl;
-        localStorage.setItem("calibre.reader.progress." + bookKey, newPos);
-    }
+    updateCurrentPosition();
 });
 
 var epub=ePub(calibre.bookUrl)
 
 let progressDiv=document.getElementById("progress");
 
+function restoreProgressWithLocations(locations) {
+    // Restore progress: from localStorage if available, using kosync progress
+    // as a fallback, with bookmark as last resort.
+    if (window.calibre && window.calibre.bookUrl && reader && reader.rendition) {
+        let bookKey = window.calibre.bookUrl;
+        let savedProgress = parseInt(localStorage.getItem("calibre.reader.progress." + bookKey))
+        let kosyncProgress = parseFloat(window.calibre.kosyncPercent);
+        console.log("savedProgress: " + savedProgress);
+        console.log("kosyncProgress: " + kosyncProgress);
+        let progress = savedProgress || kosyncProgress
+        console.log("About to advance to progress: " + progress);
+        let percentage = progress && (parseInt(progress, 10) / 100);
+        console.log("Progress percentage is: " + percentage);
+        let percentageCfi = locations.cfiFromPercentage(percentage);
+        console.log("percentageCfi: " + percentageCfi);
+        console.log("bookmark: " + window.calibre.bookmark);
+        let cfi = (percentageCfi !== -1 && percentageCfi) || window.calibre.bookmark;
+        console.log("Advancing to cfi: " + cfi);
+        if (cfi && cfi.length > 0) {
+            reader.rendition.display(cfi);
+            console.log("Advanced to cfi: " + cfi);
+        }
+        window.dispatchEvent(new Event('locationchange'))
+    }
+}
+
+// Track attempt to restore progress
+let restoreProgressInterval = null;
+
 qFinished(()=>{
     if (!epub || !epub.locations) {
         return;
     }
-    epub.locations.generate().then(()=> {
-        // Restore progress from localStorage if available, using kosync
-        // progress as a fallback.
-        if (window.calibre && window.calibre.bookUrl && reader && reader.rendition) {
-            let bookKey = window.calibre.bookUrl;
-            let savedProgress = parseInt(localStorage.getItem("calibre.reader.progress." + bookKey))
-            let kosyncProgress = parseFloat(window.calibre.kosyncPercent);
-            let progress = savedProgress || kosyncProgress
-            let percentage = progress && (parseInt(progress, 10) / 100);
-            let percentageCfi = epub.locations.cfiFromPercentage(percentage);
-            // Default to bookmark if progress cannot be otherwise determined.
-            let cfi = (percentageCfi !== -1 && percentageCfi) || window.calibre.bookmark;
-            if (cfi && cfi.length > 0) {
-                reader.rendition.display(cfi);
-                window.dispatchEvent(new Event('locationchange'))
-            }
-        }
-    });
+    if (epub.locations.length() == 0) {
+        epub.locations.generate().then(()=> {
+            console.log("Locations generated promise resolved.");
+            // The `epub.locations.generate()` promise resolves before the locations
+            // have completed being added, so we must poll until they are all
+            // there.
+            let attempt = 0;
+            let pollingFrequency = 100;
+            let retryAfter = 10;
+            let subsequentRetryAfter = 50;
+            epub.locations.isReady = false;
+            restoreProgressInterval=setInterval(()=> {
+                attempt = attempt + 1;
+                if (progressDiv) {
+                    progressDiv.textContent="Restoring Position [" + (attempt % 2 == 0 ? "/" : "\\") + "]"
+                }
+                let count = epub.locations.length();
+                let total = epub.locations.total;
+                console.log("count and total: " + count + " (" + total + ")");
+                // Handle off-by-one issue with total
+                let isReady = count > 0 && (count - total == 1);
+                if (isReady) {
+                    console.log("Locations now available...")
+                    epub.locations.isReady = true;
+                    clearInterval(restoreProgressInterval);
+                    restoreProgressWithLocations(epub.locations);
+                } else {
+                    // Under some conditions, `epub.locations.generate()` appears
+                    // not to start adding locations at all, so try it again if
+                    // we have not seen any progress after a few attempts.
+                    if (count == 0 && (attempt % retryAfter) == 0) {
+                        console.log("Locations not available and still empty, regenerating...")
+                        // Don't want to unnecessarily attempt to re-generate too often.
+                        retryAfter = subsequentRetryAfter;
+                        epub.locations.generate();
+                    }
+                }
+            }, pollingFrequency);
+        });
+    } else {
+        console.log("Locations already generated");
+        restoreProgressWithLocations(epub.locations);
+    }
 })

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -62,7 +62,7 @@
 	        <div id="title-controls">
 	            <a id="bookmark" class="icon-bookmark-empty">Bookmark</a>
 	            <a id="setting" class="icon-cog">Settings</a>
-	            <a id="fullscreen" class="icon-resize-full">Fullscreen</a>            
+	            <a id="fullscreen" class="icon-resize-full">Fullscreen</a>
 	        </div>
 	    </div>
 
@@ -99,11 +99,11 @@
                 <div class="slider">
                     <label for="fader">{{ _('Font Sizes') }}</label>
                     <input type="range" min="75" max="200" value="100" id="fontSizeFader" step="25">
-                </div>            
+                </div>
             </div>
               <div class="font" id="font">
                 <label class="item">{{_('Font')}}:</label>
-                <button type="button" id="default" onclick="selectFont(this.id)"><span>✓</span>{{_('Default')}}</button> 
+                <button type="button" id="default" onclick="selectFont(this.id)"><span>✓</span>{{_('Default')}}</button>
                 <button type="button" id="Yahei" onclick="selectFont(this.id)"><span></span>{{_('Yahei')}}</button>
                 <button type="button" id="SimSun" onclick="selectFont(this.id)"><span></span>{{_('SimSun')}}</button>
                 <button type="button" id="KaiTi" onclick="selectFont(this.id)"><span></span>{{_('KaiTi')}}</button>
@@ -113,7 +113,7 @@
                 <label class="item">{{ _('Spread') }}:</label>
                 <button type="button" id="spread" onclick="spread(this.id)"><span>✓</span>{{_('Two columns')}}</button>
                 <button type="button" id="nonespread" onclick="spread(this.id)"><span></span>{{_('One column')}}</button>
-              </div>            
+              </div>
             <div class="closer icon-cancel-circled"></div>
         </div>
     </div>
@@ -168,7 +168,7 @@
             localStorage.setItem("calibre.reader.theme", id);
             // Apply theme to epubjs iframe
             reader.rendition.themes.select(id);
-            // Apply theme to rest of the page. 
+            // Apply theme to rest of the page.
             document.getElementById("main").style.backgroundColor = themes[id]["bgColor"];
             document.getElementById("titlebar").style.color = themes[id]["title-color"] || "#fff";
           }
@@ -236,6 +236,6 @@
       <script src="{{ url_for('static', filename='js/libs/screenfull.min.js') }}"></script>
       <script src="{{ url_for('static', filename='js/libs/reader.min.js') }}"></script>
       <script src="{{ url_for('static', filename='js/reading/epub.js') }}"></script>
-      <script src="{{ url_for('static', filename='js/reading/epub-progress.js') }}"></script>      
+      <script src="{{ url_for('static', filename='js/reading/epub-progress.js') }}"></script>
     </body>
 </html>

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -130,7 +130,7 @@
             bookUrl: "{{ url_for('web.serve_book', book_id=bookid, book_format='epub', anyname='file.epub') }}",
             bookmark: "{{ bookmark.bookmark_key if bookmark != None }}",
             useBookmarks: "{{ current_user.is_authenticated | tojson }}",
-            kosyncPercent: {{ kosync_progress | tojson if kosync_progress is not none else 'null' }}
+            kosyncPercent: "{{ kosync_progress | tojson if kosync_progress is not none else 'null' }}"
         };
 
         window.themes = {


### PR DESCRIPTION
920d3df2c81fb0035002dbc347659e8f2e0545e4 has the simplest, most essential fix of quoting the value for `kosyncPercentage` in `read.html` so that it gets passed along. Also simplifies the progress restoration code and adds some additional safety with respect to incomplete `epub.locations`.

20f7c7dc0a9100e6e76ee672267ae57c4e36cb34 makes a more robust attempt to address the missing `epub.locations` issue with a polling interval.

n.b. `console.log` logging left in for now to help with visibility when evaluating this solution.