### PR TITLE
fix(kobo): some annotations might not sync to hardcover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,15 +122,15 @@ RUN \
 # STEP 4 - Install kepubify
 RUN \
   echo "**** install kepubify ****" && \
-  if [[ $KEPUBIFY_RELEASE == 'newest' ]]; then \
+  if [ "$KEPUBIFY_RELEASE" = 'newest' ]; then \
   KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/pgaskin/kepubify/releases/latest" \
   | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
-  if [ "$(uname -m)" == "x86_64" ]; then \
+  if [ "$(uname -m)" = "x86_64" ]; then \
   curl -o \
   /usr/bin/kepubify -L \
   https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit; \
-  elif [ "$(uname -m)" == "aarch64" ]; then \
+  elif [ "$(uname -m)" = "aarch64" ]; then \
   curl -o \
   /usr/bin/kepubify -L \
   https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64; \
@@ -142,11 +142,11 @@ RUN \
   # STEP 5.1 - Make the /app/calibre directory for the installed files
   mkdir -p /app/calibre && \
   # STEP 5.2 - Download the desired version of Calibre, determined by the CALIBRE_RELEASE variable and the architecture of the build environment
-  if [ "$(uname -m)" == "x86_64" ]; then \
+  if [ "$(uname -m)" = "x86_64" ]; then \
   curl -o \
   /calibre.txz -L \
   "https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-x86_64.txz"; \
-  elif [ "$(uname -m)" == "aarch64" ]; then \
+  elif [ "$(uname -m)" = "aarch64" ]; then \
   curl -o \
   /calibre.txz -L \
   "https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-arm64.txz"; \

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -2351,6 +2351,7 @@ def _configuration_update_helper():
         # Hardcover configuration
         _config_checkbox(to_save, "config_hardcover_sync")
         _config_checkbox(to_save, "config_hardcover_annotations_sync")
+        _config_checkbox(to_save, "config_kobo_device_id_auth")
         _config_string(to_save, "config_hardcover_token")
 
         _config_int(to_save, "config_updatechannel")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -94,6 +94,8 @@ class _Settings(_Base):
     config_hardcover_sync = Column(Boolean, default=False) 
     # Sync annotations to Hardcover
     config_hardcover_annotations_sync = Column(Boolean, default=False)
+    # Use Kobo device ID for auth when session cookie is expired
+    config_kobo_device_id_auth = Column(Boolean, default=False)
 
     config_default_role = Column(SmallInteger, default=0)
     config_default_show = Column(SmallInteger, default=constants.ADMIN_USER_SIDEBAR)

--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -64,6 +64,62 @@ from .usermanagement import user_login_required
 
 log = logger.create()
 
+# In-memory cache of Kobo device ID -> user ID.
+# Populated during kobo auth (URL token), used as fallback for reading services
+# auth when session cookie is expired/missing (e.g. offline annotation sync).
+# Falls back to DB lookup on cache miss (e.g. after server restart).
+_device_user_cache = {}
+
+
+def register_kobo_device(device_id, user_id, auth_token):
+    """Register device-to-user mapping in both cache and database.
+
+    If the device ID for this auth token has changed (e.g. user got a new device),
+    the stored value is updated and the change is logged.
+    """
+    if not device_id:
+        return
+    _device_user_cache[device_id] = user_id
+    try:
+        token_record = ub.session.query(ub.RemoteAuthToken).filter(
+            ub.RemoteAuthToken.auth_token == auth_token,
+            ub.RemoteAuthToken.token_type == 1
+        ).first()
+        if token_record:
+            if token_record.device_id != device_id:
+                if token_record.device_id:
+                    log.info("Kobo device ID changed for user %s: %s -> %s",
+                             user_id, token_record.device_id, device_id)
+                else:
+                    log.debug("Storing Kobo device ID for user %s: %s", user_id, device_id)
+                token_record.device_id = device_id
+                ub.session_commit()
+    except Exception as e:
+        log.error("Failed to persist Kobo device ID mapping: %s", e)
+        ub.session.rollback()
+
+
+def get_user_id_for_device(device_id):
+    """Look up user ID by Kobo device ID. Checks in-memory cache first, then DB."""
+    if not device_id:
+        return None
+    user_id = _device_user_cache.get(device_id)
+    if user_id:
+        return user_id
+    # Cache miss, fetch from the DB and update the cache
+    try:
+        token_record = ub.session.query(ub.RemoteAuthToken).filter(
+            ub.RemoteAuthToken.device_id == device_id,
+            ub.RemoteAuthToken.token_type == 1
+        ).first()
+        if token_record:
+            _device_user_cache[device_id] = token_record.user_id
+            return token_record.user_id
+    except Exception as e:
+        log.error("Failed to look up Kobo device ID mapping from DB: %s", e)
+    return None
+
+
 kobo_auth = Blueprint("kobo_auth", __name__, url_prefix="/kobo_auth")
 
 
