### PR TITLE
feat: Shelfmark Feature

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,6 @@ changelogs
 cwa-wiki
 wiki_images
 .devcontainer
-tmpclaude*
 
 # Test infrastructure (not needed in production image)
 tests/

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ changelogs
 cwa-wiki
 wiki_images
 .devcontainer
+tmpclaude*
 
 # Test infrastructure (not needed in production image)
 tests/

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ docs/
 test_venv
 cwa.code-workspace
 tmpclaude*
-package-lock.json
 
 
 # Test Scripts

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ docs/
 test_venv
 cwa.code-workspace
 tmpclaude*
-
+docker-compose.yml.live
 
 # Test Scripts
 DEV

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ docs/
 .venv-activate.sh
 test_venv
 cwa.code-workspace
-tmpclaude*
-docker-compose.yml.live
+
+
 
 # Test Scripts
 DEV

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ docs/
 .venv-activate.sh
 test_venv
 cwa.code-workspace
-
+tmpclaude*
+package-lock.json
 
 
 # Test Scripts

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -135,7 +135,7 @@ def before_request():
     #    pass    # ? fails on requesting /ajax/emailstat during restart ?
     g.constants = constants
     g.google_site_verification = os.getenv('GOOGLE_SITE_VERIFICATION', '')
-    g.download_url = (config.config_shelfmark_url or os.getenv('SHELFMARK_URL', '')).rstrip('/')
+    g.shelfmark_url = (config.config_shelfmark_url or os.getenv('SHELFMARK_URL', '')).rstrip('/')
     g.shelfmark_enabled = config.config_shelfmark_enabled
     g.allow_registration = config.config_public_reg
     g.allow_anonymous = config.config_anonbrowse

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -135,7 +135,7 @@ def before_request():
     #    pass    # ? fails on requesting /ajax/emailstat during restart ?
     g.constants = constants
     g.google_site_verification = os.getenv('GOOGLE_SITE_VERIFICATION', '')
-    g.download_url = config.config_shelfmark_url or os.getenv('SHELFMARK_URL', '')
+    g.download_url = (config.config_shelfmark_url or os.getenv('SHELFMARK_URL', '')).rstrip('/')
     g.shelfmark_enabled = config.config_shelfmark_enabled
     g.allow_registration = config.config_public_reg
     g.allow_anonymous = config.config_anonbrowse
@@ -637,6 +637,7 @@ def edit_user_table():
                                  visiblility=visibility,
                                  all_roles=constants.ALL_ROLES,
                                  kobo_support=kobo_support,
+                                 shelfmark_enabled=config.config_shelfmark_enabled,
                                  sidebar_settings=constants.sidebar_settings,
                                  title=_("Edit Users"),
                                  page="usertable")
@@ -801,7 +802,8 @@ def edit_list_user(param):
                       [constants.ROLE_ADMIN, constants.ROLE_PASSWD, constants.ROLE_EDIT_SHELFS]:
                         raise Exception(_("Guest can't have this role"))
                     # check for valid value, last on checks for power of 2 value
-                    if value > 0 and value <= constants.ROLE_VIEWER and (value & value - 1 == 0 or value == 1):
+                    max_role = constants.ROLE_SHELFMARK if config.config_shelfmark_enabled else constants.ROLE_VIEWER
+                    if value > 0 and value <= max_role and (value & value - 1 == 0 or value == 1):
                         if vals['value'] == 'true':
                             user.role |= value
                         elif vals['value'] == 'false':

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -136,6 +136,7 @@ def before_request():
     g.constants = constants
     g.google_site_verification = os.getenv('GOOGLE_SITE_VERIFICATION', '')
     g.download_url = config.config_shelfmark_url or os.getenv('SHELFMARK_URL', '')
+    g.shelfmark_enabled = config.config_shelfmark_enabled
     g.allow_registration = config.config_public_reg
     g.allow_anonymous = config.config_anonbrowse
     g.allow_upload = config.config_uploading
@@ -2432,6 +2433,7 @@ def _configuration_update_helper():
         reboot_required |= _config_string(to_save, "config_limiter_options")
 
         # Shelfmark configuration
