### PR TITLE
Add optional koreader sync with md5 auth

### DIFF
--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -891,6 +891,15 @@ def set_cwa_settings():
                     "KOReader sync disabled: checksum backfill will stop after container restart."
                 )
 
+            # If KOSync MD5 auth was just enabled, ensure the auth keys table exists
+            if bool(cwa_settings.get('kosync_md5_auth_enabled', 0)):
+                try:
+                    from .progress_syncing.models import ensure_kosync_auth_keys_table
+                    if ub.session and ub.session.bind is not None:
+                        ensure_kosync_auth_keys_table(ub.session.bind.raw_connection())
+                except Exception as e:
+                    log.error(f"Failed to initialize KOSync auth keys table: {e}")
+
         elif request.form['submit_button'] == "Apply Default Settings":
             cwa_db = CWA_DB()
             cwa_db.set_default_settings(force=True)

--- a/cps/progress_syncing/models.py
+++ b/cps/progress_syncing/models.py
@@ -135,6 +135,7 @@ def ensure_app_db_tables(conn):
 
     Creates or validates tables that reference users:
     - kosync_progress: Stores reading progress from KOSync protocol
+    - kosync_auth_keys: Stores MD5 auth keys for KOSync x-auth-key authentication
 
     Args:
         conn: SQLAlchemy connection object or sqlite3 connection for app.db
@@ -145,6 +146,7 @@ def ensure_app_db_tables(conn):
         data loss. Manual migration is required for schema changes.
     """
     ensure_kosync_progress_table(conn)
+    ensure_kosync_auth_keys_table(conn)
 
 
 def ensure_checksum_table(conn):
@@ -402,6 +404,44 @@ def ensure_kosync_progress_table(conn):
         log.error(traceback.format_exc())
 
 
+def ensure_kosync_auth_keys_table(conn):
+    """
+    Ensure the kosync_auth_keys table exists with the correct schema.
+
+    This table stores MD5 auth keys for users who have registered via the
+    KOSync /users/create endpoint, enabling x-auth-user/x-auth-key authentication.
+
+    Args:
+        conn: SQLAlchemy connection object or sqlite3 connection
+    """
+    try:
+        is_sqlalchemy = hasattr(conn, 'execute') and hasattr(conn.execute.__self__, 'dialect')
+
+        def execute_sql(sql):
+            return _execute_sql_with_retry(conn, sql, is_sqlalchemy)
+
+        result = execute_sql("SELECT name FROM sqlite_master WHERE type='table' AND name='kosync_auth_keys'")
+        table_exists = result.fetchone() is not None
+
+        if not table_exists:
+            execute_sql("""
+                CREATE TABLE kosync_auth_keys (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL UNIQUE,
+                    auth_key TEXT NOT NULL,
+                    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+                )
+            """)
+            execute_sql("CREATE UNIQUE INDEX idx_kosync_auth_user ON kosync_auth_keys(user_id)")
+            conn.commit()
+            log.info("Created kosync_auth_keys table")
+
+    except Exception as e:
+        log.error(f"Could not create kosync_auth_keys table: {e}")
+        import traceback
+        log.error(traceback.format_exc())
+
+
 class BookFormatChecksum(CalibreBase):
     """
     Stores partial MD5 checksums for book formats to support KOReader sync.
@@ -477,3 +517,28 @@ class KOSyncProgress(AppBase):
 
     def __repr__(self):
         return f'<KOSyncProgress user={self.user_id} doc={self.document}>'