@@ -157,6 +213,8 @@ def requires_kobo_auth(f):
             )
             if user is not None:
                 login_user(user)
+                device_id = request.headers.get('X-Kobo-Deviceid')
+                register_kobo_device(device_id, user.id, auth_token)
                 [limiter.limiter.storage.clear(k.key) for k in limiter.current_limits]
                 return f(*args, **kwargs)
         log.debug("Received Kobo request without a recognizable auth token.")

--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -74,10 +74,13 @@ _device_user_cache = {}
 def register_kobo_device(device_id, user_id, auth_token):
     """Register device-to-user mapping in both cache and database.
 
+    Only stores the device ID if config_kobo_device_id_auth is enabled.
     If the device ID for this auth token has changed (e.g. user got a new device),
     the stored value is updated and the change is logged.
     """
     if not device_id:
+        return
+    if not config.config_kobo_device_id_auth:
         return
     _device_user_cache[device_id] = user_id
     try:
@@ -100,8 +103,11 @@ def register_kobo_device(device_id, user_id, auth_token):
 
 
 def get_user_id_for_device(device_id):
-    """Look up user ID by Kobo device ID. Checks in-memory cache first, then DB."""
+    """Look up user ID by Kobo device ID. Checks in-memory cache first, then DB.
+    Returns None if device ID auth is disabled."""
     if not device_id:
+        return None
+    if not config.config_kobo_device_id_auth:
         return None
     user_id = _device_user_cache.get(device_id)
     if user_id:

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -26,7 +26,7 @@ import requests
 from lxml import etree
 
 from . import logger, calibre_db, db, config, ub, csrf
-from .cw_login import current_user, login_required
+from .cw_login import current_user, login_required, login_user
 from .services import hardcover
 
 log = logger.create()
@@ -135,10 +135,23 @@ def requires_reading_services_auth_and_config(f):
         # Check if user is authenticated (cookie from Kobo sync)
         if current_user.is_authenticated:
             return f(*args, **kwargs)
-        else:
-            # User not authenticated - just proxy to Kobo
-            log.debug("Reading services request without auth, proxying to Kobo")
-            return proxy_to_kobo_reading_services()
+
+        # Fallback: authenticate via X-Kobo-Deviceid header mapping
+        # This handles scenarios where the session cookie is expired/missing
+        device_id = request.headers.get('X-Kobo-Deviceid')
+        if device_id:
+            from .kobo_auth import get_user_id_for_device
+            user_id = get_user_id_for_device(device_id)
+            if user_id:
+                user = ub.session.query(ub.User).filter(ub.User.id == user_id).first()
+                if user:
+                    login_user(user)
+                    log.debug("Reading services: authenticated user %s via device ID mapping", user.name)
+                    return f(*args, **kwargs)
+
+        # User not authenticated - just proxy to Kobo
+        log.debug("Reading services request without auth, proxying to Kobo")
+        return proxy_to_kobo_reading_services()
     return decorated_function
 
 