+        _config_checkbox(to_save, "config_shelfmark_enabled")
         _config_string(to_save, "config_shelfmark_url")
 
         # Rarfile Content configuration

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -135,7 +135,7 @@ def before_request():
     #    pass    # ? fails on requesting /ajax/emailstat during restart ?
     g.constants = constants
     g.google_site_verification = os.getenv('GOOGLE_SITE_VERIFICATION', '')
-    g.download_url = os.getenv('SHELFMARK_URL', '/')
+    g.download_url = config.config_shelfmark_url or os.getenv('SHELFMARK_URL', '')
     g.allow_registration = config.config_public_reg
     g.allow_anonymous = config.config_anonbrowse
     g.allow_upload = config.config_uploading
@@ -556,6 +556,7 @@ def configuration():
                                  config=config,
                                  provider=oauth_bb.oauthblueprints,
                                  feature_support=feature_support,
+                                 shelfmark_env_url=os.getenv('SHELFMARK_URL', ''),
                                  title=_("Basic Configuration"), page="config")
 
 
@@ -2429,6 +2430,9 @@ def _configuration_update_helper():
         reboot_required |= _config_checkbox(to_save, "config_ratelimiter")
         reboot_required |= _config_string(to_save, "config_limiter_uri")
         reboot_required |= _config_string(to_save, "config_limiter_options")
+
+        # Shelfmark configuration
+        _config_string(to_save, "config_shelfmark_url")
 
         # Rarfile Content configuration
         _config_string(to_save, "config_rarfile_location")

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -135,6 +135,7 @@ def before_request():
     #    pass    # ? fails on requesting /ajax/emailstat during restart ?
     g.constants = constants
     g.google_site_verification = os.getenv('GOOGLE_SITE_VERIFICATION', '')
+    g.download_url = os.getenv('SHELFMARK_URL', '/')
     g.allow_registration = config.config_public_reg
     g.allow_anonymous = config.config_anonbrowse
     g.allow_upload = config.config_uploading

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -116,7 +116,7 @@ class _Settings(_Base):
     config_hardcover_token = Column(String)
 
     config_shelfmark_url = Column(String, default='')
-    config_shelfmark_enabled = Column(Boolean, default=True)
+    config_shelfmark_enabled = Column(Boolean, default=False)
     
     config_register_email = Column(Boolean, default=False)
     config_login_type = Column(Integer, default=0)

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -114,6 +114,8 @@ class _Settings(_Base):
     config_use_goodreads = Column(Boolean, default=False)
     config_goodreads_api_key = Column(String)
     config_hardcover_token = Column(String)
+
+    config_shelfmark_url = Column(String, default='')
     
     config_register_email = Column(Boolean, default=False)
     config_login_type = Column(Integer, default=0)

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -116,6 +116,7 @@ class _Settings(_Base):
     config_hardcover_token = Column(String)
 
     config_shelfmark_url = Column(String, default='')
+    config_shelfmark_enabled = Column(Boolean, default=True)
     
     config_register_email = Column(Boolean, default=False)
     config_login_type = Column(Integer, default=0)

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -58,6 +58,7 @@ ROLE_ANONYMOUS          = 1 << 5
 ROLE_EDIT_SHELFS        = 1 << 6
 ROLE_DELETE_BOOKS       = 1 << 7
 ROLE_VIEWER             = 1 << 8