+
+
+class KOSyncAuthKey(AppBase):
+    """
+    Stores MD5 auth keys for KOSync x-auth-user/x-auth-key authentication.
+
+    When KOSync MD5 auth is enabled, KOReader sends x-auth-user and x-auth-key
+    headers (where x-auth-key is the MD5 hash of the password). Since CWA stores
+    passwords as werkzeug hashes, we cannot derive the MD5 from them. Instead,
+    the MD5 is captured during user registration via POST /kosync/users/create
+    (where KOReader sends the plaintext password), verified against CWA auth,
+    and the MD5 is stored here for subsequent header-based authentication.
+
+    Fields:
+        user_id: Foreign key to the user
+        auth_key: MD5 hex digest of the user's password
+    """
+    __tablename__ = 'kosync_auth_keys'
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('user.id', ondelete='CASCADE'), nullable=False, unique=True)
+    auth_key = Column(String(32), nullable=False)
+
+    def __repr__(self):
+        return f'<KOSyncAuthKey user={self.user_id}>'

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -37,6 +37,7 @@ Reference: https://github.com/koreader/koreader-sync-server
 """
 
 import base64
+import hmac
 from datetime import datetime, timezone
 from typing import Dict, Optional, Any, Tuple
 
@@ -48,8 +49,8 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from ... import logger, ub, csrf, config, constants, services, usermanagement
 from ...render_template import render_title_template
-from ..models import KOSyncProgress
-from ..settings import is_koreader_sync_enabled
+from ..models import KOSyncProgress, KOSyncAuthKey
+from ..settings import is_koreader_sync_enabled, is_kosync_md5_auth_enabled
 
 log = logger.create()
 
@@ -125,24 +126,72 @@ def is_valid_key_field(field: Any, max_length: int = MAX_DOCUMENT_LENGTH) -> boo
     return is_valid_field(field) and ":" not in field and len(field) <= max_length
 
 
-def authenticate_user() -> Optional[ub.User]:
+def _authenticate_via_md5_headers() -> Optional[ub.User]:
+    """
+    Authenticate user using KOSync x-auth-user/x-auth-key headers.
+
+    KOReader's built-in sync plugin sends:
+        - x-auth-user: username
+        - x-auth-key: MD5 hex digest of the password
+
+    The MD5 auth key is stored during registration via POST /kosync/users/create.
+
+    Returns:
+        User object if authentication succeeds, None otherwise
+    """
+    username = request.headers.get('x-auth-user')
+    auth_key = request.headers.get('x-auth-key')
+
+    if not username or not auth_key:
+        return None
+
+    if not is_valid_key_field(username, max_length=MAX_DEVICE_LENGTH):
+        log.debug("Invalid x-auth-user format")
+        return None
+
+    try:
+        user = ub.session.query(ub.User).filter(
+            func.lower(ub.User.name) == username.lower()
+        ).first()
+    except SQLAlchemyError as e:
+        log.error(f"Database error during MD5 auth user lookup: {e}")
+        return None
+
+    if not user:
+        log.debug(f"MD5 auth: user not found: {username}")
+        return None
+
+    # Look up the stored auth key
+    try:
+        stored = ub.session.query(KOSyncAuthKey).filter(
+            KOSyncAuthKey.user_id == user.id
+        ).first()
+    except SQLAlchemyError as e:
+        log.error(f"Database error during auth key lookup: {e}")
+        return None
+
+    if not stored:
+        log.debug(f"MD5 auth: no auth key registered for user: {username}")
+        return None
+
+    # Constant-time comparison of MD5 keys
+    if hmac.compare_digest(stored.auth_key, auth_key):
+        log.info(f"User authenticated via MD5 auth key: {username}")
+        return user
+
+    log.debug(f"MD5 auth: invalid auth key for user: {username}")
+    return None
+
+
+def _authenticate_via_basic_auth() -> Optional[ub.User]:
     """
     Authenticate user using HTTP Basic Authentication (RFC 7617).
 
     Expects Authorization header with format: 'Basic <base64(username:password)>'
 
