### PR TITLE
Subfolder routing for auto-send users in NewBookProcessor

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1011,6 +1011,26 @@ class NewBookProcessor:
                 """)
                 auto_send_users = cur.fetchall()
 
+            # Subfolder routing: if the file was ingested from a subfolder,
+            # only send to the user whose name matches that subfolder.
+            target_username = None
+            try:
+                relative = os.path.relpath(self.filepath, self.ingest_folder)
+                parts = relative.split(os.sep)
+                if len(parts) > 1:
+                    target_username = parts[0]
+            except (ValueError, TypeError):
+                pass
+
+            if target_username:
+                auto_send_users = [
+                    u for u in auto_send_users
+                    if u[1].lower() == target_username.lower()
+                ]
+                if not auto_send_users:
+                    print(f"[ingest-processor] No CWA user matches subfolder '{target_username}', skipping auto-send", flush=True)
+                    return
+
             if not auto_send_users:
                 print(f"[ingest-processor] No users with auto-send enabled found", flush=True)
                 return


### PR DESCRIPTION
- Add per-user auto-send routing based on ingest subfolder name
- Books placed in /cwa-book-ingest/[username]/ are only sent to the matching CWA user

