### PR TITLE
Fix email send failing when metadata export produces no file

### DIFF
--- a/cps/tasks/mail.py
+++ b/cps/tasks/mail.py
@@ -259,10 +259,15 @@ class TaskEmail(CalibreTask):
             try:
                 if config.config_binariesdir and config.config_embed_metadata:
                     data_path, data_file = do_calibre_export(self.book_id, extension)
-                    datafile = os.path.join(data_path, data_file + "." + extension)
+                    if data_path and data_file:
+                        export_file = os.path.join(data_path, data_file + "." + extension)
+                        if os.path.isfile(export_file):
+                            datafile = export_file
+                        else:
+                            log.warning('Metadata export produced no file, sending without embedded metadata')
                 with open(datafile, 'rb') as file_:
                     data = file_.read()
-                if config.config_binariesdir and config.config_embed_metadata:
+                if config.config_binariesdir and config.config_embed_metadata and datafile != os.path.join(calibre_path, book_path, filename):
                     os.remove(datafile)
             except IOError as e:
                 log.error_or_exception(e, stacklevel=3)


### PR DESCRIPTION
## Fix: email send fails with "attachment not found" when calibredb export fails

### Problem

When sending a book via email with "Embed metadata in sent files" enabled and a split library configuration, the send fails with:

```
ERROR {cps.tasks.mail:137} [Errno 2] No such file or directory: '/tmp/calibre_web/<uuid>.epub'
ERROR {cps.tasks.mail:269} The requested file could not be read. Maybe wrong permissions?
```

The user sees "Attachment not found" in the task list. The book is never sent.

This can be triggered by any condition where `calibredb export` fails to produce output — transient NFS issues, missing book files, or `calibredb` errors. In a split library setup where book files are on NFS, this is more likely to occur.

### Root Cause

In `_get_attachment()` in `cps/tasks/mail.py`, when `config_embed_metadata` is enabled, `do_calibre_export()` is called to create a temporary EPUB with re-embedded metadata. If the export fails to produce a file, `do_calibre_export()` still returns a path via its fallback:

```python
# Fallback to original behavior
return tmp_dir, temp_file_name
```

`_get_attachment()` then unconditionally overwrites `datafile` with this non-existent temp path:

```python
data_path, data_file = do_calibre_export(self.book_id, extension)
datafile = os.path.join(data_path, data_file + "." + extension)
```

The original `datafile` — which pointed to the actual book file on disk and would have worked — is lost. The subsequent `open()` fails and the send is aborted.

### What changed

Before using the export path, the fix checks that:
1. `do_calibre_export()` returned non-None values
2. The exported file actually exists on disk

If either check fails, `datafile` is left pointing to the original book file and a warning is logged. The cleanup `os.remove()` is also guarded so it only runs when an export file was actually used.

A book sent without re-embedded metadata is better than a book not sent at all.

### Testing

- Send a book via email with `config_embed_metadata = 1` — sends with embedded metadata as before
- Trigger a failed export (e.g. temporarily rename the book file on disk, send, then restore) — book sends using the original file, warning logged
- Send a book without `config_embed_metadata` — no change in behaviour

### Related issue

Fixes #1235