### PR TITLE
refactor(Metadata): Refactor base Metadata class for future consolidation

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -9,7 +9,6 @@ import os
 import re
 import json
 import operator
-import time
 import sys
 import string
 import requests
@@ -26,7 +25,7 @@ from flask import Blueprint, flash, redirect, url_for, abort, request, make_resp
 from markupsafe import Markup
 from .cw_login import current_user
 from flask_babel import gettext as _
-from flask_babel import get_locale, format_time, format_datetime, format_timedelta
+from flask_babel import get_locale, format_time, format_timedelta
 from sqlalchemy import and_
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.exc import IntegrityError, OperationalError, InvalidRequestError
@@ -39,6 +38,10 @@ from .helper import check_valid_domain, send_test_mail, reset_password, generate
     valid_email, check_username
 from .embed_helper import get_calibre_binarypath
 from .gdriveutils import is_gdrive_ready, gdrive_support
+from .metadata_provider_settings import (
+    apply_user_metadata_provider_regions,
+    get_metadata_provider_context,
+)
 from .render_template import render_title_template, get_sidebar_config
 from .services.worker import WorkerThread
 from .usermanagement import user_login_required
@@ -1688,6 +1691,7 @@ def new_user():
                                  config=config, translations=translations,
                                  languages=languages, title=_("Add New User"), page="newuser",
                                  kobo_support=kobo_support, registered_oauth=oauth_bb.oauth_check,
+                                 **get_metadata_provider_context(content),
                                  opds_root_order_string=opds_context["opds_root_order_string"],
                                  opds_hidden_entries_string=opds_context["opds_hidden_entries_string"],
                                  opds_root_labels=opds_context["opds_root_labels"],
@@ -1940,6 +1944,7 @@ def edit_user(user_id):
                                  hidden_custom_shelf_ids=hidden_custom_shelf_ids,
                                  hidden_custom_shelves=hidden_custom_shelves,
                                  visible_public_shelves=visible_public_shelves,
+                                 **get_metadata_provider_context(content),
                                  opds_root_order_string=opds_context["opds_root_order_string"],
                                  opds_hidden_entries_string=opds_context["opds_hidden_entries_string"],
                                  opds_root_labels=opds_context["opds_root_labels"],
@@ -2530,6 +2535,7 @@ def _handle_new_user(to_save, content, languages, translations, kobo_support):
                                      translations=translations,
                                      languages=languages, title=_("Add new user"), page="newuser",
                                      kobo_support=kobo_support, registered_oauth=oauth_bb.oauth_check,
+                                     **get_metadata_provider_context(content),
                                      opds_root_order_string=opds_context["opds_root_order_string"],
                                      opds_hidden_entries_string=opds_context["opds_hidden_entries_string"],
                                      opds_root_labels=opds_context["opds_root_labels"],
@@ -2543,6 +2549,7 @@ def _handle_new_user(to_save, content, languages, translations, kobo_support):
         content.denied_column_value = config.config_denied_column_value
         # No default value for kobo sync shelf setting
         content.kobo_only_shelves_sync = to_save.get("kobo_only_shelves_sync", 0) == "on"
+        apply_user_metadata_provider_regions(content, to_save)
         ub.session.add(content)
         ub.session.commit()
         flash(_("User '%(user)s' created", user=content.name), category="success")
@@ -2635,6 +2642,7 @@ def _handle_edit_user(to_save, content, languages, translations, kobo_support):
     # Auto-send and metadata fetch settings
     content.auto_send_enabled = to_save.get("auto_send_enabled") == "on"
     content.auto_metadata_fetch = to_save.get("auto_metadata_fetch") == "on"
+    apply_user_metadata_provider_regions(content, to_save)
 
     # OPDS root order
     opds_order_raw = to_save.get("opds_root_order", "").strip()
@@ -2808,6 +2816,7 @@ def _handle_edit_user(to_save, content, languages, translations, kobo_support):
                                      content=content,
                                      config=config,
                                      registered_oauth=oauth_bb.oauth_check,
+                                     **get_metadata_provider_context(content),
                                      opds_root_order_string=opds_context["opds_root_order_string"],
                                      opds_hidden_entries_string=opds_context["opds_hidden_entries_string"],
                                      opds_root_labels=opds_context["opds_root_labels"],

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -90,6 +90,9 @@ class _Settings(_Base):
     config_kobo_sync = Column(Boolean, default=False)
     config_kobo_sync_magic_shelves = Column(Boolean, default=False)
 
+    # Metadata provider settings
+    config_amazon_region = Column(String, default="")
+
     # Sync read progress to Hardcover - should this be renamed?
     config_hardcover_sync = Column(Boolean, default=False) 
     # Sync annotations to Hardcover
@@ -371,6 +374,8 @@ class ConfigSQL(object):
                         setattr(self, k, "")
                 else:
                     setattr(self, k, v)
+
+        self.amazon_region = self.config_amazon_region or constants.AMAZON_REGIONS[0]
 
         # Enforce unified logging to stdout for Docker deployments
         if self.config_logfile not in (logger.LOG_TO_STDOUT, logger.LOG_TO_STDERR):

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
+import multiprocessing
 import sys
 import os
 from collections import namedtuple
@@ -232,6 +233,11 @@ LANGUAGE_NAMES = {
     "zh_Hans_CN": _("Chinese (Simplified, China)"),
     "zh_Hant_TW": _("Chinese (Traditional, Taiwan)"),
 }
+
+# If too many thread pools end up being created throughout the app we may want to consider setting this lower
+MAX_THREADS = max(
+    1, multiprocessing.cpu_count() - 1
+)
 
 # NOTE: Keep "com" as the first entry, whichever region is first is the default region until one is chosen by the admin
 # or the user. All other regions should be kept in alphabetical order.

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -45,6 +45,8 @@ else:
     if getattr(sys, 'frozen', False):
         CONFIG_DIR = os.path.abspath(os.path.join(CONFIG_DIR, os.pardir))
 
+# DEFAULT_LOCALE - If no locale is available some other way, fall back to this
+DEFAULT_LOCALE = 'en'
 
 DEFAULT_SETTINGS_FILE = "app.db"
 DEFAULT_GDRIVE_FILE = "gdrive.db"
