### PR TITLE
Fix Kobo sync failure with newer firmware: add OIDC discovery endpoint and fix OAuth routes

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1272,7 +1272,7 @@ def make_calibre_web_oauth_response():
         "token_type": "Bearer",
         "expires_in": 3600,
         "scope": content.get("scope", ""),
-        "user_id": content.get("user_id", ""),
+        "user_id": str(current_user.id) if current_user and not current_user.is_anonymous else content.get("user_id", ""),
         # Include legacy field names used by some Kobo requests
         "AccessToken": access_token,
         "RefreshToken": refresh_token,
@@ -1294,8 +1294,28 @@ def HandleAuthRequest():
     return make_calibre_web_auth_response()
 
 
+
+@csrf.exempt
+@kobo.route('/oauth/.well-known/openid-configuration', methods=['GET', 'POST'])
+@requires_kobo_auth
+def HandleOidcDiscovery():
+    base_url = url_for("kobo.HandleOauthRequest",
+                       auth_token=get_auth_token(),
+                       _external=True).rsplit("/oauth", 1)[0]
+    payload = {
+        'issuer': base_url,
+        'authorization_endpoint': base_url + '/oauth/authorize',
+        'token_endpoint': base_url + '/oauth/token',
+        'userinfo_endpoint': base_url + '/oauth/userinfo',
+        'response_types_supported': ['code'],
+        'subject_types_supported': ['public'],
+        'id_token_signing_alg_values_supported': ['RS256'],
+    }
+    return make_response(jsonify(payload))
+
 @csrf.exempt
 @kobo.route("/oauth/token", methods=["GET", "POST"])
+@kobo.route("/oauth/authorize", methods=["GET", "POST"])
 @kobo.route("/oauth/refresh", methods=["GET", "POST"])
 @kobo.route("/oauth/<path:subpath>", methods=["GET", "POST"])
 @requires_kobo_auth


### PR DESCRIPTION
## Problem

Newer Kobo firmware (tested on 4.45.23640) performs a full OIDC authentication 
flow before syncing. After `v1/initialization`, the device calls:

    GET /kobo/<token>/oauth/.well-known/openid-configuration

expecting a standard [OpenID Connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html).

CWA has no dedicated handler for this path, so it falls through to the catch-all 
`@kobo.route("/oauth/<path:subpath>")` which calls `make_calibre_web_oauth_response()`. 
This returns OAuth tokens instead of a discovery document. The Kobo rejects the 
response and retries indefinitely, resulting in **"Sync failed. Please try again."** 
on the device with no useful error in the logs.

Two additional issues compound the problem:
- `make_calibre_web_oauth_response()` reads `user_id` from `request.get_json()`, 
  which is `None` on GET requests, so it always returns `"user_id": ""` — the Kobo 
  rejects this and loops
- `/oauth/authorize` had no dedicated route, causing 308 redirects that looped

## Changes

**1. Add `HandleOidcDiscovery()`**

Dedicated route for `/oauth/.well-known/openid-configuration` that returns a 
proper OIDC discovery document using `url_for` + `get_auth_token()`, consistent 
with how other endpoints in the file build URLs.

**2. Add `/oauth/authorize` route to `HandleOauthRequest`**

Prevents 308 redirect loops when the Kobo follows the `authorization_endpoint` 
from the discovery document.

**3. Fix `user_id` in `make_calibre_web_oauth_response()`**

Use `current_user.id` instead of reading from the request body, which is always 
empty on GET requests.

## Testing

- CWA v4.0.6
- Kobo firmware 4.45.23640  
- Deployed behind nginx reverse proxy

Before: infinite loop on `oauth/.well-known/openid-configuration`, sync never completes.  
After: full OIDC flow completes, `v1/library/sync` is reached, books sync successfully.