### PR TITLE
noop: Add HTML fixture files for upcoming Amazon metadata provider tests

### DIFF
--- a/tests/fixtures/html/amazon_all_fields.html
+++ b/tests/fixtures/html/amazon_all_fields.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Book Detail Page</title>
+  </head>
+  <body>
+    <div id="dp-container">
+      <span id="wrapper">
+        <div class="blank">
+          <span id="productTitle"> An Elemental Title </span>
+          <span class="author">Gaia Earth</span>
+          <div id="text-description" data-feature-name="bookDescription">
+            <div class="red-herring">Whoops</div>
+            <div class="a-expander-content">
+              <span> In a world with elements, there are elements! </span>
+            </div>
+          </div>
+          <div data-feature-name="seriesBulletWidget">
+            <span>
+              <span>
+                <a>Book 3 of 932: True Sol Planets</a>
+              </span>
+            </span>
+          </div>
+          <div id="rpi">
+            <div id="rpi-attribute-book_details-publication_date">
+              <span>Publication date:</span>
+              <div class="rpi-attribute-value">
+                <span> January 2, 1970 </span>
+              </div>
+            </div>
+          </div>
+          <div id="detailBullets_feature_div">
+            <ul>
+              <li>
+                <span class="a-list-item">
+                  <span class="a-text-bold">Publisher:</span>
+                  <span>Sol Publishing Co</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <span id="acrPopover" title="4.5 out of 5 stars">
+          <i class="a-icon a-icon-star a-star-4-5"></i>
+          <span class="a-icon-alt">4.5 out of 5 stars</span>
+        </span>
+        <span class="after-note">Hello, World!</span>
+      </span>
+      <form>
+        <input type="hidden" id="id" name="id" value="123" />
+        <input type="hidden" id="asin" name="AsiN" value="B0DL524V1M" />
+      </form>
+    </div>
+    <script type="text/javascript">
+      var data = {
+        lowRes: "nah",
+        hiRes: "https://m.media-amazon.com/images/I/914f54v5PuL._SL1500_.jpg",
+      };
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_ca_all_fields.html
+++ b/tests/fixtures/html/amazon_ca_all_fields.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Book Detail Page</title>
+  </head>
+  <body>
+    <div id="dp-container">
+      <span id="wrapper">
+        <div class="blank">
+          <span id="productTitle"> An Elemental Title </span>
+          <span class="author">Gaia Earth</span>
+          <div id="text-description" data-feature-name="bookDescription">
+            <div class="red-herring">Whoops</div>
+            <div class="a-expander-content">
+              <span> In a world with elements, there are elements! </span>
+            </div>
+          </div>
+          <div data-feature-name="seriesBulletWidget">
+            <span>
+              <span>
+                <a>Book 3 of 932: True Sol Planets</a>
+              </span>
+            </span>
+          </div>
+          <div id="rpi">
+            <div id="rpi-attribute-book_details-publication_date">
+              <span>Publication date:</span>
+              <div class="rpi-attribute-value">
+                <span> January 2, 1970 </span>
+              </div>
+            </div>
+          </div>
+          <div id="detailBullets_feature_div">
+            <ul>
+              <li>
+                <span class="a-list-item">
+                  <span class="a-text-bold">Publisher:</span>
+                  <span>Sol Publishing Co</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <span id="acrPopover" title="4.5 out of 5 stars">
+          <i class="a-icon a-icon-star a-star-4-5"></i>
+          <span class="a-icon-alt">4.5 out of 5 stars</span>
+        </span>
+        <span class="after-note">Hello, World!</span>
+      </span>
+      <form>
+        <input type="hidden" id="id" name="id" value="123" />
+        <input type="hidden" id="asin" name="AsiN" value="B0DL524V1M" />
+      </form>
+    </div>
+    <script type="text/javascript">
+      var data = {
+        lowRes: "nah",
+        hiRes: "https://m.media-amazon.com/images/I/914f54v5PuL._SL1500_.jpg",
+      };
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_ca_search_results.html
+++ b/tests/fixtures/html/amazon_ca_search_results.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Search Results</title>
+  </head>
+  <body>
+    <div class="search-results-container">
+      <span class="search-result-item">
+        <span data-component-type="s-search-results">
+          <ul>
+            <li>
+              <a href="/ssdp/ABCDEF?digital-text=1">SSDP Product</a>
+            </li>
+            <li>
+              <a href="/dp/ABCDEF">ABCDEF but not digital</a>
+            </li>
+          </ul>
+        </span>
+        <span data-component-type="s-search-results">
+          <a href="/dp/ABCDEF?fake=no&digital-text=yes">ABCDEF but digital</a>
+          <a href="/dp/GHIJKL?digital-text=1">GHIJKL digital</a>
+        </span>
+        <span data-component-type="s-search-results">
+          <span>
+            <a href="/dp/ABCDEF?digital-text=0&duplicate=yes"
+              >Duplicate ABCDEF</a
+            >
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_jp_all_fields.html
+++ b/tests/fixtures/html/amazon_jp_all_fields.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Book Detail Page</title>
+  </head>
+  <body>
+    <div id="dp-container">
+      <span id="wrapper">
+        <div class="blank">
+          <span id="productTitle"
+            >祝福のチェスカ: 1【電子限定描き下ろし付き】 (ZERO-SUMコミックス)</span
+          >
+          <span class="author">乃原 美隆</span>
+          <div id="text-description" data-feature-name="bookDescription">
+            <div class="red-herring">Whoops</div>
+            <div class="a-expander-content">
+              <span>
+                神より与えられた超能力（ルア）を使役する人々に支配されている世界で、その力を持たない人々は『ヤグー』と呼ばれ過酷な差別に晒されていた。そんなある日、世界中の王族・為政者の子供たちが通うナンカン共和国のマカリ学園にヤグーの王子が入学することになる。それをきっかけに世界は一変し――…!?言語学の天才である少女・チェスカと虐げられし民も美しき王子・シキが出会う時、世界のルールは覆される!!壮大なる本格ファンタジーが今、幕を開ける――…!!
+              </span>
+            </div>
+          </div>
+          <div data-feature-name="seriesBulletWidget">
+            <span>
+              <span>
+                <a>全10巻中第1巻: 祝福のチェスカ</a>
+              </span>
+            </span>
+          </div>
+          <div id="rpi">
+            <div id="rpi-attribute-book_details-publication_date">
+              <span>Publication date:</span>
+              <div class="rpi-attribute-value">
+                <span>2024/10/31</span>
+              </div>
+            </div>
+            <div data-rpi-attribute-name="book_details-publisher">
+              <span>Publisher:</span>
+              <div class="rpi-attribute-value">
+                <span>一迅社</span>
+              </div>
+            </div>
+          </div>
+          <div id="detailBullets_feature_div">
+            <ul>
+              <li>
+                <span class="a-list-item">
+                  <span class="a-text-bold">Publisher:</span>
+                  <span>Not this one!</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <span id="acrPopover" title="3.5 out of 5 stars">
+          <i class="a-icon a-icon-star a-star-4-5"></i>
+          <span class="a-icon-alt">3.5 out of 5 stars</span>
+        </span>
+        <span class="after-note">Hello, World!</span>
+      </span>
+      <form>
+        <input type="hidden" id="id" name="id" value="123" />
+        <input type="hidden" id="asin" name="AsiN" value="B0DL524V1M" />
+      </form>
+    </div>
+    <script type="text/javascript">
+      var data = {
+        lowRes: "nah",
+        hiRes: "https://m.media-amazon.com/images/I/914f54v5PuL._SL1500_.jpg",
+      };
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_jp_search_results.html
+++ b/tests/fixtures/html/amazon_jp_search_results.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Search Results</title>
+  </head>
+  <body>
+    <div class="search-results-container">
+      <span class="search-result-item">
+        <span data-component-type="s-search-results">
+          <ul>
+            <li>
+              <a href="/ssdp/ABCDEF?digital-text=1">SSDP Product</a>
+            </li>
+            <li>
+              <a href="/dp/ABCDEF">ABCDEF but not digital</a>
+            </li>
+          </ul>
+        </span>
+        <span data-component-type="s-search-results">
+          <a href="/dp/ABCDEF?fake=no&digital-text=yes">ABCDEF but digital</a>
+          <a href="/dp/GHIJKL?digital-text=1">GHIJKL digital</a>
+        </span>
+        <span data-component-type="s-search-results">
+          <span>
+            <a href="/dp/ABCDEF?digital-text=0&duplicate=yes"
+              >Duplicate ABCDEF</a
+            >
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_search_results.html
+++ b/tests/fixtures/html/amazon_search_results.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Search Results</title>
+  </head>
+  <body>
+    <div class="search-results-container">
+      <span class="search-result-item">
+        <span data-component-type="s-search-results">
+          <ul>
+            <li>
+              <a href="/ssdp/ABCDEF?digital-text=1">SSDP Product</a>
+            </li>
+            <li>
+              <a href="/dp/ABCDEF">ABCDEF but not digital</a>
+            </li>
+          </ul>
+        </span>
+        <span data-component-type="s-search-results">
+          <a href="/dp/ABCDEF?fake=no&digital-text=yes">ABCDEF but digital</a>
+          <a href="/dp/GHIJKL?digital-text=1">GHIJKL digital</a>
+        </span>
+        <span data-component-type="s-search-results">
+          <span>
+            <a href="/dp/ABCDEF?digital-text=0&duplicate=yes"
+              >Duplicate ABCDEF</a
+            >
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Adds a set of HTML fixture files for future tests of the Amazon metadata provider. This PR is a no-op.

PR stack:

* #1123
* #1122
* #1121 
* #1120 
* #1119 
* #1116 👈
* `main`