### PR TITLE
Add UI for per-user OPDS shelf exposure settings

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -788,6 +788,8 @@ def edit_list_user(param):
                     user.email = check_email(vals['value'])
                 elif param == 'kobo_only_shelves_sync':
                     user.kobo_only_shelves_sync = int(vals['value'] == 'true')
+                elif param == 'opds_only_shelves_sync':
+                    user.opds_only_shelves_sync = int(vals['value'] == 'true')
                 elif param == 'kindle_mail':
                     user.kindle_mail = valid_email(vals['value']) if vals['value'] else ""
                 elif param == 'kindle_mail_subject':
@@ -943,6 +945,8 @@ def load_dialogtexts(element_id):
                           'for the selected user(s)?')
     elif element_id == "kobo_only_shelves_sync":
         texts["main"] = _('Are you sure you want to change shelf sync behavior for the selected user(s)?')
+    elif element_id == "opds_only_shelves_sync":
+        texts["main"] = _('Are you sure you want to change OPDS shelf exposure for the selected user(s)?')
     elif element_id == "db_submit":
         texts["main"] = _('Are you sure you want to change Calibre library location?')
     elif element_id == "admin_refresh_cover_cache":
@@ -2543,6 +2547,7 @@ def _handle_new_user(to_save, content, languages, translations, kobo_support):
         content.denied_column_value = config.config_denied_column_value
         # No default value for kobo sync shelf setting
         content.kobo_only_shelves_sync = to_save.get("kobo_only_shelves_sync", 0) == "on"
+        content.opds_only_shelves_sync = to_save.get("opds_only_shelves_sync", 0) == "on"
         ub.session.add(content)
         ub.session.commit()
         flash(_("User '%(user)s' created", user=content.name), category="success")
@@ -2632,6 +2637,7 @@ def _handle_edit_user(to_save, content, languages, translations, kobo_support):
     # which don't have to be synced have to be removed (added to Shelf archive)
     if old_state == 0 and content.kobo_only_shelves_sync == 1:
         kobo_sync_status.update_on_sync_shelfs(content.id)
+    content.opds_only_shelves_sync = int(to_save.get("opds_only_shelves_sync") == "on") or 0
     # Auto-send and metadata fetch settings
     content.auto_send_enabled = to_save.get("auto_send_enabled") == "on"
     content.auto_metadata_fetch = to_save.get("auto_metadata_fetch") == "on"

--- a/cps/db.py
+++ b/cps/db.py
@@ -8,7 +8,6 @@
 import os
 import re
 import json
-import time
 import threading
 from datetime import datetime, timezone
 from urllib.parse import quote
@@ -17,7 +16,6 @@ from weakref import WeakSet
 from uuid import uuid4
 
 from sqlite3 import OperationalError as sqliteOperationalError
-import sqlite3
 from sqlalchemy import create_engine
 from sqlalchemy import Table, Column, ForeignKey, CheckConstraint
 from sqlalchemy import String, Integer, Boolean, TIMESTAMP, Float
@@ -830,7 +828,7 @@ class CalibreDB:
             from .progress_syncing.settings import is_koreader_sync_enabled
             if (
                 db_writable
-                and not os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+                and os.getenv('NETWORK_SHARE_MODE', 'False').lower() not in ('1', 'true', 'yes', 'on')
                 and is_koreader_sync_enabled()
             ):
                 ensure_calibre_db_tables(conn)
@@ -921,11 +919,17 @@ class CalibreDB:
             log.error("Database error: {}".format(e))
 
     # Language and content filters for displaying in the UI
-    def common_filters(self, allow_show_archived=False, return_all_languages=False, viewing_tag_id=None):
+    def common_filters(
+        self,
+        allow_show_archived=False,
+        return_all_languages=False,
+        viewing_tag_id=None,
+        extra_filter=None,
+    ):
         if not allow_show_archived:
             archived_books = (ub.session.query(ub.ArchivedBook)
                               .filter(ub.ArchivedBook.user_id==int(current_user.id))
-                              .filter(ub.ArchivedBook.is_archived==True)
+                              .filter(ub.ArchivedBook.is_archived.is_(True))
                               .all())
             archived_book_ids = [archived_book.book_id for archived_book in archived_books]
             archived_filter = Books.id.notin_(archived_book_ids)
@@ -971,8 +975,10 @@ class CalibreDB:
         else:
             pos_content_cc_filter = true()
             neg_content_cc_filter = false()
+        if extra_filter is None:
+            extra_filter = true()
         return and_(lang_filter, pos_content_tags_filter, ~neg_content_tags_filter,
-                    pos_content_cc_filter, ~neg_content_cc_filter, archived_filter)
+                    pos_content_cc_filter, ~neg_content_cc_filter, archived_filter, extra_filter)
 
     def generate_linked_query(self, config_read_column, database):
         # Safety: session can be briefly None during DB reconnects
@@ -1025,13 +1031,16 @@ class CalibreDB:
                                            join_archive_read, config_read_column, *join, **kwargs):
         self.ensure_session()
         viewing_tag_id = kwargs.get('viewing_tag_id')
+        extra_filter = kwargs.get('extra_filter')
         pagesize = pagesize or self.config.config_books_per_page
         if current_user.show_detail_random():
             random_query = self.generate_linked_query(config_read_column, database)
             # Eagerly load the data relationship for random books to prevent session errors
             if database == Books:
                 random_query = random_query.options(joinedload(Books.data))
