### PR TITLE
Run ingest service python workers as abc, not root

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -111,7 +111,7 @@ wait_for_stable_file() {
 
 run_fallback() {
         echo "[cwa-ingest-service] Falling back to polling watcher" >&2
-        python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
+        s6-setuidgid abc python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
         while read -r events filepath; do
                 handle_event "$filepath"
         done
@@ -155,7 +155,7 @@ process_retry_queue() {
                                 echo "[cwa-ingest-service] Retrying: $queued_file"
                                 local configured_timeout=$(get_timeout_from_db)  # Get configured timeout from database
                                 local safety_timeout=$((configured_timeout * 3))  # Safety timeout is 3x the configured timeout
-                                timeout $safety_timeout python3 /app/calibre-web-automated/scripts/ingest_processor.py "$queued_file"
+                                timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$queued_file"
                                 local retry_exit=$?
 
                                 if [ $retry_exit -eq 2 ]; then
@@ -213,7 +213,7 @@ handle_event() {
         echo "processing:$filename:$(date '+%Y-%m-%d %H:%M:%S')" > "$STATUS_FILE"
 
         # Use safety timeout as last resort - processor should handle its own timeout internally
-        timeout $safety_timeout python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
+        timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
         local exit_code=$?
 
         if [ $exit_code -eq 124 ]; then


### PR DESCRIPTION
## Problem

With the documented `PUID=103 PGID=112` configuration, `cps.py` (the web app) correctly runs as the `abc` user via `s6-setuidgid abc` in `svc-calibre-web-automated/run`. Inside `cwa-ingest-service/run`, the `inotifywait` invocation is also prefixed with `s6-setuidgid abc`.

Three other python3 invocations in the same script run as root:

- `python3 watch_fallback.py` on the polling path (line 114)
- `timeout $safety_timeout python3 ingest_processor.py "$queued_file"` in the retry loop (line 158)
- `timeout $safety_timeout python3 ingest_processor.py "$filepath"` on the primary event path (line 216)

Because the actual ingest work (`ingest_processor.py`) runs as root, every auto-imported book lands in `/calibre-library` as `root:root`. The web UI, running as `abc`, then fails to delete these books:

```
Deleting book 66 failed: [Errno 13] Permission denied: '/calibre-library/Author Name/Book Title (66)/metadata.opf'
```

## Fix

Prefix each of those three python3 invocations with `s6-setuidgid abc`, matching the pattern already used for `inotifywait` in the same file.
