### PR TITLE
Do not use `install` to create the ingest directory, use mkdir

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -107,7 +107,7 @@ PY
 )
 if [ -n "$INGEST_DIR" ]; then
   # Create directory if missing
-  install -d -o abc -g abc "$INGEST_DIR" 2>/dev/null || mkdir -p "$INGEST_DIR" 2>/dev/null || true
+  mkdir -p "$INGEST_DIR" 2>/dev/null || true
   # Set ownership unless network share mode (only skip for /cwa-book-ingest)
   if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
     if [ "$INGEST_DIR" = "/cwa-book-ingest" ]; then
@@ -428,4 +428,3 @@ else
 fi
 
 echo "[cwa-init] Versions resolved: INSTALLED=$CWA_INSTALLED_VERSION, STABLE=$CWA_STABLE_VERSION"
-


### PR DESCRIPTION
install updates the permissions on the directory, which can be unexpected and unwanted. Instead, this change updates the code to just rely on the fallback `mkdir`, which correctly considers the container's umask and creates the ingest directory with predictable permissions, and only if it should not exist yet.

This ports (a slightly modified to be minimal) change proposed by @bcsteeve in https://github.com/crocodilestick/Calibre-Web-Automated/pull/1145#issuecomment-3957501965; I believe that's all that should be required for the ingest directory to be usable and its permissions to remain untouched, so other external tools can still write to it.