### PR TITLE
feat: add NETWORK_SHARE_MODE=localdb for local DB + network share setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,21 +88,21 @@ ___
 
 ## 🚨 Deploying on Network Shares (NFS/SMB) 🚨
 
-- CWA now supports network-share deployments via `NETWORK_SHARE_MODE=true`
-  - This disables SQLite WAL on `metadata.db` and `app.db` to prevent locking issues
-  - Skips recursive ownership changes that often fail on NFS/SMB
-  - Switches ingest/metadata watchers to a polling-based watcher for reliability
-- Network shares are still slower than local disks, but are now fully supported with this mode enabled
+- CWA now supports network-share deployments via `NETWORK_SHARE_MODE`:
+  - `true` — Full network share mode: disables SQLite WAL, skips recursive `chown`, uses polling watchers
+  - `localdb` — For setups where your **database is on local storage** but book files are on a network share: keeps WAL enabled for better concurrency, while still skipping `chown` and using polling watchers
+- Network shares are still slower than local disks, but are now fully supported with these modes
 
 ### Network shares and SQLite WAL mode
 
 - CWA optimizes SQLite concurrency by enabling Write-Ahead Logging (WAL) on local disks.
 - Some network filesystems (NFS/SMB) do not fully support WAL or reliable file locking, which can cause intermittent "database is locked" errors or corruption risks.
-- If you are deploying on a network share, set the following environment variable to disable WAL:
+- Choose the right mode for your setup:
 
-  - `NETWORK_SHARE_MODE=true`
+  - `NETWORK_SHARE_MODE=true` — Use when your database (`metadata.db`) is on a network share. Disables WAL to prevent locking issues.
+  - `NETWORK_SHARE_MODE=localdb` — Use when your database is on local storage but your book files are on a network share. Keeps WAL enabled for better performance while still handling NFS/SMB file permission and watching quirks.
 
-This tells CWA to avoid enabling WAL on the Calibre `metadata.db` and the `app.db` settings database. It also disables recursive ownership changes (`chown`) performed by init/maintenance scripts to avoid permission issues on network filesystems. Default is `false` (WAL enabled) for better performance on local disks.
+Both modes disable recursive ownership changes (`chown`) on mount paths and switch file watchers to polling. Default is `false` (WAL enabled, chown enabled, inotify watching) for fully local setups.
 
 #### File watching on network shares
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -719,9 +719,12 @@ class CalibreDB:
                 connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
                 # Try enabling WAL to improve concurrency unless running on a network share
                 # Controlled by env var NETWORK_SHARE_MODE (default False)
+                # localdb = DB is local but files on network share, so WAL is safe
                 try:
-                    nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
-                    if not nsm and db_writable:
+                    nsm_raw = os.getenv('NETWORK_SHARE_MODE', 'false').strip().lower()
+                    nsm = nsm_raw in ('1', 'true', 'yes', 'on', 'localdb')
+                    local_db = nsm_raw == 'localdb'
+                    if (not nsm or local_db) and db_writable:
                         connection.execute(text("PRAGMA calibre.journal_mode=WAL"))
                         connection.execute(text("PRAGMA app_settings.journal_mode=WAL"))
                     else:
@@ -779,9 +782,14 @@ class CalibreDB:
                     connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
                     # Try enabling WAL to improve concurrency unless running on a network share
                     # Controlled by env var NETWORK_SHARE_MODE (default False)
+                    # localdb = DB is local but files on network share, so WAL is safe
                     try:
-                        nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
-                        if not nsm and db_writable:
+                        nsm_raw = os.getenv('NETWORK_SHARE_MODE', 'false').strip().lower()
+                        nsm = nsm_raw in ('1', 'true', 'yes', 'on', 'localdb')
+                        local_db = nsm_raw == 'localdb'
+                        if local_db:
+                            log.info("NETWORK_SHARE_MODE=localdb: WAL enabled (local DB), chown/polling in network share mode")
+                        if (not nsm or local_db) and db_writable:
                             connection.execute(text("PRAGMA calibre.journal_mode=WAL"))
                             connection.execute(text("PRAGMA app_settings.journal_mode=WAL"))
                         else:
