### PR TITLE
fix(user_profiles.json): add getPath() to fetch()

### DIFF
--- a/cps/static/user-profile-data/CWA-profile-updater.js
+++ b/cps/static/user-profile-data/CWA-profile-updater.js
@@ -1,4 +1,4 @@
-fetch('/user_profiles.json')
+fetch(getPath() + '/user_profiles.json')
   .then(response => response.json())
   .then(usernameToImage => {
     var usernameElement = document.querySelector('#top_user .hidden-sm');

--- a/cps/templates/cwa_user_activity.html
+++ b/cps/templates/cwa_user_activity.html
@@ -865,7 +865,7 @@ function initCharts() {
     searchSuccessChart = echarts.init(document.getElementById('search-success-chart'));
     
     // Fetch user profiles first, then update visualizations
-    fetch('/user_profiles.json')
+    fetch(getPath() + '/user_profiles.json')
         .then(response => response.json())
         .then(data => {
             userProfiles = data;


### PR DESCRIPTION
Add missing call to `getPath()` in order to give the proper prefix to the `fetch()` call. This is especially important if CWA is running behind a reverse proxy.

Fixes #1188