### PR TITLE
fix: set is_proxied=True when X-Forwarded-Proto header is present

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -2306,7 +2306,10 @@ def _configuration_update_helper():
         _config_checkbox_int(to_save, "config_public_reg")
         _config_checkbox_int(to_save, "config_register_email")
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
-        _config_int(to_save, "config_external_port")
+        if not to_save.get("config_external_port", "").strip():
+            config.config_external_port = None
+        else:
+            _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
         _config_checkbox_int(to_save, "config_hardcover_sync")
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -22,7 +22,7 @@ import subprocess
 import tempfile
 import fcntl
 
-from flask import Blueprint, flash, redirect, url_for, abort, request, make_response, send_from_directory, g, Response, jsonify
+from flask import Blueprint, current_app, flash, redirect, url_for, abort, request, make_response, send_from_directory, g, Response, jsonify
 from markupsafe import Markup
 from .cw_login import current_user
 from flask_babel import gettext as _
@@ -535,6 +535,7 @@ def admin():
                                  cwa_version=cwa_version, kepubify_version=kepubify_version,
                                  calibre_version=calibre_version, feature_support=feature_support,
                                  schedule_time=schedule_time, schedule_duration=schedule_duration,
+                                 is_proxied=current_app.wsgi_app.is_proxied,
                                  title=_("Admin page"), page="admin")
 
 
@@ -555,6 +556,7 @@ def configuration():
                                  config=config,
                                  provider=oauth_bb.oauthblueprints,
                                  feature_support=feature_support,
+                                 is_proxied=current_app.wsgi_app.is_proxied,
                                  title=_("Basic Configuration"), page="config")
 
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -62,7 +62,7 @@ class _Settings(_Base):
     config_calibre_uuid = Column(String)
     config_calibre_split = Column(Boolean, default=False)
     config_calibre_split_dir = Column(String)
-    config_external_port = Column(Integer, default=constants.DEFAULT_PORT)
+    config_external_port = Column(Integer, default=None)
     config_certfile = Column(String)
     config_keyfile = Column(String)
     config_trustedhosts = Column(String, default='')

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -39,7 +39,7 @@ import requests
 from . import config, logger, kobo_auth, db, calibre_db, helper, shelf as shelf_lib, ub, csrf, kobo_sync_status, magic_shelf
 from . import isoLanguages
 from .epub import get_epub_layout
-from .constants import COVER_THUMBNAIL_SMALL, COVER_THUMBNAIL_MEDIUM, COVER_THUMBNAIL_LARGE
+from .constants import COVER_THUMBNAIL_SMALL, COVER_THUMBNAIL_MEDIUM, COVER_THUMBNAIL_LARGE, DEFAULT_PORT
 from .kobo_cover_cache import build_cover_image_id, normalize_cover_uuid
 from .helper import get_download_link
 from .services import SyncToken as SyncToken, hardcover
