### PR TITLE
Fix race condition in Duplicate Manager causing UI freeze/crash

### DIFF
--- a/cps/static/js/duplicates.js
+++ b/cps/static/js/duplicates.js
@@ -308,8 +308,11 @@ $(document).ready(function() {
     
     // Success modal OK button handler
     $('#success_modal_ok').click(function() {
-        // Reload the page to refresh the duplicate list
-        window.location.reload();
+        // Add small delay before reload to allow background cleanup to complete
+        // This prevents race conditions with duplicate cache invalidation
+        setTimeout(function() {
+            window.location.reload();
+        }, 800);
     });
     
     // Dismiss/Undismiss duplicate group handlers


### PR DESCRIPTION
The Duplicate Manager experiences race conditions when deleting or merging multiple books, leading to UI freezes and application crashes.

Cause:
- Multiple rapid database commits and cache invalidations per book
- Immediate page reload before background operations completed

Fix:
- Batch cache invalidation to run once after all operations complete
- Add skip_cache_invalidation parameter to delete_book_from_table()
- Add 800ms delay before page reload to allow cleanup to finish
- Remove queued duplicate scan calls (page reload handles refresh)

This eliminates database contention and prevents session conflicts during batch operations in the Duplicate Manager.

Fixes: #1084 