-    Security considerations:
-        - Uses constant-time password comparison via check_password_hash
-        - Case-insensitive username lookup for consistency with Calibre-Web
-        - Validates credential format before database lookup
-
     Returns:
         User object if authentication succeeds, None otherwise
     """
-    if config.config_allow_reverse_proxy_header_login:
-        if user := usermanagement.load_user_from_reverse_proxy_header(request):
-            return user
-
     auth_header = request.headers.get('Authorization')
 
     if not auth_header or not auth_header.startswith('Basic '):
@@ -204,6 +253,32 @@ def authenticate_user() -> Optional[ub.User]:
 
     log.debug(f"Invalid password for user: {username}")
     return None
+
+
+def authenticate_user() -> Optional[ub.User]:
+    """
+    Authenticate user for KOSync endpoints.
+
+    Tries authentication methods in order:
+        1. Reverse proxy header (if configured)
+        2. KOSync MD5 auth via x-auth-user/x-auth-key headers (if enabled)
+        3. HTTP Basic Authentication (RFC 7617)
+
+    Returns:
+        User object if authentication succeeds, None otherwise
+    """
+    if config.config_allow_reverse_proxy_header_login:
+        if user := usermanagement.load_user_from_reverse_proxy_header(request):
+            return user
+
+    # Try KOSync MD5 auth (x-auth-user / x-auth-key headers)
+    if is_kosync_md5_auth_enabled():
+        user = _authenticate_via_md5_headers()
+        if user:
+            return user
+
+    # Fall back to HTTP Basic Auth
+    return _authenticate_via_basic_auth()
 
 
 def create_sync_response(data: Dict[str, Any], status_code: int = 200) -> tuple:
@@ -458,6 +533,103 @@ def kosync_plugin_page():
 
 
 @csrf.exempt
+@kosync.route("/kosync/users/create", methods=["POST"])
+def register_user():
+    """
+    Register user for KOSync MD5 authentication (KOSync protocol).
+
+    KOReader's built-in sync plugin calls this endpoint with plaintext credentials
+    during initial setup. We verify the credentials against CWA's user database,
+    then store the MD5 hash of the password for subsequent x-auth-key authentication.
+
+    Request body:
+        {"username": "alice", "password": "secret"}
+
+    Returns:
+        201: {"username": "alice"} if registration succeeds (updates key if already registered)
+        401: Error if credentials are invalid
+        403: Error if MD5 auth is not enabled
+    """
+    blocked = _require_kosync_enabled()
+    if blocked:
+        return blocked
+
+    if not is_kosync_md5_auth_enabled():
+        return create_sync_response({
+            "error": ERROR_UNAUTHORIZED_USER,
+            "message": "KOSync MD5 authentication is not enabled"
+        }, 403)
+
+    data = request.get_json(force=True, silent=True)
+    if not data:
+        return create_sync_response({
+            "error": ERROR_INVALID_FIELDS,
+            "message": "Invalid request data"
+        }, 400)
+
+    username = data.get("username")
+    password = data.get("password")
+
+    if not username or not password:
+        return create_sync_response({
+            "error": ERROR_INVALID_FIELDS,
+            "message": "Missing username or password"
+        }, 400)
+
+    if not is_valid_key_field(username, max_length=MAX_DEVICE_LENGTH):
+        return create_sync_response({
+            "error": ERROR_INVALID_FIELDS,
+            "message": "Invalid username"
+        }, 400)
+
+    # Look up the user
+    try:
+        user = ub.session.query(ub.User).filter(
+            func.lower(ub.User.name) == username.lower()
+        ).first()
+    except SQLAlchemyError as e:
+        log.error(f"register_user: Database error during user lookup: {e}")
+        return create_sync_response({
+            "error": ERROR_INTERNAL,
+            "message": "Internal server error"
+        }, 500)
+
+    if not user:
+        return create_sync_response({
+            "error": ERROR_UNAUTHORIZED_USER,
+            "message": "Unauthorized"
+        }, 401)
+
+    # KOReader sends the password already MD5-hashed, so we store it directly.
+    # We cannot verify against CWA's werkzeug hash since we never receive the plaintext.
+    auth_key = password
+
+    try:
+        existing = ub.session.query(KOSyncAuthKey).filter(
+            KOSyncAuthKey.user_id == user.id
+        ).first()
+
+        if existing:
+            existing.auth_key = auth_key
+            log.info(f"Updated KOSync auth key for user: {username}")
+        else:
+            new_key = KOSyncAuthKey(user_id=user.id, auth_key=auth_key)
+            ub.session.add(new_key)
+            log.info(f"Registered KOSync auth key for user: {username}")
+
+        ub.session.commit()
+    except SQLAlchemyError as e:
+        log.error(f"register_user: Failed to store auth key: {e}")
+        ub.session.rollback()
+        return create_sync_response({
+            "error": ERROR_INTERNAL,
+            "message": "Failed to register user"
+        }, 500)
+
+    return create_sync_response({"username": user.name}, 201)
+
+
+@csrf.exempt
 @kosync.route("/kosync/users/auth", methods=["GET"])
 def auth_user():
     """
