### PR TITLE
Modify permission model of cwa-ingest-service

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -1,5 +1,10 @@
 #!/usr/bin/with-contenv bash
 
+# Drop privileges to abc (LinuxServer PUID/PGID user)
+if [ "$(id -u)" = "0" ]; then
+    exec s6-setuidgid abc "$0" "$@"
+fi
+
 echo "========== STARTING CWA-INGEST SERVICE =========="
 
 WATCH_FOLDER=$(grep -o '"ingest_folder": "[^"]*' /app/calibre-web-automated/dirs.json | grep -o '[^"]*$')
@@ -286,7 +291,7 @@ if [ -n "$(get_stale_temp_interval_from_db)" ]; then
 fi
 
 ( set -o pipefail
-        s6-setuidgid abc inotifywait -m -r --format="%e %w%f" -e close_write -e moved_to "$WATCH_FOLDER" | \
+        inotifywait -m -r --format="%e %w%f" -e close_write -e moved_to "$WATCH_FOLDER" | \
         while read -r events filepath; do
                 handle_event "$filepath"
         done


### PR DESCRIPTION
Per suggestion of @bcsteeve in #1128, modified permissions model of entire service to run as abc. Addressed my issue, submitting for review and testing.

To test, clone this PR locally, then add the following line to your compose file:

```
services:
  calibre-web-automated:
    ...
    volumes:
    ...
      - /path/to/local/repo/Calibre-Web-Automated/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service:/etc/s6-overlay/s6-rc.d/cwa-ingest-service
...
```

and restart your container.