### PR TITLE
fix: add global CSRF token to layout.html for caliBlur quick-send

### DIFF
--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -91,6 +91,7 @@
     </script>
   </head>
   <body class="{{ page }} {{ bodyClass }}{% if g.current_theme == 1 %} blur{% endif %}{% if cwa_settings and cwa_settings.get('enable_mobile_blur') %} allow-mobile-blur{% endif %}" data-text="{{_('Home')}}" data-textback="{{_('Back')}}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Static navbar -->
     <div class="navbar navbar-default navbar-static-top" role="navigation">
       <div class="container-fluid">


### PR DESCRIPTION
## Fix: caliBlur quick-send-to-eReader fails with CSRF error for non-upload users

### Problem

The caliBlur theme's quick-send-to-eReader button (the overlay icon on book covers in grid view) fails with the error:

> Error sending to eReader. Please check your configuration and ensure you have email addresses set up.

The server logs show:

```
INFO {flask_wtf.csrf:263} The CSRF token is invalid.
```

This affects all users who do not have the Upload role, across all browse pages (shelves, books, authors, etc.). Sending from the individual book detail page still works.

### Root Cause

The caliBlur quick-send handler in `caliBlur.js` retrieves the CSRF token with:

```js
'csrf_token': $('input[name="csrf_token"]').val() || '',
```

The only `csrf_token` hidden input in `layout.html` is inside the upload form, which is gated by:

```jinja
{% if current_user.role_upload() and g.allow_upload %}
```

For users without upload permission, no CSRF token exists anywhere in the DOM. The JS falls back to an empty string, and Flask rejects the request.

### Fix

Adds a global hidden CSRF input immediately after the `<body>` tag in `layout.html`, outside any conditional blocks. This makes the token available to all JavaScript on every page, regardless of user role or active theme.

### Testing

Verified on `crocodilestick/calibre-web-automated:latest` (image date 2026-02-03):

- **Before fix:** Quick-send from shelf/browse grid → CSRF error, send fails
- **After fix:** Quick-send from shelf/browse grid → email sent successfully
- **No regression:** Send from book detail page (both modal and direct) continues to work
- **No regression:** Test email from admin settings continues to work