@@ -483,7 +483,7 @@ def get_download_url_for_book(book_id, book_format):
         return "{url_scheme}://{url_base}:{url_port}/kobo/{auth_token}/download/{book_id}/{book_format}".format(
             url_scheme=request.scheme,
             url_base=host,
-            url_port=config.config_external_port,
+            url_port=config.config_external_port or DEFAULT_PORT,
             auth_token=get_auth_token(),
             book_id=book_id,
             book_format=book_format.lower()
@@ -1348,7 +1348,7 @@ def HandleInitRequest():
         calibre_web_url = "{url_scheme}://{url_base}:{url_port}".format(
             url_scheme=request.scheme,
             url_base=host,
-            url_port=config.config_external_port
+            url_port=config.config_external_port or DEFAULT_PORT
         )
         log.debug('Kobo: Received unproxied request, changed request url to %s', calibre_web_url)
         kobo_resources["image_host"] = calibre_web_url

--- a/cps/reverseproxy.py
+++ b/cps/reverseproxy.py
@@ -74,9 +74,10 @@ class ReverseProxied(object):
             if path_info and path_info.startswith(script_name):
                 environ['PATH_INFO'] = path_info[len(script_name):]
 
-        scheme = environ.get('HTTP_X_SCHEME', '')
+        scheme = environ.get('HTTP_X_SCHEME', '') or environ.get('HTTP_X_FORWARDED_PROTO', '')
         if scheme:
             environ['wsgi.url_scheme'] = scheme
+            self.proxied = True
         servr = environ.get('HTTP_X_FORWARDED_HOST', '')
         if servr:
             environ['HTTP_HOST'] = servr

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -119,8 +119,8 @@
             <div class="col-xs-6 col-sm-6">{{config.get_log_level()}}</div>
         </div>
         <div class="row">
-            <div class="col-xs-6 col-sm-6">{{_('Port')}}</div>
-            <div class="col-xs-6 col-sm-6">{{config.config_external_port}}</div>
+            <div class="col-xs-6 col-sm-6">{{_('External Port')}}</div>
+            <div class="col-xs-6 col-sm-6">{% if config.config_external_port %}{{ config.config_external_port }}{% elif is_proxied %}<em>{{ _('Not set — reverse proxy detected') }}</em>{% else %}8083{% endif %}</div>
         </div>
         {% if kobo_support and config.config_external_port != config.config_external_port %}
         <div class="row">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -209,7 +209,7 @@
       </div>
       <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
-        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if not is_proxied and config.config_external_port %}{{ config.config_external_port }}{% endif %}" autocomplete="off" placeholder="{% if is_proxied %}{{ _('Reverse proxy detected — likely unneeded') }}{% endif %}">
+        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{{ config.config_external_port or '' }}" autocomplete="off" placeholder="{% if is_proxied %}{{ _('Reverse proxy detected — likely unneeded') }}{% else %}8083{% endif %}">
       </div>
       <div class="form-group" style="margin-left:10px;">
         <input type="checkbox" id="config_hardcover_sync" name="config_hardcover_sync"  {% if config.config_hardcover_sync %}checked{% endif %}>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -209,8 +209,7 @@
       </div>
       <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
-        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port %}{{ config.config_external_port }}{% elif not is_proxied %}8083{% endif %}" autocomplete="off" placeholder="{% if is_proxied %}{{ _('Not required — reverse proxy detected') }}{% else %}8083{% endif %}">
-        {% if is_proxied %}<div class="help-block">{{_('A reverse proxy was detected. This field is only needed for direct port-forwarded access.')}}</div>{% endif %}
+        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if not is_proxied and config.config_external_port %}{{ config.config_external_port }}{% endif %}" autocomplete="off" placeholder="{% if is_proxied %}{{ _('Reverse proxy detected — likely unneeded') }}{% endif %}">
       </div>
       <div class="form-group" style="margin-left:10px;">
         <input type="checkbox" id="config_hardcover_sync" name="config_hardcover_sync"  {% if config.config_hardcover_sync %}checked{% endif %}>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -209,7 +209,8 @@
       </div>
       <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
-        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
+        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port %}{{ config.config_external_port }}{% elif not is_proxied %}8083{% endif %}" autocomplete="off" placeholder="{% if is_proxied %}{{ _('Not required — reverse proxy detected') }}{% else %}8083{% endif %}">
+        {% if is_proxied %}<div class="help-block">{{_('A reverse proxy was detected. This field is only needed for direct port-forwarded access.')}}</div>{% endif %}
       </div>
       <div class="form-group" style="margin-left:10px;">
         <input type="checkbox" id="config_hardcover_sync" name="config_hardcover_sync"  {% if config.config_hardcover_sync %}checked{% endif %}>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -209,7 +209,8 @@
       </div>
       <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
-        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{{ config.config_external_port or '' }}" autocomplete="off" placeholder="{% if is_proxied %}{{ _('Reverse proxy detected — likely unneeded') }}{% else %}8083{% endif %}">
+        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{{ config.config_external_port or '' }}" autocomplete="off" placeholder="8083">
+        {% if is_proxied %}<div class="help-block">{{_('A reverse proxy was detected. Leave blank unless you need to override the port for direct access.')}}</div>{% endif %}
       </div>
       <div class="form-group" style="margin-left:10px;">
         <input type="checkbox" id="config_hardcover_sync" name="config_hardcover_sync"  {% if config.config_hardcover_sync %}checked{% endif %}>


### PR DESCRIPTION
## Problem