@@ -181,6 +183,9 @@ INSTALLED_VERSION = os.environ.get("CWA_INSTALLED_VERSION") or _read_text("/app/
 STABLE_VERSION = os.environ.get("CWA_STABLE_VERSION") or _read_text("/app/CWA_STABLE_RELEASE", "v0.0.0")
 
 USER_AGENT = f"Calibre-Web-Automated/{INSTALLED_VERSION}"
+
+# Sometimes we want to mimic a real browser user agent
+BROWSER_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:143.0) Gecko/20100101 Firefox/143.0"
 
 NIGHTLY_VERSION = dict()
 NIGHTLY_VERSION[0] = '0af52f205358b0147ee3430f9e6c8fe007c0ea77'

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -232,3 +232,26 @@ LANGUAGE_NAMES = {
     "zh_Hans_CN": _("Chinese (Simplified, China)"),
     "zh_Hant_TW": _("Chinese (Traditional, Taiwan)"),
 }
+
+# NOTE: Keep "com" as the first entry, whichever region is first is the default region until one is chosen by the admin
+# or the user. All other regions should be kept in alphabetical order.
+AMAZON_REGIONS = [
+    "com",
+    "ae",
+    "ca",
+    "co.jp",
+    "co.uk",
+    "com.au",
+    "com.br",
+    "com.mx",
+    "de",
+    "es",
+    "fr",
+    "ie",
+    "in",
+    "it",
+    "nl",
+    "sa",
+    "se",
+    "sg",
+]

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -39,6 +39,10 @@ from .services.worker import WorkerThread, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_
 from .tasks.database import TaskReconnectDatabase
 from .tasks.auto_send import TaskAutoSend
 from .tasks.ops import TaskConvertLibraryRun, TaskEpubFixerRun
+from .metadata_provider_settings import (
+    apply_config_metadata_provider_regions,
+    get_metadata_provider_context,
+)
 
 switch_theme = Blueprint('switch_theme', __name__)
 library_refresh = Blueprint('library_refresh', __name__)
@@ -968,6 +972,7 @@ def set_cwa_settings():
 
             # Save Kobo Sync Magic Shelves setting (stored in app.db, not cwa.db)
             config.config_kobo_sync_magic_shelves = 'config_kobo_sync_magic_shelves' in request.form
+            apply_config_metadata_provider_regions(config, request.form)
             config.save()
 
             duplicate_criteria_changed = False
@@ -1053,10 +1058,13 @@ def set_cwa_settings():
     next_scan_run = get_next_duplicate_scan_run(cwa_settings)
 
     return render_title_template("cwa_settings.html", title=_("Calibre-Web Automated User Settings"), page="cwa-settings",
-                                    cwa_settings=cwa_settings, ignorable_formats=ignorable_formats, target_formats=target_formats,
-                                    automerge_options=automerge_options, autoingest_options=autoingest_options,
-                                    hardcover_token_available=hardcover_token_available,
-                                    next_duplicate_scan_run=next_scan_run, config=config)
+                                     cwa_settings=cwa_settings, ignorable_formats=ignorable_formats, target_formats=target_formats,
+                                     automerge_options=automerge_options, autoingest_options=autoingest_options,
+                                     hardcover_token_available=hardcover_token_available,
+                                     next_duplicate_scan_run=next_scan_run, config=config,
+                                     **get_metadata_provider_context(
+                                         amazon_region=getattr(config, "config_amazon_region", ""),
+                                     ))
 
 
 def get_next_duplicate_scan_run(settings):

