### PR TITLE
Fix crash when Kobo bookmark has no Location data

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -945,11 +945,12 @@ def HandleStateRequest(book_uuid):
                 current_bookmark = kobo_reading_state.current_bookmark
                 current_bookmark.progress_percent = request_bookmark["ProgressPercent"]
                 current_bookmark.content_source_progress_percent = request_bookmark["ContentSourceProgressPercent"]
-                location = request_bookmark["Location"]
+                location = request_bookmark.get("Location")
                 if location:
                     current_bookmark.location_value = location["Value"]
                     current_bookmark.location_type = location["Type"]
                     current_bookmark.location_source = location["Source"]
+                current_bookmark.last_modified = datetime.now(timezone.utc)
                 update_results_response["CurrentBookmarkResult"] = {"Result": "Success"}
 
             request_statistics = request_reading_state["Statistics"]


### PR DESCRIPTION
## Summary

- Fix `KeyError` crash in `HandleStateRequest` when a Kobo device sends bookmark data without a `Location` key. Changed `request_bookmark["Location"]` to `request_bookmark.get("Location")` so the existing `if location:` guard handles it gracefully.
- Added `last_modified` timestamp to `KoboBookmark` updates so bookmark freshness can be determined.

## Context

Not all Kobo bookmark payloads include the `Location` field. When it's missing, the current code raises a `KeyError`, preventing the bookmark from being saved at all. The fix is minimal — `.get()` returns `None`, and the existing conditional already handles that case.

## Test plan

- [ ] Sync a Kobo device with a book that has Location data — verify location is still saved
- [ ] Sync a Kobo device with a book that has no Location data — verify it no longer crashes and bookmark is saved
- [ ] Verify `last_modified` timestamp is set on bookmark after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)