### PR TITLE
feat(kobo): add highlight color to annotation tags

### DIFF
--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -435,7 +435,8 @@ def process_annotation_for_sync(
                         note_text=note_text,
                         progress_percent=progress_percent,
                         progress_page=progress_page,
-                        highlighted_text=highlighted_text
+                        highlighted_text=highlighted_text,
+                        highlight_color=highlight_color
                     )
                 
                 if result:

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -220,7 +220,7 @@ class HardcoverClient:
         return response.get("update_user_book", {}).get("user_book", {})
 
 
-    def add_journal_entry(self, identifiers, note_text, progress_percent=None, progress_page=None, highlighted_text=None):
+    def add_journal_entry(self, identifiers, note_text, progress_percent=None, progress_page=None, highlighted_text=None, highlight_color=None):
         """
         Add a journal entry (reading note) to Hardcover.
 
@@ -321,6 +321,10 @@ class HardcoverClient:
             ],
             "metadata": metadata if metadata else None
         }
+
+        # Add the highlight color as a tag
+        if highlight_color:
+            variables["tags"].append({"tag": highlight_color, "category": "general", "spoiler": False})
 
         try:
             response = self.execute(query=mutation, variables=variables)


### PR DESCRIPTION
This patch adds a tag matching the highlight color when syncing the annotations to Hardcover.