### PR TITLE
fix(cwasync): fix get progress sync error for some older KOReader versions

### DIFF
--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -3,6 +3,7 @@ local Device = require("device")
 local Dispatcher = require("dispatcher")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
+local Json = require("json")
 local Math = require("optmath")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local NetworkMgr = require("ui/network/manager")
@@ -749,6 +750,7 @@ function CWASync:getProgress(ensure_networking, interactive)
         function(ok, body)
             logger.dbg("CWASync: [Pull] progress for", self.view.document.file)
             logger.dbg("CWASync: ok:", ok, "body:", body)
+
             if not ok or not body then
                 if interactive then
                     showSyncError()
@@ -756,7 +758,22 @@ function CWASync:getProgress(ensure_networking, interactive)
                 return
             end
 
+            -- Some older KOReader Spore versions can return the raw JSON string
+            -- rather than a Lua table as the body.
+            if type(body) == "string" then
+                logger.dbg("CWASync: attempting to decode body payload as json string")
+                local decoded_ok, decoded_body = pcall(function()
+                    return Json.decode(body)
+                end)
+                body = decoded_body
+                if interactive and not decoded_ok then
+                    showSyncError()
+                    return
+                end
+            end
+
             if type(body) ~= "table" then
+                logger.dbg("CWASync: body is " .. type(body) .. " not a table")
                 if interactive then
                     showSyncError()
                 end
@@ -764,6 +781,7 @@ function CWASync:getProgress(ensure_networking, interactive)
             end
 
             if not body.percentage then
+                logger.dbg("CWASync: body.percentage missing")
                 if interactive then
                     UIManager:show(InfoMessage:new{
                         text = _("No progress found for this document."),
@@ -774,6 +792,7 @@ function CWASync:getProgress(ensure_networking, interactive)
             end
 
             if body.progress == nil then
+                logger.dbg("CWASync: body.progress missing")
                 if interactive then
                     showSyncError()
                 end

--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -760,7 +760,7 @@ function CWASync:getProgress(ensure_networking, interactive)
 
             -- Some older KOReader Spore versions can return the raw JSON string
             -- rather than a Lua table as the body.
-            if type(body) == "string" then
+            if type(body) == "string" and body:find("^(%s*){") ~= nil then
                 logger.dbg("CWASync: attempting to decode body payload as json string")
                 local decoded_ok, decoded_body = pcall(function()
                     return Json.decode(body)


### PR DESCRIPTION
KOReader includes a third-party `lua-Spore` library for handling http requests. The CWASync plugin uses this library for communication with the server (in `CWASyncClient.lua`). Some versions of this library did not properly handle the `content-type` of JSON responses, resulting in the `body` returned in the callback invoked by Spore being the raw JSON string rather than that payload properly converted into a Lua table. The plugin currently aborts if the `body` is not a table.

Here are some of the relevant events in the [history](https://github.com/koreader/koreader-base/commits/e3fb2a356a12d2dee12b547198aa6492f1bd853c/thirdparty/lua-Spore) of that `lua-Spore` dependency:

2025-05-07 lua-Spore <= 0.4.0
2025-05-08 koreader patch to fix content-type detection 2025-07-22 updated to lua-Spore 0.4.1 with a similar upstream fix for content-type detection
2026-02-03 patch for better json content-type recognition 2026-02-14 fix for that patch

It _looks_ like it was working after 2025-05-08 until 2025-07-22. And is working again now, after 2026-02-14. But outside of those ranges, the returned `body` may have been a string. With so many versions of KOReader out in the wild, we should improve our reliability by handling this anomaly.

This fix attempts to decode the body as JSON if it is a string rather than a table.

Also adds some additional debug logs to aid in diagnosing sync issues.

Edit: Now also adds a check that the body-as-string is plausibly JSON, since there are circumstances under which parsing non-JSON as JSON can cause a panic that crashes KOReader (even though that parsing happens in a `pcall()`). 