@@ -828,9 +836,12 @@ class CalibreDB:
             # Ensure progress syncing tables exist in metadata.db (book checksums)
             from .progress_syncing.models import ensure_calibre_db_tables
             from .progress_syncing.settings import is_koreader_sync_enabled
+            nsm_raw = os.getenv('NETWORK_SHARE_MODE', 'false').strip().lower()
+            nsm = nsm_raw in ('1', 'true', 'yes', 'on', 'localdb')
+            local_db = nsm_raw == 'localdb'
             if (
                 db_writable
-                and not os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+                and (not nsm or local_db)
                 and is_koreader_sync_enabled()
             ):
                 ensure_calibre_db_tables(conn)

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -387,14 +387,14 @@ def _get_ingest_path(uploaded_file, prefix_parts=None):
         raise
     # Ensure proper ownership of ingest directory (fix for issue #603)
     try:
-        nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+        nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
         if not (nsm and ingest_dir == "/cwa-book-ingest"):
             # Set ownership to abc:abc (uid=1000, gid=1000)
             os.chown(ingest_dir, 1000, 1000)
     except (OSError, PermissionError) as e:
         # Log warning but don't crash the upload process
         log.warning('Failed to set ownership of ingest directory %s: %s', ingest_dir, e)
-        log.warning("If you're using a network share, consider setting NETWORK_SHARE_MODE=true in your environment variables to skip this step.")
+        log.warning("If you're using a network share, consider setting NETWORK_SHARE_MODE=true (or localdb if your DB is local) to skip this step.")
     except Exception as e:
         # Silently ignore any other permission-related errors but log for debugging
         log.debug('Other permission error setting ingest directory ownership: %s', e)

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1257,8 +1257,10 @@ def _healthcheck_app_db(app_db_path: str) -> None:
             return
         if not os.access(app_db_path, os.W_OK):
             log.error("app.db is not writable: %s", app_db_path)
-        network_share_mode = os.environ.get("NETWORK_SHARE_MODE", "false").lower() in ("1", "true", "yes")
-        if network_share_mode:
+        nsm_raw = os.environ.get("NETWORK_SHARE_MODE", "false").strip().lower()
+        nsm = nsm_raw in ("1", "true", "yes", "on", "localdb")
+        local_db = nsm_raw == "localdb"
+        if nsm and not local_db:
             log.info("Skipping PRAGMA quick_check for app.db due to NETWORK_SHARE_MODE=true")
             return
         try:

--- a/cps/updater.py
+++ b/cps/updater.py
@@ -206,7 +206,7 @@ class Updater(threading.Thread):
         change_permissions = not (sys.platform == "win32" or sys.platform == "darwin")
         # Only skip permission changes for network-share paths
         try:
-            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
         except Exception:
             nsm = False
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,10 @@ services:
       # - CWA_PORT_OVERRIDE=8083
       # Hardcover API Key required for Hardcover as a Metadata Provider, get one here: https://docs.hardcover.app/api/getting-started/
       - HARDCOVER_TOKEN=your_hardcover_api_key_here
-      # If your library is on a network share (e.g., NFS/SMB), disables WAL and chown to reduce locking/permission issues,
-      # and switches file watching to polling (more reliable on network mounts) instead of inotify.
-      # Accepts: true/false (default: false)
+      # If your library is on a network share (e.g., NFS/SMB).
+      # - true: disables WAL, skips chown, uses polling (full network share mode)
+      # - localdb: keeps WAL enabled (DB is local), skips chown, uses polling
+      # - false: default, everything local
       - NETWORK_SHARE_MODE=false
       # If you want to force polling mode regardless of share type, set CWA_WATCH_MODE=poll
       # - CWA_WATCH_MODE=poll

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -13,9 +13,10 @@ services:
       # - CWA_PORT_OVERRIDE=8083
       # Hardcover API Key required for Hardcover as a Metadata Provider, get one here: https://docs.hardcover.app/api/getting-started/
       - HARDCOVER_TOKEN=your_hardcover_api_key_here
