### PR TITLE
fix(metadata-search): address safari metadata search failure #1055

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -238,7 +238,10 @@ $(function () {
       $.ajax({
         url: getPath() + "/metadata/search",
         type: "POST",
-        data: { query: keyword },
+        data: {
+          query: keyword,
+          'csrf_token': $('input[name="csrf_token"]').val()
+        },
         dataType: "json",
         success: function success(data) {
           if (data.length) {


### PR DESCRIPTION
Include CSRF token in `POST` to `/metadata/search`, without which a metadata search in Safari will immediately fail.