@@ -485,6 +498,89 @@ def process_annotation_for_sync(
     
 
 
+def process_annotation_patch(entitlement_id):
+    """Process a PATCH request for annotations, syncing changes to Hardcover."""
+    try:
+        data = request.get_json()
+        log_annotation_data(entitlement_id, "PATCH", data)
+
+        # Get book from database
+        book = get_book_by_entitlement_id(entitlement_id)
+        if not book:
+            log.warning(f"Book not found for entitlement {entitlement_id}, skipping Hardcover sync")
+            return
+
+        identifiers = get_book_identifiers(book)
+
+        if data and "deletedAnnotationIds" in data:
+            deleted_ids = data["deletedAnnotationIds"]
+            log.info(f"Processing {len(deleted_ids)} deleted annotation IDs")
+            for annotation_id in deleted_ids:
+                sync_record = ub.session.query(ub.KoboAnnotationSync).filter(
+                    ub.KoboAnnotationSync.annotation_id == annotation_id,
+                    ub.KoboAnnotationSync.user_id == current_user.id
+                ).first()
+                if sync_record:
+                    try:
+                        hardcover_client = hardcover.HardcoverClient(current_user.hardcover_token)
+                        deleted_id = hardcover_client.delete_journal_entry(journal_id=sync_record.hardcover_journal_id)
+                        if deleted_id == sync_record.hardcover_journal_id:
+                            try:
+                                ub.session.delete(sync_record)
+                                ub.session_commit()
+                                log.info(f"Successfully deleted journal entry {sync_record.hardcover_journal_id} from Hardcover and local DB")
+                            except Exception as db_error:
+                                log.error(f"Failed to delete local sync record after Hardcover deletion succeeded: {db_error}")
+                                log.error(f"Annotation {annotation_id} deleted from Hardcover but DB record remains - manual cleanup may be needed")
+                                ub.session.rollback()
+                        else:
+                            log.warning(f"Failed to delete journal entry {sync_record.hardcover_journal_id} from Hardcover - keeping local record")
+                    except Exception as api_error:
+                        log.error(f"Error deleting annotation {annotation_id} from Hardcover: {api_error}")
+                        # Don't delete local record if Hardcover deletion failed
+                else:
+                    log.warning(f"Sync record not found for annotation {annotation_id}, skipping deletion")
+
+        # Extract updated annotations
+        if data and "updatedAnnotations" in data:
+            annotations = data['updatedAnnotations']
+            log.info(f"Processing {len(annotations)} updated annotations")
+
+            # Batch load existing sync records to avoid N+1 queries
+            existing_syncs = {}
+            annotation_ids = [a.get('id') for a in annotations if a.get('id')]
+            if annotation_ids:
+                syncs = ub.session.query(ub.KoboAnnotationSync).filter(
+                    ub.KoboAnnotationSync.annotation_id.in_(annotation_ids),
+                    ub.KoboAnnotationSync.user_id == current_user.id
+                ).all()
+                existing_syncs = {s.annotation_id: s for s in syncs}
+
+            # Check blacklist once per book
+            book_blacklist = ub.session.query(ub.HardcoverBookBlacklist).filter(
+                ub.HardcoverBookBlacklist.book_id == book.id
+            ).first()
+            is_blacklisted = book_blacklist and book_blacklist.blacklist_annotations
+
+            # Initialize progress calculator once per book
+            progress_calculator = EpubProgressCalculator(book)
+
+            for annotation in annotations:
+                process_annotation_for_sync(
+                    annotation=annotation,
+                    book=book,
+                    identifiers=identifiers,
+                    existing_syncs=existing_syncs,
+                    progress_calculator=progress_calculator,
+                    is_blacklisted=is_blacklisted
+                )
+
+    except Exception as e:
+        log.error(f"Error processing PATCH annotations: {e}")
+        import traceback
+        log.error(traceback.format_exc())
+
+
 @csrf.exempt
 @readingservices_api_v3.route("/content/<entitlement_id>/annotations", methods=["GET", "PATCH"])
 @requires_reading_services_auth_and_config
@@ -497,84 +593,7 @@ def handle_annotations(entitlement_id):
     # GET requests are proxied directly to Kobo at the end of the function
     # We only intercept PATCH requests to sync changes to Hardcover
     if request.method == "PATCH":
-        try:
-            data = request.get_json()
-            log_annotation_data(entitlement_id, "PATCH", data)
-
-            # Get book from database
-            book = get_book_by_entitlement_id(entitlement_id)
-            if not book:
-                log.warning(f"Book not found for entitlement {entitlement_id}, skipping Hardcover sync")
-            else:
-                identifiers = get_book_identifiers(book)
-
-                if data and "deletedAnnotationIds" in data:
-                    deleted_ids = data["deletedAnnotationIds"]
-                    log.info(f"Processing {len(deleted_ids)} deleted annotation IDs")
-                    for annotation_id in deleted_ids:
-                        sync_record = ub.session.query(ub.KoboAnnotationSync).filter(
-                            ub.KoboAnnotationSync.annotation_id == annotation_id,
-                            ub.KoboAnnotationSync.user_id == current_user.id
-                        ).first()
-                        if sync_record:
-                            try:
-                                hardcover_client = hardcover.HardcoverClient(current_user.hardcover_token)
-                                deleted_id = hardcover_client.delete_journal_entry(journal_id=sync_record.hardcover_journal_id)
-                                if deleted_id == sync_record.hardcover_journal_id:
-                                    try:
-                                        ub.session.delete(sync_record)
-                                        ub.session_commit()
-                                        log.info(f"Successfully deleted journal entry {sync_record.hardcover_journal_id} from Hardcover and local DB")
-                                    except Exception as db_error:
-                                        log.error(f"Failed to delete local sync record after Hardcover deletion succeeded: {db_error}")
-                                        log.error(f"Annotation {annotation_id} deleted from Hardcover but DB record remains - manual cleanup may be needed")
-                                        ub.session.rollback()
-                                else:
-                                    log.warning(f"Failed to delete journal entry {sync_record.hardcover_journal_id} from Hardcover - keeping local record")
-                            except Exception as api_error:
-                                log.error(f"Error deleting annotation {annotation_id} from Hardcover: {api_error}")
-                                # Don't delete local record if Hardcover deletion failed
-                        else:
-                            log.warning(f"Sync record not found for annotation {annotation_id}, skipping deletion")
-            
-                # Extract updated annotations
-                if data and "updatedAnnotations" in data:
-                    annotations = data['updatedAnnotations']
-                    log.info(f"Processing {len(annotations)} updated annotations")
-                
-                    # Batch load existing sync records to avoid N+1 queries
-                    existing_syncs = {}
-                    annotation_ids = [a.get('id') for a in annotations if a.get('id')]
-                    if annotation_ids:
-                        syncs = ub.session.query(ub.KoboAnnotationSync).filter(
-                            ub.KoboAnnotationSync.annotation_id.in_(annotation_ids),
-                            ub.KoboAnnotationSync.user_id == current_user.id
-                        ).all()
-                        existing_syncs = {s.annotation_id: s for s in syncs}
-                    
-                    # Check blacklist once per book
-                    book_blacklist = ub.session.query(ub.HardcoverBookBlacklist).filter(
-                        ub.HardcoverBookBlacklist.book_id == book.id
-                    ).first()
-                    is_blacklisted = book_blacklist and book_blacklist.blacklist_annotations
-
-                    # Initialize progress calculator once per book
-                    progress_calculator = EpubProgressCalculator(book)
-
-                    for annotation in annotations:
-                        process_annotation_for_sync(
-                            annotation=annotation, 
-                            book=book, 
-                            identifiers=identifiers, 
-                            existing_syncs=existing_syncs,
-                            progress_calculator=progress_calculator,
-                            is_blacklisted=is_blacklisted
-                        )
-
-        except Exception as e:
-            log.error(f"Error processing PATCH annotations: {e}")
-            import traceback
-            log.error(traceback.format_exc())
+        process_annotation_patch(entitlement_id)
 
     # Proxy to Kobo reading services
     return proxy_to_kobo_reading_services()

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -219,6 +219,10 @@
         <input type="checkbox" id="config_hardcover_annotations_sync" name="config_hardcover_annotations_sync"  {% if config.config_hardcover_annotations_sync %}checked{% endif %}>
         <label for="config_hardcover_annotations_sync">{{_('Sync Kobo annotations to Hardcover (Requires API key per user)')}}</label>
       </div>
+      <div class="form-group" style="margin-left:10px;">
+        <input type="checkbox" id="config_kobo_device_id_auth" name="config_kobo_device_id_auth"  {% if config.config_kobo_device_id_auth %}checked{% endif %}>
+        <label for="config_kobo_device_id_auth">{{_('Use Kobo device ID for authentication (enables offline annotation sync)')}}</label>
+      </div>
     </div>
     {% endif %}
     {% if feature_support['goodreads'] %}

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -720,6 +720,7 @@ class RemoteAuthToken(Base):
     verified = Column(Boolean, default=False)
     expiration = Column(DateTime)
     token_type = Column(Integer, default=0)
+    device_id = Column(String, default=None)
 
     def __init__(self):
         super().__init__()
@@ -1037,6 +1038,15 @@ def migrate_magic_shelf_table(engine, _session):
         _run_ddl_with_retry(engine, "ALTER TABLE magic_shelf ADD column 'kobo_sync' Boolean DEFAULT 0")
 
 
+def migrate_remote_auth_token_table(engine, _session):
+    try:
+        _session.query(exists().where(RemoteAuthToken.device_id)).scalar()
+        _session.commit()
+    except exc.OperationalError:
+        _safe_session_rollback(_session, "remote_auth_token.device_id")
+        _run_ddl_with_retry(engine, "ALTER TABLE remote_auth_token ADD column 'device_id' String DEFAULT NULL")
+
+
 # Migrate database to current version, has to be updated after every database change. Currently migration from
 # maybe 4/5 versions back to current should work.
 # Migration is done by checking if relevant columns are existing, and then adding rows with SQL commands
@@ -1049,6 +1059,7 @@ def migrate_Database(_session):
     migrate_oauth_provider_table(engine, _session)
     migrate_config_table(engine, _session)
     migrate_magic_shelf_table(engine, _session)
+    migrate_remote_auth_token_table(engine, _session)
 
     # Ensure progress syncing tables in app.db (user-related tables)
     from .progress_syncing.models import ensure_app_db_tables


### PR DESCRIPTION
This patch fixes an issue where if the flask token is expired the annotations are not synced to hardcover. 

The kobo device sends requests to the base url of the `reading_services_host` without the token and hence we have no means to ID the user.

This patch stores the device ID of the kobo alongside the token in the DB and uses a in-memory map as a fast path lookup (we can get rid of it if we want).

So when a request is received and the flask token is expired, we try logging in again by ID-ing the user from the kobo device token, ensuring the annotations are always sent to hardcover.

Previously, if we missed an annotation, kobo device still assumed that the annotation is in sync with reading services and hence never sent the same annotation twice, leading to it being lost in the void.

An admin option is also added to disable auth using kobo device IDs.