### PR TITLE
fix(user-edit): fix form submission for safari #1078

### DIFF
--- a/cps/static/js/uploadprogress.js
+++ b/cps/static/js/uploadprogress.js
@@ -17,7 +17,9 @@
     var isSafari = /safari/i.test(ua) && !/chrome|chromium|crios|android/i.test(ua);
 
     if (!$.support.xhrFileUpload || !$.support.xhrFormData || isSafari) {
-        // skip decorating form
+        // Skip decorating form in Safari, but provide a no-op uploadprogress
+        // function so we do not break the jQuery bindings that make use of it.
+        $.fn.uploadprogress = function(){};
         return;
     }
 

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -550,12 +550,12 @@
     
     <!-- Action Buttons -->
     <div style="margin-bottom: 4rem; display: flex; flex-direction: column; gap: 0.5rem;">
-      <div id="user_submit" class="btn btn-default" style="width: -webkit-fill-available;">{{_('Save')}}</div>
+      <button id="user_submit" class="btn btn-default" type="button" style="width: -webkit-fill-available;">{{_('Save')}}</button>
       {% if not profile %}
-        <div class="btn btn-default" data-back="{{ url_for('admin.admin') }}" id="back" style="width: -webkit-fill-available;">{{_('Cancel')}}</div>
+      <button id="back" class="btn btn-default" type="button" data-back="{{ url_for('admin.admin') }}" style="width: -webkit-fill-available;">{{_('Cancel')}}</button>
       {% endif %}
       {% if current_user and current_user.role_admin() and not profile and not new_user and not content.role_anonymous() %}
-        <div class="btn btn-danger" id="btndeluser" data-value="{{ content.id }}" data-remote="false" style="width: -webkit-fill-available;">{{_('Delete User')}}</div>
+      <button id="btndeluser" class="btn btn-danger" type="button" data-value="{{ content.id }}" data-remote="false" style="width: -webkit-fill-available;">{{_('Delete User')}}</button>
       {% endif %}
     </div>
   </form>


### PR DESCRIPTION
Safari does not appear to propagate `click()` for `<div>` elements, so change these to proper `<button>` elements.

Our button behavior is implemented by jQuery functions, so we set `type="button"` on `<button>` elements so that we do not default to the "submit" behavior (c.f. https://www.w3.org/TR/2011/WD-html5-20110525/the-button-element.html#the-button-element). Without this property, that default submit behavior interferes with our `$("#back").click()` jQuery behavior and results in form submission when the cancel button is clicked (even if it does subsequently redirect to the admin page). Presumably we want to remove the possibility of interference for `#user_submit` and `#btndeluser` behavior as well, even though such interference was not observed during testing (and also for consistency).

Edit: Now also addresses an issue in `uploadprogress.js` that was preventing the handlers for our buttons from getting set in `main.js`.

`$("#form-upload").uploadprogress(...)` and `$("#form-upload-format").uploadprogress(...)` rely on the `uploadprogress` function being defined. If that function is not available, the error from attempting to use it prevents subsequent commands in `main.js` from executing,
resulting multiple breakages in Safari.

To fix this, we add a no-op definition of `uploadprogress()` in the Safari exemption clause in `uploadprogress.js` to satisfy the requirement.