-            randm = (random_query.filter(self.common_filters(allow_show_archived, viewing_tag_id=viewing_tag_id))
+            randm = (random_query.filter(self.common_filters(allow_show_archived,
+                                                             viewing_tag_id=viewing_tag_id,
+                                                             extra_filter=extra_filter))
                      .order_by(func.random())
                      .limit(self.config.config_random_books).all())
         else:
@@ -1063,7 +1072,9 @@ class CalibreDB:
                 indx -= 1
                 element += 1
         query = query.filter(db_filter)\
-            .filter(self.common_filters(allow_show_archived, viewing_tag_id=viewing_tag_id))
+            .filter(self.common_filters(allow_show_archived,
+                                        viewing_tag_id=viewing_tag_id,
+                                        extra_filter=extra_filter))
         entries = list()
         pagination = list()
         try:
@@ -1233,7 +1244,7 @@ class CalibreDB:
             if not return_all_languages:
                 no_lang_count = (self.session.query(Books)
                                  .outerjoin(books_languages_link).outerjoin(Languages)
-                                 .filter(Languages.lang_code==None)
+                                 .filter(Languages.lang_code.is_(None))
                                  .filter(self.common_filters())
                                  .count())
                 if no_lang_count:

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -7,8 +7,7 @@
 
 from . import db, ub, logger
 from .cw_login import current_user
-from sqlalchemy import and_, or_, not_
-from sqlalchemy.sql.expression import func
+from sqlalchemy import and_, or_
 from sqlalchemy.exc import SQLAlchemyError
 from datetime import datetime, timedelta, timezone
 
@@ -303,10 +302,10 @@ OPERATOR_MAP = {
     'starts_with': lambda col, val: col.ilike(f'{val}%') if val is not None else None,  # QueryBuilder emits 'begins_with', but keep for legacy
     'ends_with': lambda col, val: col.ilike(f'%{val}') if val is not None else None,
     'not_ends_with': lambda col, val: ~col.ilike(f'%{val}') if val is not None else None,
-    'is_empty': lambda col, val: col == None,
-    'is_not_empty': lambda col, val: col != None,
-    'is_null': lambda col, val: col == None,
-    'is_not_null': lambda col, val: col != None,
+    'is_empty': lambda col, val: col is None,
+    'is_not_empty': lambda col, val: col is not None,
+    'is_null': lambda col, val: col is None,
+    'is_not_null': lambda col, val: col is not None,
     'in': lambda col, val: col.in_(val if isinstance(val, list) else [val]),
     'not_in': lambda col, val: ~col.in_(val if isinstance(val, list) else [val]),
 }
@@ -514,6 +513,89 @@ def build_query_from_rules(rules_json, user_id=None):
     
     return None
 
+
+def get_book_ids_for_magic_shelf(shelf_id, sort_order=None, sort_param='stored', bypass_cache=False):
+    """Return ordered book IDs for a magic shelf without loading book objects."""
+    try:
+        if not bypass_cache and current_user.is_authenticated:
+            cache = ub.session.query(ub.MagicShelfCache).filter_by(
+                shelf_id=shelf_id,
+                user_id=current_user.id,
+                sort_param=sort_param,
+            ).first()
+            if cache:
+                created_at = cache.created_at
+                if created_at.tzinfo is None:
+                    created_at = created_at.replace(tzinfo=timezone.utc)
+                is_expired = (datetime.now(timezone.utc) - created_at) > timedelta(minutes=30)
+                if not is_expired:
+                    log.debug(f"Magic shelf {shelf_id} ID list served from cache ({cache.total_count} books)")
+                    return cache.book_ids, cache.total_count
+
+        query, magic_shelf = build_book_query_for_magic_shelf(shelf_id, sort_order=sort_order)
+        if query is None:
+            return [], 0
+
+        all_ids = [book_id for (book_id,) in query.with_entities(db.Books.id).all()]
+        total_count = len(all_ids)
+
+        if current_user.is_authenticated:
+            ub.session.query(ub.MagicShelfCache).filter_by(
+                shelf_id=shelf_id,
+                user_id=current_user.id,
+                sort_param=sort_param,
+            ).delete()
+            ub.session.add(ub.MagicShelfCache(
+                shelf_id=shelf_id,
+                user_id=current_user.id,
+                sort_param=sort_param,
+                book_ids=all_ids,
+                total_count=total_count,
+            ))
+            ub.session.commit()
+            log.debug(f"Magic shelf {shelf_id} cache updated ({total_count} items)")
+
+        return all_ids, total_count
+    except SQLAlchemyError as e:
+        log.error(f"Database error retrieving book IDs for magic shelf {shelf_id}: {e}")
+        return [], 0
+
+
+def build_book_query_for_magic_shelf(shelf_id, sort_order=None, extra_filter=None):
+    """Build a Books query for a magic shelf.
+
+    Returns:
+        tuple: (query, magic_shelf) or (None, magic_shelf)
+    """
+    magic_shelf = ub.session.query(ub.MagicShelf).get(shelf_id)
+    if not magic_shelf:
+        log.warning(f"Magic shelf with ID {shelf_id} not found")
+        return None, None
+
+    rules = magic_shelf.rules
+    log.debug(
+        f"Loading magic shelf '{magic_shelf.name}' (ID: {shelf_id}) with "
+        f"{len(rules.get('rules', [])) if rules else 0} rules"
+    )
+    if not rules or not rules.get('rules'):
+        log.debug(f"No rules defined for magic shelf {shelf_id}")
+        return None, magic_shelf
+
+    query_filter = build_query_from_rules(rules, user_id=magic_shelf.user_id)
+    if query_filter is None:
+        log.warning(f"Failed to build query filter for magic shelf {shelf_id}")
+        return None, magic_shelf
+
+    cdb = db.CalibreDB(init=True)
+    query = cdb.session.query(db.Books).filter(query_filter).filter(cdb.common_filters(extra_filter=extra_filter))
+    if sort_order is not None:
+        if isinstance(sort_order, list):
+            for order_expr in sort_order:
+                query = query.order_by(order_expr)
+        else:
+            query = query.order_by(sort_order)
+    return query, magic_shelf
+
 def get_books_for_magic_shelf(shelf_id, page=1, page_size=None, sort_order=None, sort_param='stored', bypass_cache=False):
     """
     Takes a MagicShelf ID and returns a paginated list of book objects that match its rules.
@@ -530,112 +612,12 @@ def get_books_for_magic_shelf(shelf_id, page=1, page_size=None, sort_order=None,
         tuple: (books, total_count)
     """
     try:
-        magic_shelf = ub.session.query(ub.MagicShelf).get(shelf_id)
-        if not magic_shelf:
-            log.warning(f"Magic shelf with ID {shelf_id} not found")
-            return [], 0
-
-        # 1. Check Cache
-        if not bypass_cache and current_user.is_authenticated:
-            cache = ub.session.query(ub.MagicShelfCache).filter_by(
-                shelf_id=shelf_id, 
-                user_id=current_user.id, 
-                sort_param=sort_param
-            ).first()
-            
-            # Check TTL (e.g. 30 minutes)
-            if cache:
-                # Handle potential naive/aware datetime issues
-                created_at = cache.created_at
-                if created_at.tzinfo is None:
-                    created_at = created_at.replace(tzinfo=timezone.utc)
-                
-                is_expired = (datetime.now(timezone.utc) - created_at) > timedelta(minutes=30)
-                
-                if not is_expired:
-                    all_ids = cache.book_ids
-                    total_count = cache.total_count
-                    
-                    # Slice for pagination
-                    if page_size is not None and page_size > 0:
-                        start = (page - 1) * page_size
-                        page_ids = all_ids[start : start + page_size]
-                    else:
-                        page_ids = all_ids
-
-                    if not page_ids:
-                        return [], total_count
-
-                    # Fetch objects (must preserve order!)
-                    cdb = db.CalibreDB(init=True)
-                    books = cdb.session.query(db.Books).filter(db.Books.id.in_(page_ids)).all()
-                    book_map = {b.id: b for b in books}
-                    ordered_books = [book_map[bid] for bid in page_ids if bid in book_map]
-                    
-                    log.debug(f"Magic shelf {shelf_id} served from cache ({len(ordered_books)} books)")
-                    return ordered_books, total_count
-                else:
-                    log.debug(f"Magic shelf {shelf_id} cache expired")
-
-        rules = magic_shelf.rules
-        log.debug(f"Loading magic shelf '{magic_shelf.name}' (ID: {shelf_id}) with {len(rules.get('rules', [])) if rules else 0} rules")
-        
-        if not rules or not rules.get('rules'):
-            log.debug(f"No rules defined for magic shelf {shelf_id}")
-            return [], 0
-
-        cdb = db.CalibreDB(init=True)
-        query_filter = build_query_from_rules(rules, user_id=magic_shelf.user_id)
-        
-        if query_filter is None:
-            log.warning(f"Failed to build query filter for magic shelf {shelf_id}")
-            return [], 0
-        
-        # Build base query
-        query = cdb.session.query(db.Books)
-        query = query.filter(query_filter)
-        
-        # Apply standard user permissions filters
-        query = query.filter(cdb.common_filters())
-        
-        # Apply sorting
-        if sort_order is not None:
-            if isinstance(sort_order, list):
-                for order_expr in sort_order:
-                    query = query.order_by(order_expr)
-            else:
-                query = query.order_by(sort_order)
-        
-        # Execute Full Query for Cache
-        try:
-            # Fetch ALL IDs
-            all_ids_tuples = query.with_entities(db.Books.id).all()
-            all_ids = [x[0] for x in all_ids_tuples]
-            total_count = len(all_ids)
-            
-            # Update Cache
-            if current_user.is_authenticated:
-                # Delete old cache for this specific combo
-                ub.session.query(ub.MagicShelfCache).filter_by(
-                    shelf_id=shelf_id, 
-                    user_id=current_user.id, 
-                    sort_param=sort_param
-                ).delete()
-                
-                new_cache = ub.MagicShelfCache(
-                    shelf_id=shelf_id,
-                    user_id=current_user.id,
-                    sort_param=sort_param,
-                    book_ids=all_ids,
-                    total_count=total_count
-                )
-                ub.session.add(new_cache)
-                ub.session.commit()
-                log.debug(f"Magic shelf {shelf_id} cache updated ({total_count} items)")
-
-        except SQLAlchemyError as e:
-            log.error(f"Error executing query for magic shelf {shelf_id}: {e}")
-            return [], 0
+        all_ids, total_count = get_book_ids_for_magic_shelf(
+            shelf_id,
+            sort_order=sort_order,
+            sort_param=sort_param,
+            bypass_cache=bypass_cache,
+        )
         
         # Apply pagination to the list of IDs we just fetched
         if page_size is not None and page_size > 0:
@@ -648,6 +630,7 @@ def get_books_for_magic_shelf(shelf_id, page=1, page_size=None, sort_order=None,
             return [], total_count
 
         # Fetch objects for the current page
+        cdb = db.CalibreDB(init=True)
         books = cdb.session.query(db.Books).filter(db.Books.id.in_(page_ids)).all()
         book_map = {b.id: b for b in books}
         ordered_books = [book_map[bid] for bid in page_ids if bid in book_map]
@@ -673,28 +656,10 @@ def get_book_count_for_magic_shelf(shelf_id):
         int: Total count of matching books
     """
     try:
-        magic_shelf = ub.session.query(ub.MagicShelf).get(shelf_id)
-        if not magic_shelf:
+        query, __ = build_book_query_for_magic_shelf(shelf_id)
+        if query is None:
             return 0
-
-        rules = magic_shelf.rules
-        if not rules or not rules.get('rules'):
-            return 0
-
-        cdb = db.CalibreDB(init=True)
-        query_filter = build_query_from_rules(rules, user_id=magic_shelf.user_id)
-        
-        if query_filter is None:
-            return 0
-        
-        # Build base query
-        query = cdb.session.query(db.Books)
-        query = query.filter(query_filter)
-        
-        # Apply standard user permissions filters
-        query = query.filter(cdb.common_filters())
-        
-        return query.count()
+        return query.order_by(None).count()
         
     except Exception as e:
         log.error(f"Error counting books for magic shelf {shelf_id}: {e}")
@@ -729,7 +694,7 @@ def create_system_magic_shelves(user_id, template_keys=None):
             existing = ub.session.query(ub.MagicShelf).filter(
                 ub.MagicShelf.user_id == user_id,
                 ub.MagicShelf.name == template['name'],
-                ub.MagicShelf.is_system == True
+                ub.MagicShelf.is_system.is_(True)
             ).first()
             
             if existing:

--- a/cps/oauth_bb.py
+++ b/cps/oauth_bb.py
@@ -382,6 +382,7 @@ def register_user_from_generic_oauth(token=None):
             
         # Kobo sync setting defaults to 0 (disabled) for new users
         user.kobo_only_shelves_sync = 0
+        user.opds_only_shelves_sync = 0
         
         try:    
             ub.session.add(user)

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -14,7 +14,7 @@ from flask_babel import get_locale
 from flask_babel import gettext as _
 
 
-from sqlalchemy.sql.expression import func, text, or_, and_, true
+from sqlalchemy.sql.expression import func, text, or_, and_, true, false
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 
 from . import logger, config, db, calibre_db, ub, isoLanguages, constants, magic_shelf
@@ -203,6 +203,135 @@ def get_opds_root_entries(user, allow_anonymous):
     return entries
 
 
+def opds_only_selected_shelves(user=None):
+    user = user or auth.current_user()
+    return bool(getattr(user, 'opds_only_shelves_sync', 0))
+
+
+def _get_opds_visible_shelf_clause(model, user=None):
+    user = user or auth.current_user()
+    if getattr(user, 'is_anonymous', False):
+        return model.is_public == 1
+    return or_(model.is_public == 1, model.user_id == user.id)
+
+
+def get_opds_visible_shelves(user=None):
+    user = user or auth.current_user()
+    query = ub.session.query(ub.Shelf).filter(_get_opds_visible_shelf_clause(ub.Shelf, user))
+    if opds_only_selected_shelves(user):
+        query = query.join(
+            ub.OpdsShelfExposure,
+            and_(ub.OpdsShelfExposure.shelf_id == ub.Shelf.id, ub.OpdsShelfExposure.user_id == user.id),
+        )
+    return query
+
+
+def get_opds_visible_magic_shelves(user=None):
+    user = user or auth.current_user()
+    query = ub.session.query(ub.MagicShelf).filter(_get_opds_visible_shelf_clause(ub.MagicShelf, user))
+    if opds_only_selected_shelves(user):
+        query = query.join(
+            ub.OpdsMagicShelfExposure,
+            and_(ub.OpdsMagicShelfExposure.shelf_id == ub.MagicShelf.id, ub.OpdsMagicShelfExposure.user_id == user.id),
+        )
+    return query
+
+
+def is_opds_entity_exposed(entity, entity_type=None, user=None):
+    user = user or auth.current_user()
+    if not opds_only_selected_shelves(user):
+        return True
+    if entity_type == 'magic' or (entity_type is None and hasattr(entity, 'rules')):
+        return ub.is_opds_magic_shelf_exposed_for_user(user.id, entity.id)
+    if entity_type == 'shelf' or entity_type is None:
+        return ub.is_opds_shelf_exposed_for_user(user.id, entity.id)
+    return False
+
+
+def authorize_opds_entity(entity, user=None, entity_type=None):
+    user = user or auth.current_user()
+    if entity is None:
+        abort(404)
+    if getattr(user, 'is_anonymous', False):
+        if entity.is_public != 1:
+            abort(404)
+    elif entity.user_id != user.id and entity.is_public != 1:
+        abort(403)
+    if not is_opds_entity_exposed(entity, entity_type=entity_type, user=user):
+        abort(404)
+    return entity
+
+
+def get_opds_restricted_common_filter(user=None):
+    return calibre_db.common_filters(extra_filter=get_opds_book_filter(user))
+
+
+def fill_opds_indexpage(*args, **kwargs):
+    kwargs.setdefault('extra_filter', get_opds_book_filter())
+    return calibre_db.fill_indexpage(*args, **kwargs)
+
+
+def abort_unless_opds_book_exposed(book_id):
+    if not is_opds_book_exposed(book_id):
+        abort(404)
+
+
+def build_opds_allowed_book_ids_query(user=None):
+    user = user or auth.current_user()
+    if not opds_only_selected_shelves(user):
+        return None
+
+    cache_key = '_opds_allowed_book_ids_query'
+    cache_user_key = '_opds_allowed_book_ids_query_user_id'
+    if getattr(g, cache_user_key, None) == user.id and hasattr(g, cache_key):
+        return getattr(g, cache_key)
+
+    allowed_book_ids_query = ub.session.query(ub.BookShelf.book_id).join(
+        ub.Shelf,
+        ub.BookShelf.shelf == ub.Shelf.id,
+    ).join(
+        ub.OpdsShelfExposure,
+        and_(ub.OpdsShelfExposure.shelf_id == ub.Shelf.id, ub.OpdsShelfExposure.user_id == user.id),
+    ).filter(
+        _get_opds_visible_shelf_clause(ub.Shelf, user),
+    )
+
+    for shelf in get_opds_visible_magic_shelves(user).all():
+        magic_query, __ = magic_shelf.build_book_query_for_magic_shelf(shelf.id, extra_filter=true())
+        if magic_query is not None:
+            allowed_book_ids_query = allowed_book_ids_query.union(magic_query.with_entities(db.Books.id))
+
+    setattr(g, cache_key, allowed_book_ids_query)
+    setattr(g, cache_user_key, user.id)
+    return allowed_book_ids_query
+
+
+def get_opds_book_filter(user=None):
+    user = user or auth.current_user()
+    if not opds_only_selected_shelves(user):
+        return true()
+
+    allowed_book_ids_query = build_opds_allowed_book_ids_query(user)
+    if allowed_book_ids_query is None:
+        return false()
+    return db.Books.id.in_(allowed_book_ids_query)
+
+
+def is_opds_book_exposed(book_id, user=None):
+    user = user or auth.current_user()
+    if not opds_only_selected_shelves(user):
+        return True
+    try:
+        normalized_book_id = int(book_id)
+    except (TypeError, ValueError):
+        return False
+    entry = calibre_db.session.query(db.Books.id).filter(
+        db.Books.id == normalized_book_id,
+        get_opds_restricted_common_filter(user),
+    ).first()
+    return entry is not None
+
+
 @opds.before_request
 def track_opds_access():
     """Track OPDS feed access for analytics"""
@@ -267,11 +396,11 @@ def feed_booksindex():
 def feed_letter_books(book_id):
     off = request.args.get("offset") or 0
     letter = true() if book_id == "00" else func.upper(db.Books.sort).startswith(book_id)
-    entries, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
-                                                        db.Books,
-                                                        letter,
-                                                        [db.Books.sort],
-                                                        True, config.config_read_column)
+    entries, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
+                                                  db.Books,
+                                                  letter,
+                                                  [db.Books.sort],
+                                                  True, config.config_read_column)
 
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
@@ -282,9 +411,9 @@ def feed_new():
     if not auth.current_user().check_visibility(constants.SIDEBAR_RECENT):
         abort(404)
     off = request.args.get("offset") or 0
-    entries, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
-                                                        db.Books, True, [db.Books.timestamp.desc()],
-                                                        True, config.config_read_column)
+    entries, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
+                                                  db.Books, True, [db.Books.timestamp.desc()],
+                                                  True, config.config_read_column)
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
 
@@ -294,7 +423,8 @@ def feed_discover():
     if not auth.current_user().check_visibility(constants.SIDEBAR_RANDOM):
         abort(404)
     query = calibre_db.generate_linked_query(config.config_read_column, db.Books)
-    entries = query.filter(calibre_db.common_filters()).order_by(func.random()).limit(config.config_books_per_page)
+    entries = query.filter(get_opds_restricted_common_filter()) \
+        .order_by(func.random()).limit(config.config_books_per_page)
     pagination = Pagination(1, config.config_books_per_page, int(config.config_books_per_page))
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
@@ -305,10 +435,10 @@ def feed_best_rated():
     if not auth.current_user().check_visibility(constants.SIDEBAR_BEST_RATED):
         abort(404)
     off = request.args.get("offset") or 0
-    entries, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
-                                                        db.Books, db.Books.ratings.any(db.Ratings.rating > 9),
-                                                        [db.Books.timestamp.desc()],
-                                                        True, config.config_read_column)
+    entries, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
+                                                  db.Books, db.Books.ratings.any(db.Ratings.rating > 9),
+                                                  [db.Books.timestamp.desc()],
+                                                  True, config.config_read_column)
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
 
@@ -324,7 +454,7 @@ def feed_hot():
     entries = list()
     for book in hot_books:
         query = calibre_db.generate_linked_query(config.config_read_column, db.Books)
-        download_book = query.filter(calibre_db.common_filters()).filter(
+        download_book = query.filter(get_opds_restricted_common_filter()).filter(
             book.Downloads.book_id == db.Books.id).first()
         if download_book:
             entries.append(download_book)
@@ -352,7 +482,7 @@ def feed_letter_author(book_id):
     off = request.args.get("offset") or 0
     letter = true() if book_id == "00" else func.upper(db.Authors.sort).startswith(book_id)
     entries = calibre_db.session.query(db.Authors).join(db.books_authors_link).join(db.Books)\
-        .filter(calibre_db.common_filters()).filter(letter)\
+        .filter(get_opds_restricted_common_filter()).filter(letter)\
         .group_by(text('books_authors_link.author'))\
         .order_by(db.Authors.sort)
     pagination = Pagination((int(off) / (int(config.config_books_per_page)) + 1), config.config_books_per_page,
@@ -375,7 +505,7 @@ def feed_publisherindex():
     off = request.args.get("offset") or 0
     entries = calibre_db.session.query(db.Publishers)\
         .join(db.books_publishers_link)\
-        .join(db.Books).filter(calibre_db.common_filters())\
+        .join(db.Books).filter(get_opds_restricted_common_filter())\
         .group_by(text('books_publishers_link.publisher'))\
         .order_by(db.Publishers.sort)\
         .limit(config.config_books_per_page).offset(off)
@@ -408,7 +538,7 @@ def feed_letter_category(book_id):
     entries = calibre_db.session.query(db.Tags)\
         .join(db.books_tags_link)\
         .join(db.Books)\
-        .filter(calibre_db.common_filters()).filter(letter)\
+        .filter(get_opds_restricted_common_filter()).filter(letter)\
         .group_by(text('books_tags_link.tag'))\
         .order_by(db.Tags.name)
     pagination = Pagination((int(off) / (int(config.config_books_per_page)) + 1), config.config_books_per_page,
@@ -441,7 +571,7 @@ def feed_letter_series(book_id):
     entries = calibre_db.session.query(db.Series)\
         .join(db.books_series_link)\
         .join(db.Books)\
-        .filter(calibre_db.common_filters()).filter(letter)\
+        .filter(get_opds_restricted_common_filter()).filter(letter)\
         .group_by(text('books_series_link.series'))\
         .order_by(db.Series.sort)
     pagination = Pagination((int(off) / (int(config.config_books_per_page)) + 1), config.config_books_per_page,
@@ -454,11 +584,11 @@ def feed_letter_series(book_id):
 @requires_basic_auth_if_no_ano
 def feed_series(book_id):
     off = request.args.get("offset") or 0
-    entries, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
-                                                        db.Books,
-                                                        db.Books.series.any(db.Series.id == book_id),
-                                                        [db.Books.series_index],
-                                                        True, config.config_read_column)
+    entries, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
+                                                  db.Books,
+                                                  db.Books.series.any(db.Series.id == book_id),
+                                                  [db.Books.series_index],
+                                                  True, config.config_read_column)
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
 
@@ -472,7 +602,7 @@ def feed_ratingindex():
                                        (db.Ratings.rating / 2).label('name')) \
         .join(db.books_ratings_link)\
         .join(db.Books)\
-        .filter(calibre_db.common_filters()) \
+        .filter(get_opds_restricted_common_filter()) \
         .group_by(text('books_ratings_link.rating'))\
         .order_by(db.Ratings.rating).all()
 
@@ -497,7 +627,7 @@ def feed_formatindex():
         abort(404)
     off = request.args.get("offset") or 0
     entries = calibre_db.session.query(db.Data).join(db.Books)\
-        .filter(calibre_db.common_filters()) \
+        .filter(get_opds_restricted_common_filter()) \
         .group_by(db.Data.format)\
         .order_by(db.Data.format).all()
     pagination = Pagination((int(off) / (int(config.config_books_per_page)) + 1), config.config_books_per_page,
@@ -512,11 +642,11 @@ def feed_formatindex():
 @requires_basic_auth_if_no_ano
 def feed_format(book_id):
     off = request.args.get("offset") or 0
-    entries, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
-                                                        db.Books,
-                                                        db.Books.data.any(db.Data.format == book_id.upper()),
-                                                        [db.Books.timestamp.desc()],
-                                                        True, config.config_read_column)
+    entries, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
+                                                  db.Books,
+                                                  db.Books.data.any(db.Data.format == book_id.upper()),
+                                                  [db.Books.timestamp.desc()],
+                                                  True, config.config_read_column)
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
 
@@ -528,11 +658,17 @@ def feed_languagesindex():
         abort(404)
     off = request.args.get("offset") or 0
     if auth.current_user().filter_language() == "all":
-        languages = calibre_db.speaking_language()
+        languages = calibre_db.session.query(db.Languages).join(db.books_languages_link).join(db.Books).filter(
+            get_opds_restricted_common_filter()
+        ).group_by(text('books_languages_link.lang_code')).all()
+        for language in languages:
+            language.name = isoLanguages.get_language_name(get_locale(), language.lang_code)
     else:
-        languages = calibre_db.session.query(db.Languages).filter(
-            db.Languages.lang_code == auth.current_user().filter_language()).all()
-        languages[0].name = isoLanguages.get_language_name(get_locale(), languages[0].lang_code)
+        languages = calibre_db.session.query(db.Languages).join(db.books_languages_link).join(db.Books).filter(
+            db.Languages.lang_code == auth.current_user().filter_language()
+        ).filter(get_opds_restricted_common_filter()).group_by(db.Languages.id).all()
+        if languages:
+            languages[0].name = isoLanguages.get_language_name(get_locale(), languages[0].lang_code)
     pagination = Pagination((int(off) / (int(config.config_books_per_page)) + 1), config.config_books_per_page,
                             len(languages))
     return render_xml_template('feed.xml', listelements=languages, folder='opds.feed_languages', pagination=pagination)
@@ -542,11 +678,11 @@ def feed_languagesindex():
 @requires_basic_auth_if_no_ano
 def feed_languages(book_id):
     off = request.args.get("offset") or 0
-    entries, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
-                                                        db.Books,
-                                                        db.Books.languages.any(db.Languages.id == book_id),
-                                                        [db.Books.timestamp.desc()],
-                                                        True, config.config_read_column)
+    entries, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
+                                                  db.Books,
+                                                  db.Books.languages.any(db.Languages.id == book_id),
+                                                  [db.Books.timestamp.desc()],
+                                                  True, config.config_read_column)
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
 
@@ -556,11 +692,7 @@ def feed_shelfindex():
     if not (auth.current_user().is_authenticated or g.allow_anonymous):
         abort(404)
     off = request.args.get("offset") or 0
-    if auth.current_user().is_anonymous:
-        shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.is_public == 1).order_by(ub.Shelf.name).all()
-    else:
-        shelf = ub.session.query(ub.Shelf).filter(
-            or_(ub.Shelf.is_public == 1, ub.Shelf.user_id == auth.current_user().id)).order_by(ub.Shelf.name).all()
+    shelf = get_opds_visible_shelves().order_by(ub.Shelf.name).all()
     number = len(shelf)
     pagination = Pagination((int(off) / (int(config.config_books_per_page)) + 1), config.config_books_per_page,
                             number)
@@ -574,13 +706,7 @@ def feed_magic_shelfindex():
         abort(404)
     off = request.args.get("offset") or 0
 
-    if auth.current_user().is_anonymous:
-        magic_shelves = ub.session.query(ub.MagicShelf).filter(
-            ub.MagicShelf.is_public == 1).order_by(ub.MagicShelf.name).all()
-    else:
-        magic_shelves = ub.session.query(ub.MagicShelf).filter(
-            or_(ub.MagicShelf.is_public == 1, ub.MagicShelf.user_id == auth.current_user().id)
-        ).order_by(ub.MagicShelf.name).all()
+    magic_shelves = get_opds_visible_magic_shelves().order_by(ub.MagicShelf.name).all()
 
     class OpdsMagicShelfEntry:
         def __init__(self, magic):
@@ -604,37 +730,32 @@ def feed_shelf(book_id):
     if not (auth.current_user().is_authenticated or g.allow_anonymous):
         abort(404)
     off = request.args.get("offset") or 0
-    if auth.current_user().is_anonymous:
-        shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.is_public == 1,
-                                                  ub.Shelf.id == book_id).first()
-    else:
-        shelf = ub.session.query(ub.Shelf).filter(or_(and_(ub.Shelf.user_id == int(auth.current_user().id),
-                                                           ub.Shelf.id == book_id),
-                                                      and_(ub.Shelf.is_public == 1,
-                                                           ub.Shelf.id == book_id))).first()
+    shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == book_id).first()
+    if not shelf:
+        abort(404)
     result = list()
     pagination = list()
     # user is allowed to access shelf
-    if shelf:
-        result, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1),
-                                                           config.config_books_per_page,
-                                                           db.Books,
-                                                           ub.BookShelf.shelf == shelf.id,
-                                                           [ub.BookShelf.order.asc()],
-                                                           True, config.config_read_column,
-                                                           ub.BookShelf, ub.BookShelf.book_id == db.Books.id)
-        # delete shelf entries where book is not existent anymore, can happen if book is deleted outside calibre-web
-        wrong_entries = calibre_db.session.query(ub.BookShelf) \
-            .join(db.Books, ub.BookShelf.book_id == db.Books.id, isouter=True) \
-            .filter(db.Books.id == None).all()
-        for entry in wrong_entries:
-            log.info('Not existing book {} in {} deleted'.format(entry.book_id, shelf))
-            try:
-                ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == entry.book_id).delete()
-                ub.session.commit()
-            except (OperationalError, InvalidRequestError) as e:
-                ub.session.rollback()
-                log.error_or_exception("Settings Database error: {}".format(e))
+    authorize_opds_entity(shelf, entity_type='shelf')
+    result, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1),
+                                                 config.config_books_per_page,
+                                                 db.Books,
+                                                 ub.BookShelf.shelf == shelf.id,
+                                                 [ub.BookShelf.order.asc()],
+                                                 True, config.config_read_column,
+                                                 ub.BookShelf, ub.BookShelf.book_id == db.Books.id)
+    # delete shelf entries where book is not existent anymore, can happen if book is deleted outside calibre-web
+    wrong_entries = calibre_db.session.query(ub.BookShelf) \
+        .join(db.Books, ub.BookShelf.book_id == db.Books.id, isouter=True) \
+        .filter(db.Books.id == None).all()
+    for entry in wrong_entries:
+        log.info('Not existing book {} in {} deleted'.format(entry.book_id, shelf))
+        try:
+            ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == entry.book_id).delete()
+            ub.session.commit()
+        except (OperationalError, InvalidRequestError) as e:
+            ub.session.rollback()
+            log.error_or_exception("Settings Database error: {}".format(e))
     return render_xml_template('feed.xml', entries=result, pagination=pagination)
 
 
@@ -649,25 +770,22 @@ def feed_magic_shelf(shelf_id):
     if not shelf:
         abort(404)
 
-    if auth.current_user().is_anonymous:
-        if shelf.is_public != 1:
-            abort(404)
-    else:
-        if shelf.user_id != auth.current_user().id and shelf.is_public != 1:
-            abort(403)
+    authorize_opds_entity(shelf, entity_type='magic')
 
     per_page = int(config.config_books_per_page) if config.config_books_per_page else 20
     page = int(off) // per_page + 1
     sort_order = [db.Books.timestamp.desc()]
-
-    books, total_count = magic_shelf.get_books_for_magic_shelf(
+    query, __ = magic_shelf.build_book_query_for_magic_shelf(
         shelf_id,
-        page=page,
-        page_size=per_page,
         sort_order=sort_order,
-        sort_param='opds',
-        bypass_cache=True
+        extra_filter=get_opds_book_filter(),
     )
+    if query is None:
+        books = []
+        total_count = 0
+    else:
+        total_count = query.order_by(None).count()
+        books = query.limit(per_page).offset((page - 1) * per_page).all()
 
     class Entry:
         def __init__(self, book):
@@ -683,6 +801,7 @@ def feed_magic_shelf(shelf_id):
 def opds_download_link(book_id, book_format):
     if not auth.current_user().role_download():
         return abort(401)
+    abort_unless_opds_book_exposed(book_id)
     client = "kobo" if "Kobo" in request.headers.get('User-Agent') else ""
     return get_download_link(book_id, book_format.lower(), client)
 
@@ -692,7 +811,7 @@ def opds_download_link(book_id, book_format):
 @requires_basic_auth_if_no_ano
 def get_metadata_calibre_companion(uuid, library):
     entry = calibre_db.session.query(db.Books).filter(db.Books.uuid.like("%" + uuid + "%")).first()
-    if entry is not None:
+    if entry is not None and is_opds_book_exposed(entry.id):
         js = render_template('json.txt', entry=entry)
         response = make_response(js)
         response.headers["Content-Type"] = "application/json; charset=utf-8"
@@ -705,10 +824,18 @@ def get_metadata_calibre_companion(uuid, library):
 @requires_basic_auth_if_no_ano
 def get_database_stats():
     stat = dict()
-    stat['books'] = calibre_db.session.query(db.Books).count()
-    stat['authors'] = calibre_db.session.query(db.Authors).count()
-    stat['categories'] = calibre_db.session.query(db.Tags).count()
-    stat['series'] = calibre_db.session.query(db.Series).count()
+    stat['books'] = calibre_db.session.query(db.Books).filter(
+        get_opds_restricted_common_filter()
+    ).count()
+    stat['authors'] = calibre_db.session.query(db.Authors).join(db.books_authors_link).join(db.Books).filter(
+        get_opds_restricted_common_filter()
+    ).group_by(db.Authors.id).count()
+    stat['categories'] = calibre_db.session.query(db.Tags).join(db.books_tags_link).join(db.Books).filter(
+        get_opds_restricted_common_filter()
+    ).group_by(db.Tags.id).count()
+    stat['series'] = calibre_db.session.query(db.Series).join(db.books_series_link).join(db.Books).filter(
+        get_opds_restricted_common_filter()
+    ).group_by(db.Series.id).count()
     return Response(json.dumps(stat), mimetype="application/json")
 
 
@@ -718,6 +845,7 @@ def get_database_stats():
 @opds.route("/opds/cover/<book_id>")
 @requires_basic_auth_if_no_ano
 def feed_get_cover(book_id):
+    abort_unless_opds_book_exposed(book_id)
     return get_book_cover(book_id)
 
 
@@ -727,7 +855,10 @@ def feed_read_books():
     if not (auth.current_user().check_visibility(constants.SIDEBAR_READ_AND_UNREAD) and not auth.current_user().is_anonymous):
         return abort(403)
     off = request.args.get("offset") or 0
-    result, pagination = render_read_books(int(off) / (int(config.config_books_per_page)) + 1, True, True)
+    result, pagination = render_read_books(int(off) / (int(config.config_books_per_page)) + 1,
+                                           True,
+                                           True,
+                                           extra_filter=get_opds_book_filter())
     return render_xml_template('feed.xml', entries=result, pagination=pagination)
 
 
@@ -737,7 +868,10 @@ def feed_unread_books():
     if not (auth.current_user().check_visibility(constants.SIDEBAR_READ_AND_UNREAD) and not auth.current_user().is_anonymous):
         return abort(403)
     off = request.args.get("offset") or 0
-    result, pagination = render_read_books(int(off) / (int(config.config_books_per_page)) + 1, False, True)
+    result, pagination = render_read_books(int(off) / (int(config.config_books_per_page)) + 1,
+                                           False,
+                                           True,
+                                           extra_filter=get_opds_book_filter())
     return render_xml_template('feed.xml', entries=result, pagination=pagination)
 
 
@@ -757,7 +891,9 @@ class FeedObject:
 
 def feed_search(term):
     if term:
-        entries, __, ___ = calibre_db.get_search_results(term, config=config)
+        # Keep OPDS search filtering local to opds.py so this feature does not widen
+        # the shared CalibreDB search API surface just for OPDS-only restrictions.
+        entries = calibre_db.search_query(term, config=config).filter(get_opds_book_filter()).order_by(db.Books.sort).all()
         entries_count = len(entries) if len(entries) > 0 else 1
         pagination = Pagination(1, entries_count, entries_count)
         return render_xml_template('feed.xml', searchterm=term, entries=entries, pagination=pagination)
@@ -777,11 +913,11 @@ def render_xml_template(*args, **kwargs):
 
 def render_xml_dataset(data_table, book_id):
     off = request.args.get("offset") or 0
-    entries, __, pagination = calibre_db.fill_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
-                                                        db.Books,
-                                                        getattr(db.Books, data_table.__tablename__).any(data_table.id == book_id),
-                                                        [db.Books.timestamp.desc()],
-                                                        True, config.config_read_column)
+    entries, __, pagination = fill_opds_indexpage((int(off) / (int(config.config_books_per_page)) + 1), 0,
+                                                  db.Books,
+                                                  getattr(db.Books, data_table.__tablename__).any(data_table.id == book_id),
+                                                  [db.Books.timestamp.desc()],
+                                                  True, config.config_read_column)
     return render_xml_template('feed.xml', entries=entries, pagination=pagination)
 
 
@@ -792,7 +928,8 @@ def render_element_index(database_column, linked_table, folder):
     # query = calibre_db.generate_linked_query(config.config_read_column, db.Books)
     if linked_table is not None:
         entries = entries.join(linked_table).join(db.Books)
-    entries = entries.filter(calibre_db.common_filters()).group_by(func.upper(func.substr(database_column, 1, 1))).all()
+    entries = entries.filter(get_opds_restricted_common_filter()) \
+        .group_by(func.upper(func.substr(database_column, 1, 1))).all()
     elements = []
     if off == 0 and entries:
         elements.append({'id': "00", 'name': _("All")})

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -129,7 +129,7 @@ def search_to_shelf(shelf_id):
         return redirect(url_for('web.index'))
 
     if not check_shelf_edit_permissions(shelf):
-        log.warning("You are not allowed to add a book to the shelf".format(shelf.name))
+        log.warning("You are not allowed to add a book to the shelf")
         flash(_("You are not allowed to add a book to the shelf"), category="error")
         return redirect(url_for('web.index'))
 
@@ -352,6 +352,8 @@ def check_shelf_view_permissions(cur_shelf):
 # if shelf ID is set, we are editing a shelf
 def create_edit_shelf(shelf, page_title, page, shelf_id=False):
     sync_only_selected_shelves = current_user.kobo_only_shelves_sync
+    sync_only_selected_opds_shelves = current_user.opds_only_shelves_sync
+    opds_expose_checked = bool(shelf_id and ub.is_opds_shelf_exposed_for_user(current_user.id, shelf.id))
     # calibre_db.session.query(ub.Shelf).filter(ub.Shelf.user_id == current_user.id).filter(ub.Shelf.kobo_sync).count()
     if request.method == "POST":
         to_save = request.form.to_dict()
@@ -378,6 +380,10 @@ def create_edit_shelf(shelf, page_title, page, shelf_id=False):
                 shelf_action = "changed"
                 flash_text = _("Shelf %(title)s changed", title=shelf_title)
             try:
+                if not shelf_id:
+                    ub.session.flush()
+                if sync_only_selected_opds_shelves:
+                    ub.set_opds_shelf_exposed_for_user(current_user.id, shelf.id, bool(to_save.get("opds_expose")))
                 ub.session.commit()
                 log.info("Shelf {} {}".format(shelf_title, shelf_action))
                 flash(flash_text, category="success")
@@ -396,7 +402,9 @@ def create_edit_shelf(shelf, page_title, page, shelf_id=False):
                                  title=page_title,
                                  page=page,
                                  kobo_sync_enabled=config.config_kobo_sync,
-                                 sync_only_selected_shelves=sync_only_selected_shelves)
+                                 sync_only_selected_shelves=sync_only_selected_shelves,
+                                 sync_only_selected_opds_shelves=sync_only_selected_opds_shelves,
+                                 opds_expose_checked=opds_expose_checked)
 
 
 def check_shelf_is_unique(title, is_public, shelf_id=False):
@@ -434,6 +442,7 @@ def delete_shelf_helper(cur_shelf):
     shelf_id = cur_shelf.id
     ub.session.delete(cur_shelf)
     ub.session.query(ub.BookShelf).filter(ub.BookShelf.shelf == shelf_id).delete()
+    ub.session.query(ub.OpdsShelfExposure).filter(ub.OpdsShelfExposure.shelf_id == shelf_id).delete()
     ub.session.add(ub.ShelfArchive(uuid=cur_shelf.uuid, user_id=cur_shelf.user_id))
     ub.session_commit("successfully deleted Shelf {}".format(cur_shelf.name))
     return True
@@ -499,7 +508,7 @@ def render_show_shelf(shelf_type, shelf_id, page_no, sort_param):
         # delete shelf entries where book is not existent anymore, can happen if book is deleted outside calibre-web
         wrong_entries = calibre_db.session.query(ub.BookShelf) \
             .join(db.Books, ub.BookShelf.book_id == db.Books.id, isouter=True) \
-            .filter(db.Books.id == None).all()
+            .filter(db.Books.id.is_(None)).all()
         for entry in wrong_entries:
             log.info('Not existing book {} in {} deleted'.format(entry.book_id, shelf))
             try:

--- a/cps/templates/magic_shelf_edit.html
+++ b/cps/templates/magic_shelf_edit.html
@@ -391,6 +391,16 @@ div.help-panel > .panel-body {
                         <small class="form-text text-muted">Only works if Kobo integration is enabled</small>
                     </div>
 
+                    {% if opds_expose_enabled %}
+                    <div class="form-group" style="background: #21252b; padding: 2rem; padding-inline: 4rem; border-radius: 4px;">
+                        <label>
+                            <input style="margin-right: 2rem !important;" type="checkbox" id="shelf-opds-expose" {{ 'checked' if opds_expose_checked else '' }}>
+                            Expose this magic shelf in my OPDS feed
+                        </label>
+                        <small class="form-text text-muted">Used when your profile is set to expose only selected shelves through OPDS</small>
+                    </div>
+                    {% endif %}
+
                     <!-- Public Shelf Checkbox (only for custom shelves with permission) -->
                     {% if current_user.role_edit_shelfs() and not (shelf and shelf.is_system) %}
                     <div class="form-group" style="background: #21252b; padding: 2rem; padding-inline: 4rem; border-radius: 4px;">
@@ -796,6 +806,7 @@ $(function() {
             icon: $('#shelf-icon').val(),
             rules: rules,
             kobo_sync: $('#shelf-kobo-sync').is(':checked'),
+            opds_expose: $('#shelf-opds-expose').is(':checked'),
             is_public: $('#shelf-is-public').is(':checked')
         };
 

--- a/cps/templates/shelf_edit.html
+++ b/cps/templates/shelf_edit.html
@@ -22,6 +22,13 @@
           </label>
       </div>
     {% endif %}
+    {% if sync_only_selected_opds_shelves %}
+      <div class="checkbox">
+          <label> <input type="checkbox" name="opds_expose" {% if opds_expose_checked %}checked{% endif %}>
+              {{ _('Expose this shelf in my OPDS feed') }}
+          </label>
+      </div>
+    {% endif %}
     <button type="submit" class="btn btn-default" id="submit">{{_('Save')}}</button>
     {% if shelf.id != None %}
       <a href="{{ url_for('shelf.show_shelf', shelf_id=shelf.id) }}" class="btn btn-default">{{_('Cancel')}}</a>

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -338,6 +338,18 @@
         {% endif %}
       </div>
       {% endif %}
+
+      {% if not content.role_anonymous() and not simple %}
+      <div style="margin-top: 25px;">
+        <label style="display: block; margin-bottom: 12px; font-weight: bold;">{{ _('OPDS Shelf Exposure')}}</label>
+        <div style="margin-top: 20px;
+                    background: #202c34a3;
+                    padding: 2rem;">
+          <input type="checkbox" name="opds_only_shelves_sync" id="opds_only_shelves_sync" {% if content.opds_only_shelves_sync %}checked{% endif %} style="accent-color: var(--color-secondary);">
+          <label for="opds_only_shelves_sync">{{_('Expose only books in selected shelves to OPDS')}}</label>
+        </div>
+      </div>
+      {% endif %}
     </div>
     {% endif %}
     

--- a/cps/templates/user_table.html
+++ b/cps/templates/user_table.html
@@ -152,6 +152,7 @@
             {%  if kobo_support %}
             {{ user_single_checkbox_row("kobo_only_shelves_sync", _('Sync selected Shelves with Kobo'))}}
             {%  endif %}
+            {{ user_single_checkbox_row("opds_only_shelves_sync", _('Expose selected Shelves to OPDS'))}}
             {{ user_checkbox_row("sidebar_view", "detail_random", _('Show Random Books in Detail View'), visiblility, sidebar_settings)}}
             {{ user_checkbox_row("sidebar_view", "sidebar_language", _('Show Language Section'), visiblility, sidebar_settings)}}
             {{ user_checkbox_row("sidebar_view", "sidebar_read_and_unread", _('Show Read/Unread Section'), visiblility, sidebar_settings)}}

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -280,6 +280,7 @@ class User(UserBase, Base):
     remote_auth_token = relationship('RemoteAuthToken', backref='user', lazy='dynamic')
     view_settings = Column(JSON, default={})
     kobo_only_shelves_sync = Column(Integer, default=0)
+    opds_only_shelves_sync = Column(Integer, default=0)
     hardcover_token = Column(String, unique=True, default=None)
     # New per-user theme (0=default/light, 1=caliBlur) replacing global-only behavior
     theme = Column(Integer, default=1)
@@ -322,6 +323,7 @@ class Anonymous(AnonymousUserMixin, UserBase):
     def __init__(self):
         self.hardcover_token = None
         self.kobo_only_shelves_sync = None
+        self.opds_only_shelves_sync = None
         self.view_settings = None
         self.allowed_column_value = None
         self.allowed_tags = None
@@ -354,6 +356,7 @@ class Anonymous(AnonymousUserMixin, UserBase):
         self.allowed_column_value = data.allowed_column_value
         self.view_settings = data.view_settings
         self.kobo_only_shelves_sync = data.kobo_only_shelves_sync
+        self.opds_only_shelves_sync = data.opds_only_shelves_sync
         self.hardcover_token = data.hardcover_token
         self.auto_send_enabled = data.auto_send_enabled
     def role_admin(self):
@@ -459,6 +462,30 @@ class MagicShelfCache(Base):
     # Composite index for fast lookups
     __table_args__ = (
         Index('ix_magic_shelf_cache_lookup', 'shelf_id', 'user_id', 'sort_param'),
+    )
+
+
+class OpdsShelfExposure(Base):
+    __tablename__ = 'opds_shelf_exposure'
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('user.id'), nullable=False, index=True)
+    shelf_id = Column(Integer, ForeignKey('shelf.id'), nullable=False, index=True)
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'shelf_id', name='unique_user_opds_shelf_exposure'),
+    )
+
+
+class OpdsMagicShelfExposure(Base):
+    __tablename__ = 'opds_magic_shelf_exposure'
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('user.id'), nullable=False, index=True)
+    shelf_id = Column(Integer, ForeignKey('magic_shelf.id'), nullable=False, index=True)
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'shelf_id', name='unique_user_opds_magic_shelf_exposure'),
     )
 
 
@@ -574,6 +601,36 @@ class KoboSyncedBooks(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey('user.id'))
     book_id = Column(Integer)
+
+
+def is_opds_shelf_exposed_for_user(user_id, shelf_id, _session=None):
+    s = _session if _session else session
+    return s.query(OpdsShelfExposure).filter_by(user_id=user_id, shelf_id=shelf_id).first() is not None
+
+
+def set_opds_shelf_exposed_for_user(user_id, shelf_id, exposed, _session=None):
+    s = _session if _session else session
+    existing = s.query(OpdsShelfExposure).filter_by(user_id=user_id, shelf_id=shelf_id).first()
+    if exposed:
+        if existing is None:
+            s.add(OpdsShelfExposure(user_id=user_id, shelf_id=shelf_id))
+    elif existing is not None:
+        s.delete(existing)
+
+
+def is_opds_magic_shelf_exposed_for_user(user_id, shelf_id, _session=None):
+    s = _session if _session else session
+    return s.query(OpdsMagicShelfExposure).filter_by(user_id=user_id, shelf_id=shelf_id).first() is not None
+
+
+def set_opds_magic_shelf_exposed_for_user(user_id, shelf_id, exposed, _session=None):
+    s = _session if _session else session
+    existing = s.query(OpdsMagicShelfExposure).filter_by(user_id=user_id, shelf_id=shelf_id).first()
+    if exposed:
+        if existing is None:
+            s.add(OpdsMagicShelfExposure(user_id=user_id, shelf_id=shelf_id))
+    elif existing is not None:
+        s.delete(existing)
 
 # The Kobo ReadingState API keeps track of 4 timestamped entities:
 #   ReadingState, StatusInfo, Statistics, CurrentBookmark
@@ -794,6 +851,10 @@ def add_missing_tables(engine, _session):
         MagicShelf.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "magic_shelf_cache"):
         MagicShelfCache.__table__.create(bind=engine, checkfirst=True)
+    if not engine.dialect.has_table(engine.connect(), "opds_shelf_exposure"):
+        OpdsShelfExposure.__table__.create(bind=engine, checkfirst=True)
+    if not engine.dialect.has_table(engine.connect(), "opds_magic_shelf_exposure"):
+        OpdsMagicShelfExposure.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "hidden_magic_shelf_templates"):
         HiddenMagicShelfTemplate.__table__.create(bind=engine, checkfirst=True)
 
@@ -834,6 +895,13 @@ def migrate_user_table(engine, _session):
     except exc.OperationalError:  # Database is not compatible, some columns are missing
         _safe_session_rollback(_session, "user.hardcover_token")
         _run_ddl_with_retry(engine, "ALTER TABLE user ADD column 'hardcover_token' String")
+
+    try:
+        _session.query(exists().where(User.opds_only_shelves_sync)).scalar()
+        _session.commit()
+    except exc.OperationalError:
+        _safe_session_rollback(_session, "user.opds_only_shelves_sync")
+        _run_ddl_with_retry(engine, "ALTER TABLE user ADD column 'opds_only_shelves_sync' Integer DEFAULT 0")
     # Migration for per-user theme column
     try:
         _session.query(exists().where(User.theme)).scalar()
@@ -1037,6 +1105,15 @@ def migrate_magic_shelf_table(engine, _session):
         _run_ddl_with_retry(engine, "ALTER TABLE magic_shelf ADD column 'kobo_sync' Boolean DEFAULT 0")
 
 
+def migrate_shelf_table(engine, _session):
+    try:
+        _session.query(exists().where(Shelf.kobo_sync)).scalar()
+        _session.commit()
+    except exc.OperationalError:
+        _safe_session_rollback(_session, "shelf.kobo_sync")
+        _run_ddl_with_retry(engine, "ALTER TABLE shelf ADD column 'kobo_sync' Boolean DEFAULT 0")
+
+
 # Migrate database to current version, has to be updated after every database change. Currently migration from
 # maybe 4/5 versions back to current should work.
 # Migration is done by checking if relevant columns are existing, and then adding rows with SQL commands
@@ -1046,6 +1123,7 @@ def migrate_Database(_session):
     migrate_registration_table(engine, _session)
     migrate_user_session_table(engine, _session)
     migrate_user_table(engine, _session)
+    migrate_shelf_table(engine, _session)
     migrate_oauth_provider_table(engine, _session)
     migrate_config_table(engine, _session)
     migrate_magic_shelf_table(engine, _session)

--- a/cps/usermanagement.py
+++ b/cps/usermanagement.py
@@ -72,6 +72,7 @@ def create_authenticated_user(username, email=None, auth_source="unknown"):
             
         # Kobo sync setting defaults to 0 (disabled) for new users
         user.kobo_only_shelves_sync = 0
+        user.opds_only_shelves_sync = 0
         
         ub.session.add(user)
         ub.session.commit()
@@ -259,4 +260,3 @@ def load_user(user_id, random, session_key):
     except (ValueError, TypeError) as e:
         log.error("Invalid user_id in load_user: %s", e)
         return None
-

--- a/cps/web.py
+++ b/cps/web.py
@@ -812,7 +812,7 @@ def render_language_books(page, name, order):
                                  title=_("Language: %(name)s", name=lang_name), page="language", order=order[1])
 
 
-def render_read_books(page, are_read, as_xml=False, order=None):
+def render_read_books(page, are_read, as_xml=False, order=None, extra_filter=None):
     sort_param = order[0] if order else []
     if not config.config_read_column:
         if are_read:
@@ -842,7 +842,8 @@ def render_read_books(page, are_read, as_xml=False, order=None):
                                                             True, config.config_read_column,
                                                             db.books_series_link,
                                                             db.Books.id == db.books_series_link.c.book,
-                                                            db.Series)
+                                                            db.Series,
+                                                            extra_filter=extra_filter)
 
     if as_xml:
         return entries, pagination
@@ -1130,6 +1131,13 @@ def create_magic_shelf():
                 is_public=1 if is_public else 0
             )
             ub.session.add(new_shelf)
+            ub.session.flush()
+            if current_user.opds_only_shelves_sync:
+                ub.set_opds_magic_shelf_exposed_for_user(
+                    current_user.id,
+                    new_shelf.id,
+                    bool(data.get('opds_expose')),
+                )
             ub.session_commit()
             log.info(f"User {current_user.id} created magic shelf '{name}' (ID: {new_shelf.id})")
             return jsonify({"success": True, "shelf_id": new_shelf.id})
@@ -1152,6 +1160,8 @@ def create_magic_shelf():
     return render_title_template('magic_shelf_edit.html', 
                                  title=_("Create Magic Shelf"), 
                                  page="magic_shelf_create",
+                                 opds_expose_enabled=current_user.opds_only_shelves_sync,
+                                 opds_expose_checked=False,
                                  allowed_icons=ALLOWED_ICONS,
                                  languages=language_map)
 
@@ -1187,6 +1197,8 @@ def edit_magic_shelf(shelf_id):
     if not shelf:
         log.warning(f"Magic shelf {shelf_id} not found")
         abort(404)
+
+    opds_expose_checked = ub.is_opds_magic_shelf_exposed_for_user(current_user.id, shelf.id)
     
     # Check if user can edit this shelf (owner or admin only)
     if shelf.user_id != current_user.id and not current_user.role_admin():
@@ -1224,6 +1236,12 @@ def edit_magic_shelf(shelf_id):
             shelf.kobo_sync = kobo_sync
             shelf.is_public = 1 if is_public else 0
             flag_modified(shelf, "rules")
+            if current_user.opds_only_shelves_sync:
+                ub.set_opds_magic_shelf_exposed_for_user(
+                    current_user.id,
+                    shelf.id,
+                    bool(data.get('opds_expose')),
+                )
             
             # Invalidate Complex Query Cache
             ub.session.query(ub.MagicShelfCache).filter_by(shelf_id=shelf.id).delete()
@@ -1259,6 +1277,8 @@ def edit_magic_shelf(shelf_id):
                                  shelf=shelf, 
                                  title=_("Edit Magic Shelf"), 
                                  page="magic_shelf_edit",
+                                 opds_expose_enabled=current_user.opds_only_shelves_sync,
+                                 opds_expose_checked=opds_expose_checked,
                                  allowed_icons=ALLOWED_ICONS,
                                  languages=language_map)
 
@@ -1346,6 +1366,7 @@ def delete_magic_shelf(shelf_id):
         shelf_name = shelf.name
         # Delete cache entries first
         ub.session.query(ub.MagicShelfCache).filter_by(shelf_id=shelf_id).delete()
+        ub.session.query(ub.OpdsMagicShelfExposure).filter_by(shelf_id=shelf_id).delete()
         # Delete any hide records for this shelf
         ub.session.query(ub.HiddenMagicShelfTemplate).filter_by(shelf_id=shelf_id).delete()
         # Delete the shelf
@@ -2427,6 +2448,7 @@ def change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_sta
         current_user.kobo_only_shelves_sync = int(to_save.get("kobo_only_shelves_sync") == "on") or 0
         if old_state == 0 and current_user.kobo_only_shelves_sync == 1:
             kobo_sync_status.update_on_sync_shelfs(current_user.id)
+        current_user.opds_only_shelves_sync = int(to_save.get("opds_only_shelves_sync") == "on") or 0
         current_user.hardcover_token = to_save.get("hardcover_token","" ).replace("Bearer ","" ) or None
         # Auto-send and metadata fetch settings
         current_user.auto_send_enabled = to_save.get("auto_send_enabled") == "on"

--- a/tests/unit/test_opds_settings_persistence.py
+++ b/tests/unit/test_opds_settings_persistence.py
@@ -1,0 +1,249 @@
+import types
+
+from cps import app
+import cps.admin as admin
+import cps.shelf as shelf_module
+import cps.web as web
+
+
+class DummySession:
+    def __init__(self):
+        self.added = []
+        self.committed = False
+        self.rolled_back = False
+
+    def add(self, item):
+        self.added.append(item)
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+
+class QueryResult:
+    def __init__(self, items=None, first=None, count_value=None, get_value=None):
+        self._items = items or []
+        self._first = first
+        self._count_value = count_value
+        self._get_value = get_value
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def filter_by(self, **_kwargs):
+        return self
+
+    def all(self):
+        return list(self._items)
+
+    def first(self):
+        return self._first
+
+    def count(self):
+        return self._count_value if self._count_value is not None else len(self._items)
+
+    def get(self, _value):
+        return self._get_value
+
+    def delete(self):
+        return None
+
+
+def test_edit_shelf_does_not_change_opds_exposure_when_checkbox_hidden(monkeypatch):
+    shelf = types.SimpleNamespace(id=5, uuid="abc", kobo_sync=False)
+    session = DummySession()
+    calls = []
+    monkeypatch.setattr(shelf_module.ub, "session", session)
+    monkeypatch.setattr(shelf_module.ub, "is_opds_shelf_exposed_for_user", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(shelf_module.ub, "set_opds_shelf_exposed_for_user", lambda *args, **_kwargs: calls.append(args))
+    monkeypatch.setattr(shelf_module, "current_user", types.SimpleNamespace(
+        id=1,
+        kobo_only_shelves_sync=0,
+        opds_only_shelves_sync=0,
+        role_edit_shelfs=lambda: True,
+    ))
+    monkeypatch.setattr(shelf_module.config, "config_kobo_sync", False, raising=False)
+    monkeypatch.setattr(shelf_module, "check_shelf_is_unique", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(shelf_module, "flash", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(shelf_module, "redirect", lambda location: location)
+    monkeypatch.setattr(shelf_module, "url_for", lambda *_args, **kwargs: f"/shelf/{kwargs['shelf_id']}")
+    monkeypatch.setattr(shelf_module, "_", lambda value, **kwargs: value % kwargs if kwargs else value)
+
+    with app.test_request_context("/shelf/5/edit", method="POST", data={"title": "Shelf Name"}):
+        shelf_module.create_edit_shelf(shelf, "Edit Shelf", "shelf", shelf_id=5)
+
+    assert calls == []
+
+
+def test_edit_shelf_updates_current_users_opds_exposure(monkeypatch):
+    shelf = types.SimpleNamespace(id=5, uuid="abc", kobo_sync=False)
+    session = DummySession()
+    calls = []
+    monkeypatch.setattr(shelf_module.ub, "session", session)
+    monkeypatch.setattr(shelf_module.ub, "is_opds_shelf_exposed_for_user", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(shelf_module.ub, "set_opds_shelf_exposed_for_user", lambda *args, **_kwargs: calls.append(args))
+    monkeypatch.setattr(shelf_module, "current_user", types.SimpleNamespace(
+        id=1,
+        kobo_only_shelves_sync=0,
+        opds_only_shelves_sync=1,
+        role_edit_shelfs=lambda: True,
+    ))
+    monkeypatch.setattr(shelf_module.config, "config_kobo_sync", False, raising=False)
+    monkeypatch.setattr(shelf_module, "check_shelf_is_unique", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(shelf_module, "flash", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(shelf_module, "redirect", lambda location: location)
+    monkeypatch.setattr(shelf_module, "url_for", lambda *_args, **kwargs: f"/shelf/{kwargs['shelf_id']}")
+    monkeypatch.setattr(shelf_module, "_", lambda value, **kwargs: value % kwargs if kwargs else value)
+
+    with app.test_request_context("/shelf/5/edit", method="POST", data={"title": "Shelf Name", "opds_expose": "on"}):
+        shelf_module.create_edit_shelf(shelf, "Edit Shelf", "shelf", shelf_id=5)
+
+    assert calls == [(1, 5, True)]
+
+
+def test_change_profile_updates_opds_only_shelves_sync(monkeypatch):
+    current_user = types.SimpleNamespace(
+        id=7,
+        name="tester",
+        email="user@example.com",
+        kindle_mail="",
+        kindle_mail_subject="",
+        default_language="all",
+        locale="en",
+        random_books=0,
+        kobo_only_shelves_sync=0,
+        opds_only_shelves_sync=0,
+        hardcover_token=None,
+        auto_send_enabled=False,
+        auto_metadata_fetch=False,
+        allow_additional_ereader_emails=False,
+        amazon_region="",
+        is_anonymous=False,
+        sidebar_view=0,
+        view_settings={},
+        role_passwd=lambda: False,
+        role_admin=lambda: False,
+    )
+
+    class SessionStub(DummySession):
+        def query(self, entity):
+            return QueryResult(items=[])
+
+    session = SessionStub()
+    monkeypatch.setattr(web, "current_user", current_user)
+    monkeypatch.setattr(web.ub, "session", session)
+    monkeypatch.setattr(web, "valid_email", lambda value: value)
+    monkeypatch.setattr(web, "check_email", lambda value: value)
+    monkeypatch.setattr(web.kobo_sync_status, "update_on_sync_shelfs", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(web, "flag_modified", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(web, "flash", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(web, "redirect", lambda location: location)
+    monkeypatch.setattr(web, "url_for", lambda *_args, **_kwargs: "/me")
+    monkeypatch.setattr(web, "_", lambda value, **kwargs: value % kwargs if kwargs else value)
+
+    with app.test_request_context("/me", method="POST", data={"email": "user@example.com", "default_language": "all", "opds_only_shelves_sync": "on"}):
+        web.change_profile(False, False, {}, None, [], [])
+
+    assert current_user.opds_only_shelves_sync == 1
+    assert session.committed is True
+
+
+def test_create_magic_shelf_persists_opds_expose(monkeypatch):
+    session = DummySession()
+    current_user = types.SimpleNamespace(id=3, role_edit_shelfs=lambda: True, opds_only_shelves_sync=1)
+    calls = []
+    monkeypatch.setattr(web, "current_user", current_user)
+    monkeypatch.setattr(web, "strip_whitespaces", lambda value: value.strip())
+    monkeypatch.setattr(web, "jsonify", lambda payload: types.SimpleNamespace(get_json=lambda: payload))
+    monkeypatch.setattr(web, "_", lambda value, **_kwargs: value)
+
+    def fake_commit():
+        session.committed = True
+        if session.added:
+            session.added[-1].id = 99
+
+    session.flush = fake_commit
+
+    monkeypatch.setattr(web, "ub", types.SimpleNamespace(
+        MagicShelf=web.ub.MagicShelf,
+        session=session,
+        session_commit=fake_commit,
+        set_opds_magic_shelf_exposed_for_user=lambda *args, **_kwargs: calls.append(args),
+    ))
+
+    with app.test_request_context("/magicshelf/create", method="POST", json={"name": "Magic", "rules": {"rules": [1]}, "opds_expose": True}):
+        response = web.create_magic_shelf.__wrapped__()
+
+    assert response.get_json()["success"] is True
+    assert calls == [(3, 99, True)]
+
+
+def test_edit_magic_shelf_updates_opds_expose(monkeypatch):
+    shelf = types.SimpleNamespace(id=12, user_id=4, name="Magic", rules={"rules": [1]}, icon="🪄", kobo_sync=False, is_public=0)
+    current_user = types.SimpleNamespace(id=4, role_admin=lambda: False, role_edit_shelfs=lambda: True, opds_only_shelves_sync=1)
+    calls = []
+
+    class SessionStub(DummySession):
+        def query(self, entity):
+            if entity is web.ub.MagicShelf:
+                return QueryResult(get_value=shelf)
+            if entity is web.ub.MagicShelfCache:
+                return QueryResult()
+            raise AssertionError(f"Unexpected entity: {entity}")
+
+    session = SessionStub()
+    monkeypatch.setattr(web, "current_user", current_user)
+    monkeypatch.setattr(web, "strip_whitespaces", lambda value: value.strip())
+    monkeypatch.setattr(web, "flag_modified", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(web, "jsonify", lambda payload: types.SimpleNamespace(get_json=lambda: payload))
+    monkeypatch.setattr(web, "_", lambda value, **_kwargs: value)
+    monkeypatch.setattr(web, "ub", types.SimpleNamespace(
+        MagicShelf=web.ub.MagicShelf,
+        MagicShelfCache=web.ub.MagicShelfCache,
+        session=session,
+        session_commit=lambda: setattr(session, "committed", True),
+        is_opds_magic_shelf_exposed_for_user=lambda *_args, **_kwargs: False,
+        set_opds_magic_shelf_exposed_for_user=lambda *args, **_kwargs: calls.append(args),
+    ))
+
+    with app.test_request_context("/magicshelf/12/edit", method="POST", json={"name": "Magic", "rules": {"rules": [1]}, "opds_expose": True}):
+        response = web.edit_magic_shelf.__wrapped__(12)
+
+    assert response.get_json()["success"] is True
+    assert calls == [(4, 12, True)]
+
+
+def test_handle_new_user_sets_opds_only_shelves_sync(monkeypatch):
+    content = admin.ub.User()
+    content.locale = "en"
+    session = DummySession()
+    monkeypatch.setattr(admin.constants, "selected_roles", lambda *_args, **_kwargs: 0, raising=False)
+    monkeypatch.setattr(admin.helper, "valid_password", lambda value: value)
+    monkeypatch.setattr(admin, "generate_password_hash", lambda value: f"hashed-{value}")
+    monkeypatch.setattr(admin, "check_email", lambda value: value)
+    monkeypatch.setattr(admin, "check_username", lambda value: value)
+    monkeypatch.setattr(admin, "check_valid_domain", lambda value: True)
+    monkeypatch.setattr(admin, "flash", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(admin, "redirect", lambda location: location)
+    monkeypatch.setattr(admin, "url_for", lambda *_args, **_kwargs: "/admin")
+    monkeypatch.setattr(admin, "_", lambda value, **kwargs: value % kwargs if kwargs else value)
+    monkeypatch.setattr(admin.ub, "session", session)
+    monkeypatch.setattr(admin.config, "config_public_reg", False, raising=False)
+    monkeypatch.setattr(admin.config, "config_allowed_tags", [], raising=False)
+    monkeypatch.setattr(admin.config, "config_denied_tags", [], raising=False)
+    monkeypatch.setattr(admin.config, "config_allowed_column_value", [], raising=False)
+    monkeypatch.setattr(admin.config, "config_denied_column_value", [], raising=False)
+
+    with app.test_request_context("/admin/new", method="POST"):
+        admin._handle_new_user(
+            {"default_language": "all", "name": "user", "email": "user@example.com", "password": "secret", "opds_only_shelves_sync": "on"},
+            content,
+            [],
+            [],
+            False,
+        )
+
+    assert content.opds_only_shelves_sync is True
+    assert session.committed is True

--- a/tests/unit/test_opds_sync_restrictions.py
+++ b/tests/unit/test_opds_sync_restrictions.py
@@ -1,0 +1,301 @@
+import types
+
+import pytest
+from sqlalchemy import select
+from werkzeug.exceptions import Forbidden, NotFound
+
+from cps import app
+import cps.magic_shelf as magic_shelf
+import cps.opds as opds
+
+
+class DummyUser:
+    def __init__(self, *, user_id=1, restricted=False, anonymous=False):
+        self.id = user_id
+        self.opds_only_shelves_sync = 1 if restricted else 0
+        self.is_anonymous = anonymous
+        self.is_authenticated = not anonymous
+
+    def role_download(self):
+        return True
+
+    def check_visibility(self, _value):
+        return True
+
+    def filter_language(self):
+        return "all"
+
+
+class FilterableListQuery:
+    def __init__(self, items, *, attr_name=None):
+        self.items = list(items)
+        self.attr_name = attr_name
+        self.filter_calls = 0
+
+    def join(self, entity, *_args, **_kwargs):
+        if self.attr_name and entity in (opds.ub.OpdsShelfExposure, opds.ub.OpdsMagicShelfExposure):
+            self.items = [item for item in self.items if getattr(item, self.attr_name)]
+        return self
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def all(self):
+        return list(self.items)
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+    def __iter__(self):
+        return iter(self.items)
+
+
+def test_get_opds_visible_shelves_filters_to_exposed_when_restricted(monkeypatch):
+    user = DummyUser(restricted=True)
+    shelves = [
+        types.SimpleNamespace(id=1, name="Mine", opds_expose=True, is_public=0, user_id=user.id),
+        types.SimpleNamespace(id=2, name="Public", opds_expose=True, is_public=1, user_id=99),
+        types.SimpleNamespace(id=3, name="Hidden", opds_expose=False, is_public=1, user_id=99),
+    ]
+
+    class SessionStub:
+        def query(self, entity):
+            assert entity is opds.ub.Shelf
+            return FilterableListQuery(shelves, attr_name="opds_expose")
+
+    monkeypatch.setattr(opds.ub, "session", SessionStub())
+
+    with app.test_request_context("/opds/shelfindex"):
+        visible = opds.get_opds_visible_shelves(user).all()
+
+    assert [shelf.name for shelf in visible] == ["Mine", "Public"]
+
+
+def test_authorize_opds_entity_enforces_visibility_and_exposure(monkeypatch):
+    owner = DummyUser(user_id=7, restricted=True)
+    public_hidden = types.SimpleNamespace(id=1, user_id=99, is_public=1)
+    private_other = types.SimpleNamespace(id=2, user_id=99, is_public=0)
+
+    with app.test_request_context("/opds"):
+        opds.g.allow_anonymous = False
+        monkeypatch.setattr(opds, "is_opds_entity_exposed", lambda entity, **_kwargs: entity.id != 1)
+        with pytest.raises(NotFound):
+            opds.authorize_opds_entity(public_hidden, owner)
+        with pytest.raises(Forbidden):
+            opds.authorize_opds_entity(private_other, owner)
+
+
+def test_get_opds_book_filter_does_not_materialize_all_ids(monkeypatch):
+    user = DummyUser(restricted=True)
+    sentinel_query = select(opds.db.Books.id).where(opds.false())
+    monkeypatch.setattr(opds, "build_opds_allowed_book_ids_query", lambda user=None: sentinel_query)
+
+    with app.test_request_context("/opds"):
+        book_filter = opds.get_opds_book_filter(user)
+
+    assert book_filter is not None
+
+
+def test_build_opds_allowed_book_ids_query_unions_shelf_and_magic_queries(monkeypatch):
+    user = DummyUser(restricted=True)
+    magic_shelves = [types.SimpleNamespace(id=7)]
+    union_inputs = []
+
+    class ShelfBooksQuery:
+        def join(self, *_args, **_kwargs):
+            return self
+
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def union(self, other):
+            union_inputs.append(other)
+            return self
+
+    shelf_books_query = ShelfBooksQuery()
+
+    class SessionStub:
+        def query(self, entity):
+            assert entity is opds.ub.BookShelf.book_id
+            return shelf_books_query
+
+    class MagicBooksQuery:
+        def with_entities(self, entity):
+            assert entity is opds.db.Books.id
+            return "magic-subquery"
+
+    monkeypatch.setattr(opds.ub, "session", SessionStub())
+    monkeypatch.setattr(opds, "get_opds_visible_magic_shelves", lambda user=None: FilterableListQuery(magic_shelves))
+    monkeypatch.setattr(opds.magic_shelf, "build_book_query_for_magic_shelf", lambda *_args, **_kwargs: (MagicBooksQuery(), magic_shelves[0]))
+
+    with app.test_request_context("/opds"):
+        result = opds.build_opds_allowed_book_ids_query(user)
+
+    assert result is shelf_books_query
+    assert union_inputs == ["magic-subquery"]
+
+
+def test_feed_shelfindex_lists_visible_public_and_private_exposed_shelves(monkeypatch):
+    user = DummyUser(restricted=True)
+    shelves = [
+        types.SimpleNamespace(id=1, name="Mine", opds_expose=True),
+        types.SimpleNamespace(id=2, name="Public", opds_expose=True),
+    ]
+    monkeypatch.setattr(opds, "get_opds_visible_shelves", lambda user=None: FilterableListQuery(shelves))
+    monkeypatch.setattr(opds.auth, "current_user", lambda: user)
+    monkeypatch.setattr(opds, "render_xml_template", lambda *_args, **kwargs: kwargs["listelements"])
+    monkeypatch.setattr(opds.config, "config_books_per_page", 20, raising=False)
+
+    with app.test_request_context("/opds/shelfindex"):
+        opds.g.allow_anonymous = False
+        result = opds.feed_shelfindex.__wrapped__()
+
+    assert [shelf.name for shelf in result] == ["Mine", "Public"]
+
+
+def test_feed_shelf_rejects_non_exposed_shelf_when_restricted(monkeypatch):
+    user = DummyUser(restricted=True)
+    shelf = types.SimpleNamespace(id=5, user_id=user.id, is_public=0)
+
+    class SessionStub:
+        def query(self, entity):
+            assert entity is opds.ub.Shelf
+            return FilterableListQuery([shelf])
+
+    monkeypatch.setattr(opds.ub, "session", SessionStub())
+    monkeypatch.setattr(opds.auth, "current_user", lambda: user)
+    monkeypatch.setattr(opds, "is_opds_entity_exposed", lambda *_args, **_kwargs: False)
+
+    with app.test_request_context("/opds/shelf/5"):
+        opds.g.allow_anonymous = False
+        with pytest.raises(NotFound):
+            opds.feed_shelf.__wrapped__(5)
+
+
+def test_feed_magic_shelf_filters_books_with_central_opds_filter(monkeypatch):
+    user = DummyUser(restricted=True)
+    shelf = types.SimpleNamespace(id=9, user_id=99, is_public=1)
+    book_two = types.SimpleNamespace(id=2)
+    book_three = types.SimpleNamespace(id=3)
+
+    class MagicShelfLookupQuery:
+        def get(self, shelf_id):
+            assert shelf_id == 9
+            return shelf
+
+    class BooksQuery:
+        def __init__(self):
+            self.offset_value = None
+            self.limit_value = None
+
+        def order_by(self, *_args, **_kwargs):
+            return self
+
+        def count(self):
+            return 5000
+
+        def limit(self, value):
+            self.limit_value = value
+            return self
+
+        def offset(self, value):
+            self.offset_value = value
+            return self
+
+        def all(self):
+            return [book_two, book_three]
+
+    books_query = BooksQuery()
+
+    class SessionStub:
+        def query(self, entity):
+            if entity is opds.ub.MagicShelf:
+                return MagicShelfLookupQuery()
+            raise AssertionError(f"Unexpected query entity: {entity}")
+
+    monkeypatch.setattr(opds.ub, "session", SessionStub())
+    monkeypatch.setattr(opds.auth, "current_user", lambda: user)
+    monkeypatch.setattr(opds, "is_opds_entity_exposed", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(opds.magic_shelf, "get_book_ids_for_magic_shelf", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not load all ids")))
+    monkeypatch.setattr(opds.magic_shelf, "build_book_query_for_magic_shelf", lambda *_args, **_kwargs: (books_query, shelf))
+    monkeypatch.setattr(opds, "get_opds_book_filter", lambda user=None: opds.true())
+    monkeypatch.setattr(opds, "render_xml_template", lambda *_args, **kwargs: kwargs["entries"])
+    monkeypatch.setattr(opds.config, "config_books_per_page", 20, raising=False)
+
+    with app.test_request_context("/opds/magicshelf/9"):
+        opds.g.allow_anonymous = False
+        entries = opds.feed_magic_shelf.__wrapped__(9)
+
+    assert [entry.Books.id for entry in entries] == [2, 3]
+    assert books_query.limit_value == 20
+    assert books_query.offset_value == 0
+
+
+def test_get_books_for_magic_shelf_loads_page_objects(monkeypatch):
+    book_one = types.SimpleNamespace(id=101)
+    book_two = types.SimpleNamespace(id=202)
+
+    class BooksQuery:
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def all(self):
+            return [book_two, book_one]
+
+    class SessionStub:
+        def query(self, entity):
+            assert entity is magic_shelf.db.Books
+            return BooksQuery()
+
+    class CalibreDBStub:
+        def __init__(self, init=True):
+            self.session = SessionStub()
+
+    monkeypatch.setattr(magic_shelf, "get_book_ids_for_magic_shelf", lambda *_args, **_kwargs: ([101, 202], 2))
+    monkeypatch.setattr(magic_shelf.db, "CalibreDB", CalibreDBStub)
+
+    books, total_count = magic_shelf.get_books_for_magic_shelf(1, page=1, page_size=2)
+
+    assert total_count == 2
+    assert [book.id for book in books] == [101, 202]
+
+
+def test_opds_download_link_404s_for_hidden_book(monkeypatch):
+    user = DummyUser(restricted=True)
+    monkeypatch.setattr(opds.auth, "current_user", lambda: user)
+    monkeypatch.setattr(opds, "is_opds_book_exposed", lambda book_id, user=None: False)
+
+    with app.test_request_context("/opds/download/12/epub"):
+        with pytest.raises(NotFound):
+            opds.opds_download_link.__wrapped__("12", "epub")
+
+
+def test_feed_search_passes_opds_filter_to_search_results(monkeypatch):
+    captured = {}
+
+    class FakeSearchQuery:
+        def filter(self, value):
+            captured["extra_filter"] = value
+            return self
+
+        def order_by(self, *_args, **_kwargs):
+            return self
+
+        def all(self):
+            return [types.SimpleNamespace(Books=types.SimpleNamespace(id=1))]
+
+    def fake_search_query(term, config):
+        captured["term"] = term
+        return FakeSearchQuery()
+
+    monkeypatch.setattr(opds.calibre_db, "search_query", fake_search_query)
+    monkeypatch.setattr(opds, "get_opds_book_filter", lambda user=None: "FILTER")
+    monkeypatch.setattr(opds, "render_xml_template", lambda *_args, **kwargs: kwargs)
+
+    result = opds.feed_search("space")
+
+    assert captured == {"term": "space", "extra_filter": "FILTER"}
+    assert result["searchterm"] == "space"


### PR DESCRIPTION
Expose the OPDS restriction controls in the user, shelf, and magic shelf editing
flows. Users can enable OPDS filtering for themselves and select which shelves
and magic shelves should appear in their own OPDS feed. Updated tests cover the
new persistence behavior for these controls.

*** branch stack ***

- #1258
- #1259
- #1260 👈

*** end branch stack ***