### PR TITLE
fix: restore missing back button in epub reader

### DIFF
--- a/cps/static/css/reader.css
+++ b/cps/static/css/reader.css
@@ -46,6 +46,11 @@
     font-size: 16px;
 }
 
+#back-button {
+  width: 50px !important;
+  right: 50px;
+}
+
 .reader-error {
     padding: 24px;
     margin: 24px;

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -29,6 +29,7 @@
             <!--a id="show-Search" class="show_view icon-search" data-view="Search">Search</a-->
             <a id="show-Toc" class="show_view icon-list-1 active" data-view="Toc">TOC</a>
             <a id="show-Bookmarks" class="show_view icon-bookmark" data-view="Bookmarks">Bookmarks</a>
+            <a id="back-button" data-view="Back to Books" href="{{ url_for('web.index') }}">Books</a>
             <!--a id="show-Notes" class="show_view icon-edit" data-view="Notes">Notes</a-->
 
         </div>


### PR DESCRIPTION
Closes #1203 

Cherry-picked from calibre-web. Adds the back-button link to the reader sidebar so users can navigate back to the library without closing the tab or manually entering a URL.