### PR TITLE
Fix: magic shelf author sort returning no books

### DIFF
--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -594,10 +594,22 @@ def get_books_for_magic_shelf(shelf_id, page=1, page_size=None, sort_order=None,
         # Build base query
         query = cdb.session.query(db.Books)
         query = query.filter(query_filter)
-        
+
         # Apply standard user permissions filters
         query = query.filter(cdb.common_filters())
-        
+
+        # Join Series table if sort order references it (e.g. author sort
+        # includes series name for sub-sorting within each author).
+        # Without this join, ORDER BY series.name produces empty results.
+        if sort_order is not None:
+            order_list = sort_order if isinstance(sort_order, list) else [sort_order]
+            needs_series_join = any(
+                'series' in str(getattr(expr, 'element', expr)).lower()
+                for expr in order_list
+            )
+            if needs_series_join:
+                query = query.outerjoin(db.books_series_link).outerjoin(db.Series)
+
         # Apply sorting
         if sort_order is not None:
             if isinstance(sort_order, list):
@@ -605,7 +617,7 @@ def get_books_for_magic_shelf(shelf_id, page=1, page_size=None, sort_order=None,
                     query = query.order_by(order_expr)
             else:
                 query = query.order_by(sort_order)
-        
+
         # Execute Full Query for Cache
         try:
             # Fetch ALL IDs


### PR DESCRIPTION
## Fix: magic shelves return no books when sorted by author

### Problem

Opening a magic shelf and sorting by "Author A-Z" or "Author Z-A" returns zero books, even when the shelf contains books. All other sort options work correctly.

### Root Cause

`get_sort_function()` in `web.py` returns `[db.Books.author_sort.asc(), db.Series.name, db.Books.series_index]` for author sort. This includes `db.Series.name` for sub-sorting books within each author by series.

However, `get_books_for_magic_shelf()` in `magic_shelf.py` builds its base query as `cdb.session.query(db.Books)` with no join to the `Series` table. When SQLAlchemy tries to ORDER BY `series.name` without that table in the query, it returns no results.

Regular shelves don't have this problem because `change_shelf_order()` in `shelf.py` explicitly adds the outerjoin.

### What changed

Adds a conditional `outerjoin` to `Series` (via `books_series_link`) in `get_books_for_magic_shelf()` when the sort order references `db.Series.name`. This matches the approach already used in `shelf.py`.

### Testing

- Open a magic shelf with books in it
- Switch sort to "Author A-Z" — books should appear sorted by author
- Switch sort to "Author Z-A" — books should appear in reverse author order
- Verify default sort and other sort options still work

### Related issue

Fixes #1232