### PR TITLE
Expose custom columns as category elements in OPDS feed

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -437,6 +437,24 @@ class Books(Base):
         return self.timestamp.strftime('%Y-%m-%dT%H:%M:%S+00:00') or ''
 
     @property
+    def custom_extra_fill(self):
+        out = []
+        for col_id in cc_classes:
+            val = getattr(self, 'custom_column_' + str(col_id), None)
+            if val:
+                col_def = CalibreDB.session_factory().query(CustomColumns).filter(CustomColumns.id == col_id).first()
+                name = col_def.name if col_def else "Column {}".format(col_id)
+                values = val if isinstance(val, list) else [val]
+                for item in values:
+                    if hasattr(item, 'value'):
+                        out.append({
+                            'name': name,
+                            'value': item.value
+                        })
+        return out
+
+
+    @property
     def isbn(self):
         for identifier in self.identifiers:
             if identifier.type and identifier.type.lower() == "isbn":

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -63,6 +63,11 @@
               term="{{tag.name}}"
               label="{{tag.name}}"/>
     {% endfor %}
+    {% for cc in entry.Books.custom_extra_fill %}
+    <category scheme="custom_column:{{cc.name}}"
+              term="{{cc.name}}"
+              label="{{cc.value}}"/>
+    {% endfor %}
     {% if entry.Books.comments[0] %}<summary>{{entry.Books.comments[0].text|striptags}}</summary>{% endif %}
     {% if entry.Books.has_cover %}
     <link type="image/jpeg" href="{{url_for('opds.feed_get_cover', book_id=entry.Books.id)}}" rel="http://opds-spec.org/image"/>


### PR DESCRIPTION
The issue is part of https://github.com/crocodilestick/Calibre-Web-Automated/issues/882

Added custom column fields to the OPDS feed response using the Atom <category> element. Custom columns from the Calibre database are now exposed in the feed, allowing OPDS clients to read and filter by user-defined metadata.

**Changes**

Included custom column data in the OPDS <category> entries with term, label, and scheme attributes
Mapped Calibre custom column values to standard Atom category format for compatibility with OPDS readers

**Why**
Custom columns can contain useful metadata (e.g., read status, genre tags, source, page count, etc.) that wasn't previously available in the OPDS feed. This enables better filtering and organization in OPDS-compatible e-readers and clients.