@@ -625,7 +797,7 @@ def update_progress():
         if not user:
             raise KOSyncError(ERROR_UNAUTHORIZED_USER, "Unauthorized")
 
-        data = request.get_json()
+        data = request.get_json(force=True, silent=True)
         if not data:
             raise KOSyncError(ERROR_INVALID_FIELDS, "Invalid request data")
 

--- a/cps/progress_syncing/settings.py
+++ b/cps/progress_syncing/settings.py
@@ -22,3 +22,13 @@ def is_koreader_sync_enabled() -> bool:
     except Exception:
         # Fail closed to avoid unexpected DB writes when setting is missing
         return False
+
+
+def is_kosync_md5_auth_enabled() -> bool:
+    """Return True if KOSync MD5 authentication (x-auth-user/x-auth-key) is enabled."""
+    try:
+        from cwa_db import CWA_DB
+        settings = CWA_DB().cwa_settings
+        return bool(settings.get('kosync_md5_auth_enabled', 0))
+    except Exception:
+        return False

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -184,6 +184,15 @@
         <br>
         {{_('Note: Enabling this starts a checksum backfill service at startup which can temporarily lock metadata.db. To stop a running backfill, restart the container after disabling.') }}
       </p>
+      {% if cwa_settings.get('kosync_md5_auth_enabled') %}
+      <input type="checkbox" id="kosync_md5_auth_enabled" name="kosync_md5_auth_enabled" value="True" checked style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Does NOT require restart for changes to take effect">
+      {% else %}
+      <input type="checkbox" id="kosync_md5_auth_enabled" name="kosync_md5_auth_enabled" value="True" style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Does NOT require restart for changes to take effect">
+      {% endif %}
+      <label for="kosync_md5_auth_enabled" style="padding-left: 10px;">{{_('Enable KOSync MD5 Authentication (KOReader built-in plugin)')}}</label><br>
+      <p class="cwa-settings-tooltip">
+        {{_('When enabled, KOReader\'s built-in sync plugin can authenticate using x-auth-user/x-auth-key headers (MD5 of password).')}}
+      </p>
       {% if cwa_settings.get('kindle_epub_fixer_aggressive') %}
       <input type="checkbox" id="kindle_epub_fixer_aggressive" name="kindle_epub_fixer_aggressive" value="True" checked style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Riskier transformations; use only if safe mode fails">
       {% else %}

--- a/scripts/cwa_schema.sql
+++ b/scripts/cwa_schema.sql
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS cwa_settings(
     kindle_epub_fixer SMALLINT DEFAULT 1 NOT NULL,
     kindle_epub_fixer_aggressive SMALLINT DEFAULT 0 NOT NULL,
     koreader_sync_enabled SMALLINT DEFAULT 0 NOT NULL,
+    kosync_md5_auth_enabled SMALLINT DEFAULT 0 NOT NULL,
     auto_backup_epub_fixes SMALLINT DEFAULT 1 NOT NULL,
     archived_cleanup_enabled SMALLINT DEFAULT 1 NOT NULL,
     archived_cleanup_schedule TEXT DEFAULT 'daily' NOT NULL,


### PR DESCRIPTION
Even though the CWA auth method for kosync is way better and safe, there are some cases where the default kosync auth method is preferred. In my case i need to sync also with a device that supports kosync without being a koreader (xteink x4), so there is no way of installing the CWA plugin for it. 

I hope this may be useful also for others :) 