--- a/cps/metadata_provider_settings.py
+++ b/cps/metadata_provider_settings.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Helpers for metadata provider region settings."""
+
+from collections.abc import Sequence
+from typing import Any
+
+from . import constants
+
+
+def validate_provider_region(value: Any, allowed_regions: Sequence[str]) -> str:
+    """Return a normalized region value or an empty string when invalid."""
+    if value is None:
+        return ""
+
+    region = str(value).strip().lower()
+    return region if region in allowed_regions else ""
+
+
+def validate_amazon_region(value: Any) -> str:
+    """Return a validated Amazon region."""
+    return validate_provider_region(value, constants.AMAZON_REGIONS)
+
+
+def get_effective_amazon_region(
+    user: Any | None = None,
+    *,
+    config_amazon_region: Any | None = None,
+) -> str:
+    """Return the effective Amazon region using user, config, then default fallback."""
+    user_region = validate_amazon_region(getattr(user, "amazon_region", None)) if user is not None else ""
+    if user_region:
+        return user_region
+
+    config_region = validate_amazon_region(config_amazon_region)
+    if config_region:
+        return config_region
+
+    return constants.AMAZON_REGIONS[0]
+
+
+def apply_config_metadata_provider_regions(config_obj: Any, form_data: dict[str, Any]) -> None:
+    """Apply validated metadata provider regions to a config-like object."""
+    config_obj.config_amazon_region = validate_amazon_region(form_data.get("amazon_region"))
+
+
+def apply_user_metadata_provider_regions(user: Any, form_data: dict[str, Any]) -> None:
+    """Apply validated metadata provider regions to a user-like object."""
+    user.amazon_region = validate_amazon_region(form_data.get("amazon_region"))
+
+
+def get_metadata_provider_context(
+    user: Any | None = None,
+    *,
+    amazon_region: str | None = None,
+) -> dict[str, Any]:
+    """Return shared template context for metadata provider region settings."""
+    return {
+        "amazon_regions": constants.AMAZON_REGIONS,
+        "amazon_region": amazon_region
+        if amazon_region is not None
+        else getattr(user, "amazon_region", "")
+        if user is not None
+        else "",
+    }

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -8,20 +8,26 @@
 import concurrent.futures
 import importlib
 import inspect
-import json
 import os
 import sys
 
-from flask import Blueprint, request, url_for, make_response, jsonify, copy_current_request_context
-from .cw_login import current_user
-from flask_babel import get_locale
+from flask import (
+    Blueprint,
+    copy_current_request_context,
+    jsonify,
+    make_response,
+    request,
+    url_for,
+)
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 from sqlalchemy.orm.attributes import flag_modified
 
 from cps.services.Metadata import Metadata
-from . import constants, logger, ub, web_server
-from .usermanagement import user_login_required
 
+from . import constants, logger, ub, web_server
+from .cw_babel import get_locale
+from .cw_login import current_user
+from .usermanagement import user_login_required
 
 meta = Blueprint("metadata", __name__)
 
@@ -30,8 +36,12 @@ log = logger.create()
 try:
     from dataclasses import asdict
 except ImportError:
-    log.info('*** "dataclasses" is needed for calibre-web automated to run. Please install it using pip: "pip install dataclasses" ***')
-    print('*** "dataclasses" is needed for calibre-web automated to run. Please install it using pip: "pip install dataclasses" ***')
+    log.info(
+        '*** "dataclasses" is needed for calibre-web automated to run. Please install it using pip: "pip install dataclasses" ***'
+    )
+    print(
+        '*** "dataclasses" is needed for calibre-web automated to run. Please install it using pip: "pip install dataclasses" ***'
+    )
     web_server.stop(True)
     sys.exit(6)
 
@@ -74,24 +84,27 @@ cl.sort(key=lambda x: x.__class__.__name__)
 def _get_global_provider_enabled_map() -> dict:
     try:
         # Import here to avoid circular import issues and keep startup fast
-        sys.path.insert(1, '/app/calibre-web-automated/scripts/')
+        sys.path.insert(1, "/app/calibre-web-automated/scripts/")
         from cwa_db import CWA_DB  # type: ignore
+
         cwa_db = CWA_DB()
         settings = cwa_db.get_cwa_settings()
-        
+
         if not settings:
             log.warning("Could not get CWA settings for provider enabled map")
             return {}
-        
+
         from cps.cwa_functions import parse_metadata_providers_enabled
+
         return parse_metadata_providers_enabled(
-            settings.get('metadata_providers_enabled', '{}')
+            settings.get("metadata_providers_enabled", "{}")
         )
     except Exception as e:
         # On any failure, treat as all enabled (empty dict = all default to enabled)
         log.warning(f"Error loading provider enabled map: {e}")
         return {}
     # Remove redundant return
+
 
 @meta.route("/metadata/provider")
 @user_login_required
@@ -163,9 +176,15 @@ def metadata_search():
         # ret = cl[0].search(query, static_cover, locale)
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             meta = {
-                executor.submit(copy_current_request_context(c.search), query, static_cover, locale): c
+                executor.submit(
+                    copy_current_request_context(c.search),
+                    query,
+                    static_cover,
+                    locale,
+                ): c
                 for c in cl
-                if active.get(c.__id__, True) and bool(global_enabled.get(c.__id__, True))
+                if active.get(c.__id__, True)
+                and bool(global_enabled.get(c.__id__, True))
             }
             for future in concurrent.futures.as_completed(meta):
                 try:
@@ -178,4 +197,4 @@ def metadata_search():
                 if not result:
                     continue
                 data.extend([asdict(x) for x in result if x])
-    return  make_response(jsonify(data))
+    return make_response(jsonify(data))

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -169,12 +169,14 @@ def metadata_search():
     query = request.form.to_dict().get("query")
     data = list()
     active = current_user.view_settings.get("metadata", {})
-    locale = get_locale()
+    locale = get_locale() or "en_US"
     global_enabled = _get_global_provider_enabled_map()
     if query:
         static_cover = url_for("static", filename="generic_cover.svg")
         # ret = cl[0].search(query, static_cover, locale)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=constants.MAX_THREADS
+        ) as executor:
             meta = {
                 executor.submit(
                     copy_current_request_context(c.search),

--- a/cps/services/Metadata.py
+++ b/cps/services/Metadata.py
@@ -6,12 +6,27 @@
 # See CONTRIBUTORS for full list of authors.
 
 import abc
+import concurrent.futures
 import dataclasses
 import os
 import re
-from typing import Dict, Generator, List, Optional, Union
+import time
+from datetime import datetime
+from typing import Dict, Generator, Hashable, Iterable, List, Optional, TypeVar, Union
 
-from cps import constants
+from bs4 import BeautifulSoup as BS
+
+try:
+    from curl_cffi import requests as creq  # type: ignore
+except ImportError:
+    import requests as creq  # Fallback to regular requests if curl-cffi not available
+import cps.logger as logger
+from cps import constants, isoLanguages
+
+log = logger.create()
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
 
 
 @dataclasses.dataclass
@@ -44,20 +59,309 @@ class MetaRecord:
 
 
 class Metadata:
+    """Abstract base class for metadata sources.
+
+    Attributes:
+        __name__ (str): Human-readable name of the metadata source.
+        __id__ (str): Unique identifier for the metadata source.
+        MAX_SEARCH_RESULTS (int): Maximum number of search results to return.
+        active (bool): Whether this metadata source is active.
+        headers (dict): HTTP headers to use for requests.
+        session (requests.Session): HTTP session for making requests.
+        _last_request_time (float): Timestamp of the last request made.
+        _min_request_interval (float): Minimum interval in seconds between requests.
+    """
+
     __name__ = "Generic"
     __id__ = "generic"
 
+    # Maximum number of search results to return from any one provider
+    MAX_SEARCH_RESULTS = 5
+
+    active = True
+
+    # Timestamp of the last request made by this metadata source. Used for rate limiting.
+    _last_request_time = 0.0
+
+    # Minimum interval in seconds between requests to this metadata source
+    _min_request_interval = 0.5
+
+    _thread_pool: concurrent.futures.ThreadPoolExecutor | None = None
+
     def __init__(self):
-        self.active = True
+        self._thread_pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=constants.MAX_THREADS
+        )
+
+        # Headers passed to HTTP requests
+        # Headers are defined in the constructor because they depend on instance-level language_codes and we may as well
+        # just keep it all together here.
+        self.headers = {
+            "User-Agent": constants.BROWSER_USER_AGENT,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/png,image/svg+xml,*/*;q=0.8",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Accept-Language": self.accept_language_header(),
+        }
+
+        # The session is defined in the constructor because of a quirk of Python: at the class level it's constructed
+        # once, when the class is defined, and never touched again. This means that subclasses would share the same
+        # session instance, which is not what we want. By defining it in the constructor, each subclass instance gets
+        # its own session.
+        try:
+            # Try curl-cffi with impersonation first
+            self.session = creq.Session(impersonate="chrome120")
+        except (TypeError, AttributeError):
+            # Fallback to regular requests session
+            self.session = creq.Session()
+        self.session.headers.update(self.headers)
+
+    def accept_language_header(self) -> str:
+        """Return the Accept-Language header value for this metadata source.
+
+        This is done as an instance function because some metadata provider regions may have multiple languages with
+        different priorities. We assume that the order of language codes returned by language_codes() reflects the
+        priority.
+
+        Returns:
+            str: Accept-Language header value.
+        """
+        # TODO: Allow user to configure language preference order?
+        return ",".join(
+            [
+                f"{lang};q={1 - i * 0.1:.1f}" if i else lang
+                for i, lang in enumerate(self.language_codes())
+            ]
+        )
+
+    def language_codes(self) -> list[str]:
+        """Return the list of language codes for this metadata source.
+
+        Returns:
+            list[str]: List of language codes.
+        """
+        return ["en-US", "en"]
 
     def set_status(self, state):
+        """Set the active state of this metadata source.
+
+        Args:
+            state (bool): True to activate, False to deactivate.
+        """
         self.active = state
 
     @abc.abstractmethod
+    def base_url(self) -> str:
+        """Return the base URL of the metadata source.
+
+        Returns:
+            str: Base URL as a string.
+        """
+        return ""
+
+    @abc.abstractmethod
     def search(
-        self, query: str, generic_cover: str = "", locale: str = "en"
-    ) -> Optional[List[MetaRecord]]:
-        pass
+        self, query: str, generic_cover: str = "", locale: str = "en_US"
+    ) -> list[MetaRecord] | None:
+        """Search this metadata provider for matching query results.
+
+        Args:
+            query (str): The search query.
+            generic_cover (str, optional): Path to generic cover image. Defaults to "".
+
+        Returns:
+            list[MetaRecord] | None: List of MetaRecord objects or None on failure or no results.
+        """
+        return None
+
+    @abc.abstractmethod
+    def parse_detail_page(
+        self, detail_uri: str, generic_cover: str, index: int
+    ) -> tuple[MetaRecord, int] | None:
+        """Parse a book detail page from the metadata source.
+
+        Args:
+            detail_uri (str): The URI of the detail page.
+            generic_cover (str): Path to generic cover image.
+            index (int): Index of the book in the search results.
+
+        Returns:
+            tuple[MetaRecord, int] | None: A tuple of MetaRecord and index, or None on failure.
+        """
+        return None
+
+    def _wait_for_rate_limit(self) -> None:
+        """Wait if necessary to respect the minimum request interval."""
+        if self._min_request_interval > 0:
+            now = time.time()
+            delta = now - self._last_request_time
+            if delta < self._min_request_interval:
+                sleep_time = self._min_request_interval - delta
+                log.debug(
+                    f"Time until next request for {self.__name__} is allowed: {sleep_time:.2f}s"
+                )
+                time.sleep(sleep_time)
+
+    def get_raw(self, url: str, timeout: int = 10, **kwargs) -> bytes | None:
+        """Get a URL and return the raw response.
+
+        Args:
+            url (str): The URL to fetch.
+            timeout (int, optional): Request timeout in seconds. Defaults to 10.
+            **kwargs: Additional keyword arguments passed directly to `requests.get()`.
+        Returns:
+            bytes | None: Raw response bytes or None on failure.
+        """
+        self._wait_for_rate_limit()
+
+        try:
+            r = self.session.get(url, timeout=timeout, **kwargs)
+            self._last_request_time = time.time()
+            r.raise_for_status()
+            return r.content
+        except Exception as ex:
+            log.error_or_exception(ex)
+            return None
+
+    def get(self, url: str, timeout: int = 10, **kwargs) -> BS | None:
+        """Get a URL and return the parsed BaeutifulSoup object.
+
+        Args:
+            url (str): The URL to fetch.
+            timeout (int, optional): Request timeout in seconds. Defaults to 10.
+            **kwargs: Additional keyword arguments passed directly to `requests.get()`.
+
+        Returns:
+            BS | None: Parsed BeautifulSoup object or None on failure.
+        """
+        r = self.get_raw(url, timeout=timeout, **kwargs)
+        if r is None:
+            return None
+
+        # lxml is faster, fall back to html.parser if needed
+        try:
+            detail_soup = BS(r.decode(), "lxml")
+        except Exception:
+            detail_soup = BS(r.decode(), "html.parser")
+
+        return detail_soup
+
+    def post(self, url: str, timeout: int = 10, **kwargs) -> BS | dict | None:
+        """Post to a URL and return the parsed result. If the Content-Type is JSON return a dict, otherwise return a BeautifulSoup object.
+
+        Args:
+            url (str): The URL to post to.
+            timeout (int, optional): Request timeout in seconds. Defaults to 10.
+            **kwargs: Additional keyword arguments passed directly to `requests.post()`.
+
+        Returns:
+            BS | dict | None: Parsed BeautifulSoup object, dict for JSON responses, or None on failure.
+        """
+        self._wait_for_rate_limit()
+
+        try:
+            as_json = kwargs.pop("as_json", False)
+            r = self.session.post(url, timeout=timeout, **kwargs)
+            self._last_request_time = time.time()
+            r.raise_for_status()
+
+            if as_json or self.headers.get("Accept", "").lower() == "application/json":
+                return r.json()
+
+            # lxml is faster, fall back to html.parser if needed
+            try:
+                detail_soup = BS(r.text, "lxml")
+            except Exception:
+                detail_soup = BS(r.text, "html.parser")
+
+            return detail_soup
+        except Exception as ex:
+            log.error_or_exception(ex)
+            return None
+
+    @property
+    def primary_language(self) -> str:
+        """Return the primary language code.
+
+        The primary language is constructed by taking the first language code from language_codes and stripping any
+        country code. The result is expected to be a valid ISO 639-1 language code. For example, "en-US" becomes "en".
+
+        Returns:
+            str: ISO 639-1 language string
+        """
+        return self.language_codes()[0].split("-", 1)[0]
+
+    def _normalize_date(self, date_str: str) -> str | None:
+        """Normalize date strings to YYYY-MM-DD format.
+
+        Args:
+            date_str (str): Input date string.
+
+        Returns:
+            str | None: Normalized date string or None if parsing fails.
+        """
+        date_str = date_str.strip()
+
+        if not date_str:
+            return None
+
+        # Strip time part if present (ISO 8601 like 2025-09-09T00:00:00Z)
+        if "T" in date_str:
+            date_str = date_str.split("T", 1)[0]
+        # Strip time part if present (like '2025-09-09 00:00:00' or '09 September 2025 00:00:00')
+        date_match = re.match(
+            r"^(.*?)(\s+\d{1,2}:\d{2}(:\d{2})?([+-]\d{2}:\d{2}|Z)?)$", date_str
+        )
+        if date_match:
+            date_str = date_match.group(1).strip()
+
+        # Try common date formats
+        for fmt in (
+            "%Y-%m-%d",  # e.g., 2025-09-17
+            "%Y/%m/%d",  # e.g., 2025/09/17
+            "%Y-%m",  # e.g., 2025-09
+            "%Y/%m",  # e.g., 2025/09
+            "%Y",  # e.g., 2025
+            "%B %d, %Y",  # e.g., September 9, 2025
+            "%b %d, %Y",  # e.g., Sep 9, 2025
+            "%d %B %Y",  # e.g., 9 September 2025
+            "%d %b %Y",  # e.g., 9 Sep 2025
+            "%B %Y",  # e.g., September 2025
+            "%b %Y",  # e.g., Sep 2025
+        ):
+            try:
+                dt = datetime.strptime(date_str, fmt)
+                if fmt == "%Y":
+                    return dt.strftime("%Y")
+                if fmt in ("%Y-%m", "%Y/%m"):
+                    return dt.strftime("%Y-%m")
+                if fmt in ("%B %Y", "%b %Y"):
+                    return dt.strftime("%Y-%m")
+                return dt.strftime("%Y-%m-%d")
+            except ValueError:
+                continue
+
+        # Last-ditch fallback: try to extract a 4-digit year or date string
+        m = re.search(r"(19|20)\d{2}(-\d{2}-\d{2})?", date_str)
+        if m:
+            date_val = m.group(0)
+            return date_val if len(date_val) == 10 else date_val[:4]
+
+        # No luck
+        return None
+
+    def _close_session(self):
+        """Properly close the session if it exists."""
+        if self.session:
+            try:
+                self.session.close()
+            except Exception:
+                pass
+            finally:
+                self.session = None
+
+    def __del__(self):
+        """Cleanup when object is destroyed."""
+        self._close_session()
 
     @staticmethod
     def get_title_tokens(
@@ -102,3 +406,159 @@ class Metadata:
                 not strip_joiners or token.lower() not in ("a", "and", "the", "&")
             ):
                 yield token
+
+    def get_detail_records(
+        self, links: Iterable[str], generic_cover: str
+    ) -> list[MetaRecord]:
+        """Fetch detailed metadata records in parallel from a list of links.
+
+        Args:
+            links (Iterable[str]): List of URLs to fetch metadata from.
+            generic_cover (str): Path to generic cover image.
+
+        Returns:
+            list[MetaRecord]: List of fetched MetaRecord objects in the order returned by the provider.
+        """
+
+        links_list = list(links)
+        if len(links_list) == 0:
+            return []
+
+        futures = {
+            self._thread_pool.submit(self.parse_detail_page, link, generic_cover, index)
+            for index, link in enumerate(links_list[: self.MAX_SEARCH_RESULTS])
+        }
+
+        try:
+            values = list(
+                filter(
+                    lambda v: v,
+                    map(
+                        lambda x: x.result(),
+                        concurrent.futures.as_completed(futures, timeout=15),
+                    ),
+                )
+            )
+        except concurrent.futures.TimeoutError as te:
+            log.warning(
+                f"Timeout while fetching detail pages from {self.__name__}: {te}"
+            )
+            return []
+
+        # Sort results by original source index to maintain order for best relevance
+        return [x[0] for x in sorted(values, key=lambda t: t[1])]
+
+    def validate_isbn(self, isbn: str) -> str | None:
+        """Validate and clean ISBN format."""
+        if not isbn or not isinstance(isbn, str):
+            return None
+
+        # Clean ISBN: remove hyphens, spaces, and convert to uppercase
+        clean_isbn = re.sub(r"[^0-9X]", "", isbn.strip().upper())
+
+        # Check if it's ISBN-10 or ISBN-13
+        total = 0
+        if len(clean_isbn) == 10:
+            for i, ch in enumerate(clean_isbn):
+                if i == 9 and ch == "X":
+                    val = 10
+                elif ch.isdigit():
+                    val = int(ch)
+                else:
+                    return None
+                total += val * (10 - i)
+            if total % 11 == 0:
+                return clean_isbn
+        elif len(clean_isbn) == 13:
+            if clean_isbn[:3] not in ("978", "979"):
+                return None
+            for i, ch in enumerate(clean_isbn):
+                if not ch.isdigit():
+                    return None
+                val = int(ch)
+                total += val * (1 if i % 2 == 0 else 3)
+            if total % 10 == 0:
+                return clean_isbn
+
+        return None
+
+    def clean_description(self, text: str, strip_html=False) -> str:
+        """Clean and sanitize description text."""
+        if not text:
+            return ""
+
+        t = str(text).strip()
+        if not t:
+            return ""
+
+        # Normalize various types of whitespace
+        t = t.replace("\u00a0", " ")  # Non-breaking space
+        t = t.replace("\u2009", " ")  # Thin space
+        t = t.replace("\u200b", "")  # Zero-width space
+        t = re.sub(r"[\t ]+", " ", t).strip()
+
+        # Unescape common escaped characters
+        t = re.sub(r"\\([#@%&*~`])", r"\1", t)
+
+        # Remove excessive newlines but preserve paragraph breaks
+        t = re.sub(r"\n\s*\n\s*\n+", "\n\n", t)
+
+        if strip_html:
+            # Remove any HTML tags that might remain
+            try:
+                # Use BeautifulSoup to properly strip HTML
+                clean_soup = BS(t, "lxml")
+                t = clean_soup.get_text(" ", strip=True)
+            except Exception:
+                # Fallback: simple HTML tag removal
+                t = re.sub(r"<[^>]+>", " ", t)
+
+            # Limit length to prevent extremely long descriptions
+            max_length = 5000
+            if len(t) > max_length:
+                t = t[: max_length - 3].rsplit(" ", 1)[0] + "..."
+
+        return t
+
+    def safe_get(
+        self, data: dict[K, V], *keys: K, default: V | None = None
+    ) -> V | dict[K, V] | None:
+        """Safely get a nested value from a dictionary.
+
+        Args:
+            data (dict[str, any]): The dictionary to retrieve the value from.
+            *keys (str): Sequence of keys to traverse the nested dictionary.
+            default (any|None, optional): Default value to return if any key is missing. Defaults to None.
+        Returns:
+            any|None: The retrieved value or the default if any key is missing.
+        """
+        try:
+            value: V | dict[K, V] | None = data
+            for key in keys:
+                if isinstance(value, dict) and key in value:
+                    value = value[key]
+                else:
+                    return default
+            return value
+        except (TypeError, KeyError):
+            return default
+
+    def get_language_name(
+        self, lang_code: str, locale: str = constants.DEFAULT_LOCALE
+    ) -> str:
+        """Get the full language display name from a language code.
+
+        Args:
+            lang_code (str): ISO 639-1 or ISO 639-3 language code.
+            locale (str, optional): Locale for language name.
+        Returns:
+            str: Full language name or empty string if not found.
+        """
+        if len(lang_code) < 2 or len(lang_code) > 3:
+            return ""
+
+        lang_code = lang_code.lower()
+        if len(lang_code) == 2:
+            lang_code = isoLanguages.get_lang3(lang_code)
+
+        return isoLanguages.get_language_name(locale, lang_code)

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -735,6 +735,19 @@
     </div>
 
     <div class="settings-container">
+      <div class="form-group">
+        <h4 class="settings-section-header">{{_('Metadata Provider Settings')}}</h4>
+        <label for="amazon_region" style="padding-right: 10px; margin-bottom: 16px !important;">{{_('Choose an Amazon region')}}:</label>
+        <select class="cwa-settings-select" name="amazon_region" id="amazon_region">
+          <option value="">({{ _('Default') }})</option>
+          {% for region in amazon_regions -%}
+          <option value="{{ region }}"{% if amazon_region == region %} selected{% endif %}>www.amazon.{{ region }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
+    <div class="settings-container">
         <h4 class="settings-section-header">{{_('Web UI Settings')}}</h4>
 
       {% if cwa_settings['cwa_update_notifications'] %}

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -292,6 +292,19 @@
     </div>
     {% endif %}
     
+    <div class="settings-container" style="max-width: none; margin-inline: 0rem;">
+      <div class="form-group" style="margin-bottom: 20px; display: flex; flex-direction: column; gap: 0.5rem;">
+        <h4 class="settings-section-header">{{_('Metadata Provider Settings')}}</h4>
+        <label for="amazon_region" style="margin-bottom: 8px !important;">{{_('Choose an Amazon region')}}:</label>
+        <select class="form-control" name="amazon_region" id="amazon_region">
+          <option value="">({{ _('Global Default') }})</option>
+          {% for region in amazon_regions -%}
+          <option value="{{ region }}"{% if amazon_region == region %} selected{% endif %}>www.amazon.{{ region }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
     <!-- OAuth & API Integrations Card -->
     {% if (registered_oauth.keys()| length > 0 and not new_user and profile) or (hardcover_support and not new_user) or (kobo_support and not new_user) %}
     <div class="settings-container" style="max-width: none; margin-inline: 0rem;">

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -287,6 +287,7 @@ class User(UserBase, Base):
     auto_send_enabled = Column(Boolean, default=False)
     # Allow entering additional email addresses on send-to-eReader
     allow_additional_ereader_emails = Column(Boolean, default=True)
+    amazon_region = Column(String, default=None)
 
 
 if oauth_support:
@@ -335,6 +336,7 @@ class Anonymous(AnonymousUserMixin, UserBase):
         self.role = None
         self.name = None
         self.auto_send_enabled = False
+        self.amazon_region = None
         self.loadSettings()
 
     def loadSettings(self):
@@ -356,6 +358,7 @@ class Anonymous(AnonymousUserMixin, UserBase):
         self.kobo_only_shelves_sync = data.kobo_only_shelves_sync
         self.hardcover_token = data.hardcover_token
         self.auto_send_enabled = data.auto_send_enabled
+        self.amazon_region = data.amazon_region
     def role_admin(self):
         return False
 
@@ -926,6 +929,16 @@ def migrate_user_table(engine, _session):
         print(f"[Migration] Warning: Could not update duplicates sidebar setting: {e}")
         _session.rollback()
 
+    # Migration to add Amazon region setting
+    try:
+        _session.query(exists().where(User.amazon_region)).scalar()
+        _session.commit()
+    except exc.OperationalError:
+        with engine.connect() as conn:
+            trans = conn.begin()
+            conn.execute(text("ALTER TABLE user ADD column 'amazon_region' String DEFAULT ''"))
+            trans.commit()
+
 def migrate_oauth_provider_table(engine, _session):
     try:
         _session.query(exists().where(OAuthProvider.oauth_base_url)).scalar()
@@ -1015,6 +1028,21 @@ def migrate_config_table(engine, _session):
         except Exception as e:
             log.error("Failed to add config_ldap_auto_create_users column: %s", e)
             # Don't raise - let CWA continue without this feature
+            pass
+
+    # Add Amazon region configuration
+    try:
+        _session.execute(text("SELECT config_amazon_region FROM settings LIMIT 1"))
+        _session.commit()
+    except exc.OperationalError:
+        try:
+            _safe_session_rollback(_session, "settings.config_amazon_region")
+            _run_ddl_with_retry(
+                engine,
+                "ALTER TABLE settings ADD column 'config_amazon_region' String DEFAULT ''",
+            )
+        except Exception as e:
+            log.error("Failed to add config_amazon_region column: %s", e)
             pass
 
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -8,7 +8,6 @@ import os
 import json
 import mimetypes
 import chardet  # dependency of requests
-import copy
 import importlib
 import re
 import zipfile
@@ -43,6 +42,10 @@ from .redirect import get_redirect_location
 from .cw_babel import get_available_locale
 from .usermanagement import login_required_if_no_ano
 from .kobo_sync_status import remove_synced_book
+from .metadata_provider_settings import (
+    apply_user_metadata_provider_regions,
+    get_metadata_provider_context,
+)
 from . import magic_shelf
 from .render_template import render_title_template
 from .kobo_sync_status import change_archived_books
@@ -54,7 +57,6 @@ from .string_helper import strip_whitespaces
 
 # CWA Imports
 import sqlite3
-import time
 import time
 
 import sys
@@ -2432,6 +2434,8 @@ def change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_sta
         current_user.auto_send_enabled = to_save.get("auto_send_enabled") == "on"
         current_user.auto_metadata_fetch = to_save.get("auto_metadata_fetch") == "on"
         current_user.allow_additional_ereader_emails = to_save.get("allow_additional_ereader_emails") == "on"
+
+        apply_user_metadata_provider_regions(current_user, to_save)
         
         # Handle hidden magic shelf templates and custom shelves
         from . import magic_shelf
@@ -2648,6 +2652,7 @@ def change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_sta
                                      kobo_support=kobo_support,
                                      hardcover_support=hardcover_support,
                                      registered_oauth=local_oauth_check,
+                                     **get_metadata_provider_context(current_user),
                                      oauth_status=oauth_status)
 
     val = 0
@@ -2774,6 +2779,7 @@ def profile():
                                  title=_(f"{current_user.name.capitalize()}'s Profile", name=current_user.name),
                                  page="me",
                                  registered_oauth=local_oauth_check,
+                                 **get_metadata_provider_context(current_user),
                                  oauth_status=oauth_status)
 
 

--- a/scripts/cwa_schema.sql
+++ b/scripts/cwa_schema.sql
@@ -102,6 +102,7 @@ CREATE TABLE IF NOT EXISTS cwa_settings(
     duplicate_scan_hour INTEGER DEFAULT 3 NOT NULL,
     duplicate_scan_chunk_size INTEGER DEFAULT 5000 NOT NULL,
     duplicate_scan_debounce_seconds INTEGER DEFAULT 60 NOT NULL
+    amazon_region TEXT DEFAULT "com" NOT NULL
 );
 
 -- Persisted scheduled jobs (initial focus: auto-send). Rows remain until dispatched or manually cleared.

--- a/tests/fixtures/html/amazon_all_fields.html
+++ b/tests/fixtures/html/amazon_all_fields.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Book Detail Page</title>
+  </head>
+  <body>
+    <div id="dp-container">
+      <span id="wrapper">
+        <div class="blank">
+          <span id="productTitle"> An Elemental Title </span>
+          <span class="author">Gaia Earth</span>
+          <div id="text-description" data-feature-name="bookDescription">
+            <div class="red-herring">Whoops</div>
+            <div class="a-expander-content">
+              <span> In a world with elements, there are elements! </span>
+            </div>
+          </div>
+          <div data-feature-name="seriesBulletWidget">
+            <span>
+              <span>
+                <a>Book 3 of 932: True Sol Planets</a>
+              </span>
+            </span>
+          </div>
+          <div id="rpi">
+            <div id="rpi-attribute-book_details-publication_date">
+              <span>Publication date:</span>
+              <div class="rpi-attribute-value">
+                <span> January 2, 1970 </span>
+              </div>
+            </div>
+          </div>
+          <div id="detailBullets_feature_div">
+            <ul>
+              <li>
+                <span class="a-list-item">
+                  <span class="a-text-bold">Publisher:</span>
+                  <span>Sol Publishing Co</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <span id="acrPopover" title="4.5 out of 5 stars">
+          <i class="a-icon a-icon-star a-star-4-5"></i>
+          <span class="a-icon-alt">4.5 out of 5 stars</span>
+        </span>
+        <span class="after-note">Hello, World!</span>
+      </span>
+      <form>
+        <input type="hidden" id="id" name="id" value="123" />
+        <input type="hidden" id="asin" name="AsiN" value="B0DL524V1M" />
+      </form>
+    </div>
+    <script type="text/javascript">
+      var data = {
+        lowRes: "nah",
+        hiRes: "https://m.media-amazon.com/images/I/914f54v5PuL._SL1500_.jpg",
+      };
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_ca_all_fields.html
+++ b/tests/fixtures/html/amazon_ca_all_fields.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Book Detail Page</title>
+  </head>
+  <body>
+    <div id="dp-container">
+      <span id="wrapper">
+        <div class="blank">
+          <span id="productTitle"> An Elemental Title </span>
+          <span class="author">Gaia Earth</span>
+          <div id="text-description" data-feature-name="bookDescription">
+            <div class="red-herring">Whoops</div>
+            <div class="a-expander-content">
+              <span> In a world with elements, there are elements! </span>
+            </div>
+          </div>
+          <div data-feature-name="seriesBulletWidget">
+            <span>
+              <span>
+                <a>Book 3 of 932: True Sol Planets</a>
+              </span>
+            </span>
+          </div>
+          <div id="rpi">
+            <div id="rpi-attribute-book_details-publication_date">
+              <span>Publication date:</span>
+              <div class="rpi-attribute-value">
+                <span> January 2, 1970 </span>
+              </div>
+            </div>
+          </div>
+          <div id="detailBullets_feature_div">
+            <ul>
+              <li>
+                <span class="a-list-item">
+                  <span class="a-text-bold">Publisher:</span>
+                  <span>Sol Publishing Co</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <span id="acrPopover" title="4.5 out of 5 stars">
+          <i class="a-icon a-icon-star a-star-4-5"></i>
+          <span class="a-icon-alt">4.5 out of 5 stars</span>
+        </span>
+        <span class="after-note">Hello, World!</span>
+      </span>
+      <form>
+        <input type="hidden" id="id" name="id" value="123" />
+        <input type="hidden" id="asin" name="AsiN" value="B0DL524V1M" />
+      </form>
+    </div>
+    <script type="text/javascript">
+      var data = {
+        lowRes: "nah",
+        hiRes: "https://m.media-amazon.com/images/I/914f54v5PuL._SL1500_.jpg",
+      };
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_ca_search_results.html
+++ b/tests/fixtures/html/amazon_ca_search_results.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Search Results</title>
+  </head>
+  <body>
+    <div class="search-results-container">
+      <span class="search-result-item">
+        <span data-component-type="s-search-results">
+          <ul>
+            <li>
+              <a href="/ssdp/ABCDEF?digital-text=1">SSDP Product</a>
+            </li>
+            <li>
+              <a href="/dp/ABCDEF">ABCDEF but not digital</a>
+            </li>
+          </ul>
+        </span>
+        <span data-component-type="s-search-results">
+          <a href="/dp/ABCDEF?fake=no&digital-text=yes">ABCDEF but digital</a>
+          <a href="/dp/GHIJKL?digital-text=1">GHIJKL digital</a>
+        </span>
+        <span data-component-type="s-search-results">
+          <span>
+            <a href="/dp/ABCDEF?digital-text=0&duplicate=yes"
+              >Duplicate ABCDEF</a
+            >
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_jp_all_fields.html
+++ b/tests/fixtures/html/amazon_jp_all_fields.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Book Detail Page</title>
+  </head>
+  <body>
+    <div id="dp-container">
+      <span id="wrapper">
+        <div class="blank">
+          <span id="productTitle"
+            >祝福のチェスカ: 1【電子限定描き下ろし付き】 (ZERO-SUMコミックス)</span
+          >
+          <span class="author">乃原 美隆</span>
+          <div id="text-description" data-feature-name="bookDescription">
+            <div class="red-herring">Whoops</div>
+            <div class="a-expander-content">
+              <span>
+                神より与えられた超能力（ルア）を使役する人々に支配されている世界で、その力を持たない人々は『ヤグー』と呼ばれ過酷な差別に晒されていた。そんなある日、世界中の王族・為政者の子供たちが通うナンカン共和国のマカリ学園にヤグーの王子が入学することになる。それをきっかけに世界は一変し――…!?言語学の天才である少女・チェスカと虐げられし民も美しき王子・シキが出会う時、世界のルールは覆される!!壮大なる本格ファンタジーが今、幕を開ける――…!!
+              </span>
+            </div>
+          </div>
+          <div data-feature-name="seriesBulletWidget">
+            <span>
+              <span>
+                <a>全10巻中第1巻: 祝福のチェスカ</a>
+              </span>
+            </span>
+          </div>
+          <div id="rpi">
+            <div id="rpi-attribute-book_details-publication_date">
+              <span>Publication date:</span>
+              <div class="rpi-attribute-value">
+                <span>2024/10/31</span>
+              </div>
+            </div>
+            <div data-rpi-attribute-name="book_details-publisher">
+              <span>Publisher:</span>
+              <div class="rpi-attribute-value">
+                <span>一迅社</span>
+              </div>
+            </div>
+          </div>
+          <div id="detailBullets_feature_div">
+            <ul>
+              <li>
+                <span class="a-list-item">
+                  <span class="a-text-bold">Publisher:</span>
+                  <span>Not this one!</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <span id="acrPopover" title="3.5 out of 5 stars">
+          <i class="a-icon a-icon-star a-star-4-5"></i>
+          <span class="a-icon-alt">3.5 out of 5 stars</span>
+        </span>
+        <span class="after-note">Hello, World!</span>
+      </span>
+      <form>
+        <input type="hidden" id="id" name="id" value="123" />
+        <input type="hidden" id="asin" name="AsiN" value="B0DL524V1M" />
+      </form>
+    </div>
+    <script type="text/javascript">
+      var data = {
+        lowRes: "nah",
+        hiRes: "https://m.media-amazon.com/images/I/914f54v5PuL._SL1500_.jpg",
+      };
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_jp_search_results.html
+++ b/tests/fixtures/html/amazon_jp_search_results.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Search Results</title>
+  </head>
+  <body>
+    <div class="search-results-container">
+      <span class="search-result-item">
+        <span data-component-type="s-search-results">
+          <ul>
+            <li>
+              <a href="/ssdp/ABCDEF?digital-text=1">SSDP Product</a>
+            </li>
+            <li>
+              <a href="/dp/ABCDEF">ABCDEF but not digital</a>
+            </li>
+          </ul>
+        </span>
+        <span data-component-type="s-search-results">
+          <a href="/dp/ABCDEF?fake=no&digital-text=yes">ABCDEF but digital</a>
+          <a href="/dp/GHIJKL?digital-text=1">GHIJKL digital</a>
+        </span>
+        <span data-component-type="s-search-results">
+          <span>
+            <a href="/dp/ABCDEF?digital-text=0&duplicate=yes"
+              >Duplicate ABCDEF</a
+            >
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/html/amazon_search_results.html
+++ b/tests/fixtures/html/amazon_search_results.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Amazon Search Results</title>
+  </head>
+  <body>
+    <div class="search-results-container">
+      <span class="search-result-item">
+        <span data-component-type="s-search-results">
+          <ul>
+            <li>
+              <a href="/ssdp/ABCDEF?digital-text=1">SSDP Product</a>
+            </li>
+            <li>
+              <a href="/dp/ABCDEF">ABCDEF but not digital</a>
+            </li>
+          </ul>
+        </span>
+        <span data-component-type="s-search-results">
+          <a href="/dp/ABCDEF?fake=no&digital-text=yes">ABCDEF but digital</a>
+          <a href="/dp/GHIJKL?digital-text=1">GHIJKL digital</a>
+        </span>
+        <span data-component-type="s-search-results">
+          <span>
+            <a href="/dp/ABCDEF?digital-text=0&duplicate=yes"
+              >Duplicate ABCDEF</a
+            >
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>
+</html>

--- a/tests/unit/test_metadata_provider_settings.py
+++ b/tests/unit/test_metadata_provider_settings.py
@@ -82,4 +82,7 @@ class TestMetadataProviderSettings:
     def test_get_effective_amazon_region_falls_back_to_default(self) -> None:
         user = SimpleNamespace(amazon_region="")
 
-        assert get_effective_amazon_region(user, config_amazon_region="not-real") == constants.AMAZON_REGIONS[0]
+        assert (
+            get_effective_amazon_region(user, config_amazon_region="not-real")
+            == constants.AMAZON_REGIONS[0]
+        )

--- a/tests/unit/test_metadata_provider_settings.py
+++ b/tests/unit/test_metadata_provider_settings.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for metadata provider region helpers and config loading."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from cps import constants
+from cps.metadata_provider_settings import (
+    apply_config_metadata_provider_regions,
+    apply_user_metadata_provider_regions,
+    get_effective_amazon_region,
+    get_metadata_provider_context,
+    validate_amazon_region,
+)
+
+
+@pytest.mark.unit
+class TestMetadataProviderSettings:
+    def test_validate_provider_regions(self) -> None:
+        assert validate_amazon_region("de") == "de"
+        assert validate_amazon_region("DE") == "de"
+        assert validate_amazon_region("invalid") == ""
+
+    def test_apply_user_metadata_provider_regions(self) -> None:
+        user = SimpleNamespace(amazon_region=None)
+
+        apply_user_metadata_provider_regions(
+            user,
+            {"amazon_region": "ca"},
+        )
+        assert user.amazon_region == "ca"
+
+        apply_user_metadata_provider_regions(
+            user,
+            {"amazon_region": "not-real"},
+        )
+        assert user.amazon_region == ""
+
+    def test_apply_config_metadata_provider_regions(self) -> None:
+        config = SimpleNamespace(config_amazon_region="")
+
+        apply_config_metadata_provider_regions(
+            config,
+            {"amazon_region": "co.uk"},
+        )
+        assert config.config_amazon_region == "co.uk"
+
+        apply_config_metadata_provider_regions(
+            config,
+            {"amazon_region": "not-real"},
+        )
+        assert config.config_amazon_region == ""
+
+    def test_get_metadata_provider_context(self) -> None:
+        user = SimpleNamespace(amazon_region="ca")
+
+        context = get_metadata_provider_context(user)
+
+        assert context["amazon_regions"] == constants.AMAZON_REGIONS
+        assert context["amazon_region"] == "ca"
+
+    def test_get_metadata_provider_context_with_explicit_values(self) -> None:
+        context = get_metadata_provider_context(amazon_region="de")
+
+        assert context["amazon_region"] == "de"
+
+    def test_get_effective_amazon_region_prefers_user_over_config(self) -> None:
+        user = SimpleNamespace(amazon_region="fr")
+
+        assert get_effective_amazon_region(user, config_amazon_region="de") == "fr"
+
+    def test_get_effective_amazon_region_uses_config_when_user_missing(self) -> None:
+        user = SimpleNamespace(amazon_region="")
+
+        assert get_effective_amazon_region(user, config_amazon_region="de") == "de"
+
+    def test_get_effective_amazon_region_falls_back_to_default(self) -> None:
+        user = SimpleNamespace(amazon_region="")
+
+        assert get_effective_amazon_region(user, config_amazon_region="not-real") == constants.AMAZON_REGIONS[0]


### PR DESCRIPTION
This PR refactors the base Metadata class to prepare for consolidating the various metadata providers into a more unified structure. The changes for now are effectively a no-op, since any metadata providers implementing the same function names just override what's here.

This PR includes commits from #1121 and its dependencies. Once those PRs are merged this should collapse to one commit. Check out the latest commit from the Commits tab to see just the changes for this PR.

PR stack:

* #1123
* #1122 👈
* #1121 
* #1120 
* #1119 
* #1116
* `main`