+ROLE_SHELFMARK          = 1 << 9
 
 ALL_ROLES = {
                 "admin_role": ROLE_ADMIN,
@@ -68,6 +69,7 @@ ALL_ROLES = {
                 "edit_shelf_role": ROLE_EDIT_SHELFS,
                 "delete_role": ROLE_DELETE_BOOKS,
                 "viewer_role": ROLE_VIEWER,
+                "shelfmark_role": ROLE_SHELFMARK,
             }
 
 DETAIL_RANDOM           = 1 <<  0

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -26,6 +26,9 @@
               <th class="hidden-xs hidden-sm hidden-md">{{_('Edit')}}</th>
               <th class="hidden-xs hidden-sm hidden-md">{{_('Delete')}}</th>
               <th class="hidden-xs hidden-sm hidden-md">{{_('Public Shelf')}}</th>
+              {% if config.config_shelfmark_enabled %}
+              <th class="hidden-xs hidden-sm hidden-md">{{_('Shelfmark')}}</th>
+              {%  endif %}
           </tr>
           {% for user in allUser %}
             {% if not user.role_anonymous() or config.config_anonbrowse %}
@@ -45,6 +48,9 @@
               <td class="hidden-xs hidden-sm hidden-md">{{ display_bool_setting(user.role_edit()) }}</td>
               <td class="hidden-xs hidden-sm hidden-md">{{ display_bool_setting(user.role_delete_books()) }}</td>
               <td class="hidden-xs hidden-sm hidden-md">{{ display_bool_setting(user.role_edit_shelfs()) }}</td>
+              {% if config.config_shelfmark_enabled %}
+              <td class="hidden-xs hidden-sm hidden-md">{{ display_bool_setting(user.role_shelfmark()) }}</td>
+              {%  endif %}
             </tr>
             {% endif %}
           {% endfor %}

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -618,11 +618,17 @@
   <div class="settings-container">
     <h4 class="settings-section-header">{{_('Shelfmark Settings')}}</h4>
         <div class="form-group">
-          <label for="config_shelfmark_url">{{_('Shelfmark URL')}}</label>
-          <div class="help-block">{{_('URL or absolute path used for the Shelfmark Search button (e.g. https://example.com or /path/to/search). If set via the SHELFMARK_URL environment variable and left blank here, the environment variable value will be used.')}}</div>
-          <input type="text" class="form-control" id="config_shelfmark_url" name="config_shelfmark_url"
-                 value="{{ config.config_shelfmark_url if config.config_shelfmark_url else shelfmark_env_url }}"
-                 autocomplete="off" placeholder="https://example.com or /path/to/shelfmark">
+          <input type="checkbox" id="config_shelfmark_enabled" data-control="shelfmark_url_settings" name="config_shelfmark_enabled" {% if config.config_shelfmark_enabled %}checked{% endif %}>
+          <label for="config_shelfmark_enabled">{{_('Enable Shelfmark')}}</label>
+        </div>
+        <div data-related="shelfmark_url_settings">
+          <div class="form-group">
+            <label for="config_shelfmark_url">{{_('Shelfmark URL')}}</label>
+            <div class="help-block">{{_('URL or absolute path used for the Shelfmark Search button (e.g. https://shelfmark.example.com or /path/to/shelfmark). If set via the SHELFMARK_URL environment variable and left blank here, the environment variable value will be used.')}}</div>
+            <input type="text" class="form-control" id="config_shelfmark_url" name="config_shelfmark_url"
+                   value="{{ config.config_shelfmark_url if config.config_shelfmark_url else shelfmark_env_url }}"
+                   autocomplete="off" placeholder="https://shelfmark.example.com or /path/to/shelfmark">
+          </div>
         </div>
   </div>
 

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -615,6 +615,17 @@
             </div>
     </div>
 
+  <div class="settings-container">
+    <h4 class="settings-section-header">{{_('Shelfmark Settings')}}</h4>
+        <div class="form-group">
+          <label for="config_shelfmark_url">{{_('Shelfmark URL')}}</label>
+          <div class="help-block">{{_('URL or absolute path used for the Shelfmark Search button (e.g. https://example.com or /path/to/search). If set via the SHELFMARK_URL environment variable and left blank here, the environment variable value will be used.')}}</div>
+          <input type="text" class="form-control" id="config_shelfmark_url" name="config_shelfmark_url"
+                 value="{{ config.config_shelfmark_url if config.config_shelfmark_url else shelfmark_env_url }}"
+                 autocomplete="off" placeholder="https://example.com or /path/to/shelfmark">
+        </div>
+  </div>
+
     <div style="max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; width: -webkit-fill-available; justify-content: space-between; margin-inline: 2rem;">
       <button type="button" name="submit" id="config_submit" class="btn btn-default">{{_('Save')}}</button>
       <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-default">{{_('Cancel')}}</a>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -122,6 +122,8 @@
           {% if current_user.is_authenticated or g.allow_anonymous %}
           <ul class="nav navbar-nav ">
             <li><a href="{{url_for('search.advanced_search')}}" id="advanced_search"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Advanced Search')}}</span></a></li>
+            <li style="padding: 13px 4px; color: #ccc;">|</li>
+            <li><a id="download-books" href="/download" target="_blank" data-text="{{_('Download Books')}}"><span style="font-size:1.1em;">☠</span> <span class="hidden-sm">{{_('Download Books')}}</span></a></li>
           </ul>
           {% endif %}
           <ul class="nav navbar-nav navbar-right" id="main-nav">

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -49,9 +49,10 @@
           e.preventDefault();
           var queryEl = document.getElementById('query');
           var query = queryEl ? queryEl.value.trim() : '';
+          var baseUrl = {{ g.download_url | tojson }};
           var url = query
-              ? '{{ g.download_url }}/?q=' + encodeURIComponent(query).replace(/%20/g, '+') + '&content_type=ebook'
-              : '{{ g.download_url }}';
+              ? baseUrl + '/?q=' + encodeURIComponent(query).replace(/%20/g, '+') + '&content_type=ebook'
+              : baseUrl;
           window.open(url, '_blank');
       }
 