When CWA is served through a **Cloudflare Tunnel** (or any reverse proxy that sends `X-Forwarded-Proto` without `X-Forwarded-Host`), the Kobo sync URL is generated with `localhost:8083` instead of the public HTTPS URL.

**Root cause:** `ReverseProxied.is_proxied` only returns `True` when `X-Forwarded-Host` or `X-Script-Name` headers are present. Cloudflare Tunnel sends `X-Forwarded-Proto: https` but **not** `X-Forwarded-Host`, so `is_proxied` stays `False`. This causes `kobo.py:get_download_url_for_book()` to fall back to an explicit `host:port` URL instead of the proxied public URL.

**Result:** Kobo sync silently breaks — books appear in the library but downloads fail because URLs have `:8083` appended (e.g. `https://books.example.com:8083/kobo/...`).

## My Setup

- Raspberry Pi running CWA in Docker
- Cloudflare Tunnel exposing it externally (no port forwarding)
- Kobo Clara BW syncing via the external URL

## Changes

### 1. `cps/reverseproxy.py` — Core fix

Also check `X-Forwarded-Proto` / `X-Scheme` when determining scheme, and set `self.proxied = True` whenever any proxy header is detected — consistent with the existing `X-Forwarded-Host` behaviour.

```python
# Before
scheme = environ.get('HTTP_X_SCHEME', '')
if scheme:
    environ['wsgi.url_scheme'] = scheme

# After
scheme = environ.get('HTTP_X_SCHEME', '') or environ.get('HTTP_X_FORWARDED_PROTO', '')
if scheme:
    environ['wsgi.url_scheme'] = scheme
    self.proxied = True
```

### 2. `cps/config_sql.py` — Schema default change

Changed `config_external_port` column default from `8083` to `None`. The old default of `8083` was misleading behind a proxy — it caused the port to always be appended to URLs even when it shouldn't be.

```python
config_external_port = Column(Integer, default=None)  # was default=constants.DEFAULT_PORT
```

### 3. `cps/kobo.py` — Runtime fallback

Fall back to `DEFAULT_PORT` (8083) at runtime when `config_external_port` is `None`, rather than relying on the DB default. This preserves the existing behavior for non-proxied setups.

```python
url_port = config.config_external_port or DEFAULT_PORT
```

### 4. `cps/admin.py` — Blank port handling + proxy context

- Passes `is_proxied` to `config_edit.html` and `admin.html` templates
- Handles blank External Port submission as `NULL` instead of crashing (`int('')` threw `ValueError`):

```python
if not to_save.get("config_external_port", "").strip():
    config.config_external_port = None
else:
    _config_int(to_save, "config_external_port")
```

### 5. `cps/templates/config_edit.html` — Port field UX

- Port field is no longer `required`; value is blank when `NULL`; placeholder shows `8083`
- Help text shown when proxy detected:
  > "A reverse proxy was detected. Leave blank unless you need to override the port for direct access."

### 6. `cps/templates/admin.html` — Config display

- Shows stored value if set
- Shows "Not set — reverse proxy detected" (italic) if proxied and not set
- Falls back to `8083` if not proxied and not set

## Background

This same bug exists in the original Calibre-Web. I've raised the core `reverseproxy.py` fix upstream: janeczku/calibre-web#3595. The additional changes here (config schema, admin handling, templates) are CWA-specific improvements to make the proxy experience cleaner.

## Verified

Tested end-to-end on a **fresh Docker install** behind a Cloudflare Tunnel:

| Test | Result |
|------|--------|
| Reverse proxy auto-detected via `X-Forwarded-Proto` | ✅ |
| Help text "A reverse proxy was detected..." shown on config page | ✅ |
| Port field blank by default with placeholder `8083` | ✅ |
| Config saves cleanly with blank port (previously crashed) | ✅ |
| Kobo Auth URL uses public hostname (`https://...`) | ✅ |
| Kobo download URLs use public hostname (not `localhost:8083`) | ✅ |
| E2E tested on fresh Docker install with empty library | ✅ |
| Kobo device sync confirmed — books downloaded to device (Kobo Clara BW) | ✅ |

---

**Note:** Python isn't my primary language so apologies if the implementation isn't idiomatic — happy to iterate based on feedback.