-      # If your library is on a network share (e.g., NFS/SMB), disables WAL and chown to reduce locking/permission issues,
-      # and switches file watching to polling (more reliable on network mounts) instead of inotify.
-      # Accepts: true/false (default: false)
+      # If your library is on a network share (e.g., NFS/SMB).
+      # - true: disables WAL, skips chown, uses polling (full network share mode)
+      # - localdb: keeps WAL enabled (DB is local), skips chown, uses polling
+      # - false: default, everything local
       - NETWORK_SHARE_MODE=false
       # If you want to force polling mode regardless of share type, set CWA_WATCH_MODE=poll
       # - CWA_WATCH_MODE=poll

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -256,7 +256,7 @@ handle_event() {
         echo "idle" > "$STATUS_FILE"
 }
 
-if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
+if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ] || [ "${NETWORK_SHARE_MODE,,}" = "localdb" ]; then
         echo "[cwa-ingest-service] NETWORK_SHARE_MODE=true -> using fallback watcher"
         run_fallback; exit 0
 fi

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -56,7 +56,7 @@ fi
 mkdir -p /app/calibre-web-automated/cps/cache
 
 # permissions (skip chown on network shares for bind mounts, but still fix /app)
-if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
+if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ] || [ "${NETWORK_SHARE_MODE,,}" = "localdb" ]; then
   echo "[cwa-init] NETWORK_SHARE_MODE=true detected; skipping initial chown of /config"
   chown -R abc:abc /app/calibre-web-automated/cps/cache
 else
@@ -109,7 +109,7 @@ if [ -n "$INGEST_DIR" ]; then
   # Create directory if missing
   install -d -o abc -g abc "$INGEST_DIR" 2>/dev/null || mkdir -p "$INGEST_DIR" 2>/dev/null || true
   # Set ownership unless network share mode (only skip for /cwa-book-ingest)
-  if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
+  if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ] || [ "${NETWORK_SHARE_MODE,,}" = "localdb" ]; then
     if [ "$INGEST_DIR" = "/cwa-book-ingest" ]; then
       echo "[cwa-init] NETWORK_SHARE_MODE=true detected; skipping chown of $INGEST_DIR"
     else
@@ -265,7 +265,7 @@ dirs=${dirs:1}
 echo "[cwa-init] Preparing to set ownership of everything in$dirs to abc:abc..."
 
 for d in "${requiredDirs[@]}"; do