@@ -132,8 +133,8 @@
           {% if current_user.is_authenticated or g.allow_anonymous %}
           <ul class="nav navbar-nav ">
             <li><a href="{{url_for('search.advanced_search')}}" id="advanced_search"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Advanced Search')}}</span></a></li>
-            {% if g.shelfmark_enabled %}
-            <li style="padding: 13px 4px; color: #ccc;">|</li>
+            {% if g.shelfmark_enabled and current_user.role_shelfmark() %}
+            <li class="divider-vertical"></li>
             <li><a id="shelfmark_search" href="#" onclick="openDownloadLink(event)"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Shelfmark Search')}}</span></a></li>
             {% endif %}
           </ul>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -133,7 +133,7 @@
           <ul class="nav navbar-nav ">
             <li><a href="{{url_for('search.advanced_search')}}" id="advanced_search"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Advanced Search')}}</span></a></li>
             <li style="padding: 13px 4px; color: #ccc;">|</li>
-            <li><a id="download-books" href="#" onclick="openDownloadLink(event)" data-text="{{_('Download Books')}}"><span style="font-size:1.1em;">☠</span> <span class="hidden-sm">{{_('Download Books')}}</span></a></li>
+            <li><a id="shelfmark_search" href="#" onclick="openDownloadLink(event)"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Shelfmark Search')}}</span></a></li>
           </ul>
           {% endif %}
           <ul class="nav navbar-nav navbar-right" id="main-nav">

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -45,6 +45,16 @@
           .catch(error => console.error("Error:", error));
       }
 
+      function openDownloadLink(e) {
+          e.preventDefault();
+          var queryEl = document.getElementById('query');
+          var query = queryEl ? queryEl.value.trim() : '';
+          var url = query
+              ? '{{ g.download_url }}/?q=' + encodeURIComponent(query).replace(/%20/g, '+') + '&content_type=ebook'
+              : '{{ g.download_url }}';
+          window.open(url, '_blank');
+      }
+
       function checkLibraryMessages() {
           fetch("/cwa-library-refresh/messages")
               .then(response => response.json())
@@ -123,7 +133,7 @@
           <ul class="nav navbar-nav ">
             <li><a href="{{url_for('search.advanced_search')}}" id="advanced_search"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Advanced Search')}}</span></a></li>
             <li style="padding: 13px 4px; color: #ccc;">|</li>
-            <li><a id="download-books" href="/download" target="_blank" data-text="{{_('Download Books')}}"><span style="font-size:1.1em;">☠</span> <span class="hidden-sm">{{_('Download Books')}}</span></a></li>
+            <li><a id="download-books" href="#" onclick="openDownloadLink(event)" data-text="{{_('Download Books')}}"><span style="font-size:1.1em;">☠</span> <span class="hidden-sm">{{_('Download Books')}}</span></a></li>
           </ul>
           {% endif %}
           <ul class="nav navbar-nav navbar-right" id="main-nav">

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -45,11 +45,11 @@
           .catch(error => console.error("Error:", error));
       }
 
-      function openDownloadLink(e) {
+      function openShelfmarkSearch(e) {
           e.preventDefault();
           var queryEl = document.getElementById('query');
           var query = queryEl ? queryEl.value.trim() : '';
-          var baseUrl = {{ g.download_url | tojson }};
+          var baseUrl = {{ g.shelfmark_url | tojson }};
           var url = query
               ? baseUrl + '/?q=' + encodeURIComponent(query).replace(/%20/g, '+') + '&content_type=ebook'
               : baseUrl;
@@ -135,7 +135,7 @@
             <li><a href="{{url_for('search.advanced_search')}}" id="advanced_search"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Advanced Search')}}</span></a></li>
             {% if g.shelfmark_enabled and current_user.role_shelfmark() %}
             <li class="divider-vertical"></li>
-            <li><a id="shelfmark_search" href="#" onclick="openDownloadLink(event)"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Shelfmark Search')}}</span></a></li>
+            <li><a id="shelfmark_search" href="#" onclick="openShelfmarkSearch(event)"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Shelfmark Search')}}</span></a></li>
             {% endif %}
           </ul>
           {% endif %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -132,8 +132,10 @@
           {% if current_user.is_authenticated or g.allow_anonymous %}
           <ul class="nav navbar-nav ">
             <li><a href="{{url_for('search.advanced_search')}}" id="advanced_search"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Advanced Search')}}</span></a></li>
+            {% if g.shelfmark_enabled %}
             <li style="padding: 13px 4px; color: #ccc;">|</li>
             <li><a id="shelfmark_search" href="#" onclick="openDownloadLink(event)"><span class="glyphicon glyphicon-search" style="padding-left: 10px; padding-right: 6px;"></span><span class="hidden-sm"> {{_('Shelfmark Search')}}</span></a></li>
+            {% endif %}
           </ul>
           {% endif %}
           <ul class="nav navbar-nav navbar-right" id="main-nav">

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -438,10 +438,17 @@
           <input type="checkbox" name="passwd_role" id="passwd_role" {% if content.role_passwd() %}checked{% endif %} style="accent-color: var(--color-secondary);">
           <label for="passwd_role">{{_('Allow Changing Password')}}</label>
         </div>
-        
+
         <div>
           <input type="checkbox" name="edit_shelf_role" id="edit_shelf_role" {% if content.role_edit_shelfs() %}checked{% endif %} style="accent-color: var(--color-secondary);">
           <label for="edit_shelf_role">{{_('Allow Editing Public Shelves')}}</label>
+        </div>
+        {% endif %}
+
+        {% if config.config_shelfmark_enabled %}
+        <div>
+          <input type="checkbox" name="shelfmark_role" id="shelfmark_role" {% if content.role_shelfmark() %}checked{% endif %} style="accent-color: var(--color-secondary);">
+          <label for="shelfmark_role">{{_('Allow Shelfmark')}}</label>
         </div>
         {% endif %}
       </div>

--- a/cps/templates/user_table.html
+++ b/cps/templates/user_table.html
@@ -149,6 +149,9 @@
             {{ user_checkbox_row("role", "edit_role", _('Edit'), visiblility, all_roles)}}
             {{ user_checkbox_row("role", "delete_role", _('Delete'), visiblility, all_roles)}}
             {{ user_checkbox_row("role", "edit_shelf_role", _('Edit Public Shelves'), visiblility, all_roles)}}
+            {% if shelfmark_enabled %}
+            {{ user_checkbox_row("role", "shelfmark_role", _('Shelfmark'), visiblility, all_roles)}}
+            {% endif %}
             {%  if kobo_support %}
             {{ user_single_checkbox_row("kobo_only_shelves_sync", _('Sync selected Shelves with Kobo'))}}
             {%  endif %}

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -193,6 +193,9 @@ class UserBase:
     def role_viewer(self):
         return self._has_role(constants.ROLE_VIEWER)
 
+    def role_shelfmark(self):
+        return self._has_role(constants.ROLE_SHELFMARK)
+
     @property
     def is_active(self):
         return True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
+      # URL to your Shelfmark Instance. Example: https://shelfmark.domain.com, or if setup as a path of your CWA domain Example: https://cwa.domain.com/shelfmark, use /shelfmark
+      # - SHELFMARK_URL=https://shelfmark.domain.com #or /path 
     volumes:
       # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings etc.
       - /path/to/config/folder:/config

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -38,7 +38,6 @@ services:
       ### This will let you see your changes in realtime, test ect. You can use build.sh to prepare images with your changes.
       ### For example:
       # /your/dev/env/cps:/app/calibre-web-automated/cps
-      - ./cps:/app/calibre-web-automated/cps
 
     ports:
       # Change the first number to change the port you want to access the Web UI, not the second

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -31,13 +31,13 @@ services:
       - /path/to/your/calibre/library:/calibre-library
       # If you use calibre plugins, you can bind your plugins folder here to have CWA attempt to add them to it's workflow (WIP)
       - /path/to/your/calibre/plugins/folder:/config/.config/calibre/plugins
-
       # DEV SPECIFIC BINDS
       ### The current easiest way to develop CWA is to live edit a running instance.
       ### To do so, use docker binds to bind the files your working on to their counterparts in the running container.
       ### This will let you see your changes in realtime, test ect. You can use build.sh to prepare images with your changes.
       ### For example:
       # /your/dev/env/cps:/app/calibre-web-automated/cps
+      - ./cps:/app/calibre-web-automated/cps   # ← add this
 
     ports:
       # Change the first number to change the port you want to access the Web UI, not the second

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -4,6 +4,7 @@ services:
     image: crocodilestick/calibre-web-automated:latest
     container_name: calibre-web-automated
     environment:
+      # - SHELFMARK_URL=https://shelfmark.domain.com #or /path #URL to your Shelfmark Instance. Example: https://shelfmark.domain.com, or if setup as a path of your CWA domain Example: https://cwa.domain.com/shelfmark, use /shelfmark
       # Only change these if you know what you're doing
       - PUID=1000
       - PGID=1000
@@ -37,7 +38,7 @@ services:
       ### This will let you see your changes in realtime, test ect. You can use build.sh to prepare images with your changes.
       ### For example:
       # /your/dev/env/cps:/app/calibre-web-automated/cps
-      - ./cps:/app/calibre-web-automated/cps   # ← add this
+      - ./cps:/app/calibre-web-automated/cps
 
     ports:
       # Change the first number to change the port you want to access the Web UI, not the second


### PR DESCRIPTION
Idea for Shelfmark feature (https://github.com/calibrain/shelfmark)
Disclosure: Claude assisted

### **Shelfmark Setting in Basic Config:** 
Enable/disable globally, and set Shelfmark URL/Path. URL/Path can also be set with env SHELFMARK_URL.

<img width="900" height="331" alt="image" src="https://github.com/user-attachments/assets/b469dd80-8216-4731-a446-8d8be411b1b0" />

### **Shelfmark Search:**
 Button which takes the query in search box and opens a new tab to `[ShelfmarkURL]\?q=a+query&content_type=ebook`. (Note: content_type is still in dev branch of Shelfmark) OR if search box is empty, just goes to the ShelfmarkURL without any query. Shelfmark Search is hidden if Shelfmark is disabled globally

<img width="815" height="223" alt="image" src="https://github.com/user-attachments/assets/f51432f8-add0-42b7-8c50-490fb51b75ba" />


### **Shelfmark Role:** 
If Shelfmark is enabled globally users with Shelfmark Role will see Shelfmark Search, users without will not. Appears on admin, user_edit, and user_table. Shelfmark Role is hidden/disabled if Shelfmark disabled globally.

<img width="1096" height="272" alt="image" src="https://github.com/user-attachments/assets/6ee8e26e-27e6-49ad-be94-4cdc4d77e553" />
<img width="1129" height="341" alt="image" src="https://github.com/user-attachments/assets/35e7c5cb-08ee-4535-a78b-b50615a43c41" />
<img width="1046" height="228" alt="image" src="https://github.com/user-attachments/assets/e5a97637-b670-49ed-b420-f2f10fc43f03" />