-  if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
+  if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ] || [ "${NETWORK_SHARE_MODE,,}" = "localdb" ]; then
     case "$d" in
       /config|/config/*|/calibre-library|/calibre-library/*|/cwa-book-ingest|/cwa-book-ingest/*)
         echo "[cwa-init] NETWORK_SHARE_MODE=true detected; skipping chown of $d"

--- a/root/etc/s6-overlay/s6-rc.d/metadata-change-detector/run
+++ b/root/etc/s6-overlay/s6-rc.d/metadata-change-detector/run
@@ -41,7 +41,7 @@ is_docker_desktop() {
 }
 
 # Prefer polling when running over network shares to better handle NFS/SMB semantics
-if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
+if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ] || [ "${NETWORK_SHARE_MODE,,}" = "localdb" ]; then
         echo "[metadata-change-detector] NETWORK_SHARE_MODE=true detected; using polling watcher instead of inotify"
         run_fallback
         exit 0

--- a/scripts/auto_library.py
+++ b/scripts/auto_library.py
@@ -59,7 +59,7 @@ class AutoLibrary:
             print(f"[cwa-auto-library] No app.db found in {self.config_dir}, copying from /app/calibre-web-automated/empty_library/app.db")
             shutil.copyfile(self.empty_appdb, f"{self.config_dir}/app.db")
             try:
-                nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+                nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
                 if not nsm:
                     subprocess.run(["chown", "-R", "abc:abc", self.config_dir], check=True)
                 else:
@@ -147,7 +147,7 @@ class AutoLibrary:
         print("[cwa-auto-library]: No existing library found. Creating new library...")
         shutil.copyfile(self.empty_metadb, f"{self.library_dir}/metadata.db")
         try:
-            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
             if not nsm:
                 subprocess.run(["chown", "-R", "abc:abc", self.library_dir], check=True)
             else:

--- a/scripts/convert_library.py
+++ b/scripts/convert_library.py
@@ -49,7 +49,7 @@ gid = grp.getgrnam(GROUP_NAME).gr_gid
 
 # Set permissions for log file (skip on network shares)
 try:
-    nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+    nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
     if not nsm:
         subprocess.run(["chown", f"{uid}:{gid}", convert_library_log_file], check=True)
     else:
@@ -547,7 +547,7 @@ class LibraryConverter:
 
     def set_library_permissions(self):
         try:
-            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
             if not nsm:
                 subprocess.run(["chown", "-R", "abc:abc", self.library_dir], check=True)
                 print_and_log(f"[convert-library]: ({self.current_book}/{len(self.to_convert)}) Successfully set ownership of new files in {self.library_dir} to abc:abc.")

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1246,7 +1246,7 @@ class NewBookProcessor:
 
     def set_library_permissions(self):
         try:
-            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
             if not nsm:
                 subprocess.run(["chown", "-R", "abc:abc", self.library_dir], check=True)
             else:

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -93,7 +93,7 @@ except KeyError:
 # Set permissions for log file (skip on network shares or if uid/gid not available)
 if uid is not None and gid is not None:
     try:
-        nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+        nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on", "localdb")
         if not nsm:
             subprocess.run(["chown", f"{uid}:{gid}", epub_fixer_log_file], check=True)
         else:

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -245,7 +245,7 @@ class TestEnvironmentConfiguration:
         """Verify network share mode can be detected from environment."""
         # This should not crash
         network_mode = os.environ.get('NETWORK_SHARE_MODE', 'false').lower()
-        assert network_mode in ['true', 'false', '0', '1', 'yes', 'no', 'on', 'off'], \
+        assert network_mode in ['true', 'false', '0', '1', 'yes', 'no', 'on', 'off', 'localdb'], \
             f"Invalid NETWORK_SHARE_MODE value: {network_mode}"
 
 


### PR DESCRIPTION
## Summary

Adds `localdb` as a third value for `NETWORK_SHARE_MODE`, targeting a common NAS setup: database on local storage (SSD/NVMe), book files on NFS/SMB.

Currently these users are stuck — `true` disables WAL causing lock-ups, `false` enables chown causing NFS failures.

| Behavior | `false` | `true` | `localdb` (new) |
|----------|---------|--------|-----------------|
| SQLite WAL | on | off | **on** |
| KOReader DDL | on | off | **on** |
| PRAGMA quick_check | on | skip | **on** |
| chown skip (mount paths) | off | on | on |
| Polling (file watching) | off | on | on |

100% backwards compatible — all existing values behave identically.

Also fixes `cps/ub.py` missing `"on"` from accepted NSM values.

## Related issues

- https://github.com/crocodilestick/Calibre-Web-Automated/discussions/631
- https://github.com/crocodilestick/Calibre-Web-Automated/issues/1082
- https://github.com/crocodilestick/Calibre-Web-Automated/issues/1142
- https://github.com/crocodilestick/Calibre-Web-Automated/issues/972
- https://github.com/crocodilestick/Calibre-Web-Automated/issues/1005

## Test plan

- [ ] `NETWORK_SHARE_MODE=false` — unchanged behavior
- [ ] `NETWORK_SHARE_MODE=true` — unchanged behavior
- [ ] `NETWORK_SHARE_MODE=localdb` — WAL enabled, chown skipped, polling used
- [ ] Logs show `NETWORK_SHARE_MODE=localdb: WAL enabled` info message

🤖 Generated with [Claude Code](https://claude.com/claude-code)