### PR TITLE
fix(metadata search): Send CSRF token in a way to work with Mobile Safari

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -238,7 +238,10 @@ $(function () {
       $.ajax({
         url: getPath() + "/metadata/search",
         type: "POST",
-        data: { query: keyword },
+        data: {
+          query: keyword,
+          csrf_token: $("input[name='csrf_token']").first().val(),
+        },
         dataType: "json",
         success: function success(data) {
           if (data.length) {

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -286,11 +286,13 @@ $(function() {
     $.ajaxPrefilter(preFilters.fire);
 
     // equip all post requests with csrf_token
-    var csrftoken = $("input[name='csrf_token']").val();
     $.ajaxSetup({
         beforeSend: function(xhr, settings) {
             if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-                xhr.setRequestHeader("X-CSRFToken", csrftoken)
+                var csrftoken = $("input[name='csrf_token']").first().val();
+                if (csrftoken) {
+                    xhr.setRequestHeader("X-CSRFToken", csrftoken);
+                }
             }
         }
     });

--- a/cps/templates/cwa_convert_library.html
+++ b/cps/templates/cwa_convert_library.html
@@ -83,7 +83,7 @@
   }
 
   function scheduleConvertLibrary(delayMinutes) {
-    fetch('/cwa-internal/schedule-convert-library', {
+    cwaFetch('/cwa-internal/schedule-convert-library', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ delay_minutes: delayMinutes, username: '{{ current_user.name }}' })
@@ -109,7 +109,7 @@
     let get;
     
     try {
-      const res = await fetch("{{ url_for('convert_library.get_status')}}");
+      const res = await cwaFetch("{{ url_for('convert_library.get_status')}}");
       get = await res.json();
     } catch (e) {
       console.error("Error: ", e);

--- a/cps/templates/cwa_epub_fixer.html
+++ b/cps/templates/cwa_epub_fixer.html
@@ -103,7 +103,7 @@
   }
 
   function scheduleEpubFixer(delayMinutes) {
-    fetch('/cwa-internal/schedule-epub-fixer', {
+    cwaFetch('/cwa-internal/schedule-epub-fixer', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ delay_minutes: delayMinutes, username: '{{ current_user.name }}' })
@@ -168,7 +168,7 @@
       return;
     }
     try {
-      const res = await fetch(`/ajax/listbooks?search=${encodeURIComponent(query)}&limit=10&offset=0`);
+      const res = await cwaFetch(`/ajax/listbooks?search=${encodeURIComponent(query)}&limit=10&offset=0`);
       const data = await res.json();
       renderEpubFixerSearchResults((data && data.rows) ? data.rows : []);
     } catch (e) {
@@ -183,7 +183,7 @@
       return;
     }
     try {
-      const res = await fetch("{{ url_for('epub_fixer.run_epub_fixer_for_book') }}", {
+      const res = await cwaFetch("{{ url_for('epub_fixer.run_epub_fixer_for_book') }}", {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ book_id: bookId })
@@ -206,7 +206,7 @@
     let get;
     
     try {
-      const res = await fetch("{{ url_for('epub_fixer.get_status')}}");
+      const res = await cwaFetch("{{ url_for('epub_fixer.get_status')}}");
       get = await res.json();
     } catch (e) {
       console.error("Error: ", e);

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -30,13 +30,35 @@
     <script>
       let checkMessagesInterval = null; // Store interval ID
 
-      function refreshLibrary() {
-          fetch("/cwa-library-refresh", {
-              method: "POST",
-              headers: {
-                  "Content-Type": "application/json"
+      function getCsrfToken() {
+          const input = document.querySelector("input[name='csrf_token']");
+          return input ? input.value : "";
+      }
+
+      function cwaFetch(url, options = {}) {
+          const fetchOptions = { ...options };
+          fetchOptions.credentials = fetchOptions.credentials || "same-origin";
+
+          const method = (fetchOptions.method || "GET").toUpperCase();
+          if (!["GET", "HEAD", "OPTIONS", "TRACE"].includes(method)) {
+              const headers = new Headers(fetchOptions.headers || {});
+              const csrfToken = getCsrfToken();
+              if (csrfToken && !headers.has("X-CSRFToken")) {
+                  headers.set("X-CSRFToken", csrfToken);
               }
-          })
+              fetchOptions.headers = headers;
+          }
+
+          return fetch(url, fetchOptions);
+      }
+
+      function refreshLibrary() {
+          cwaFetch("/cwa-library-refresh", {
+               method: "POST",
+               headers: {
+                   "Content-Type": "application/json"
+               }
+           })
           .then(response => response.json())
           .then(data => {
             updateLibraryRefreshMessage(data.message);  // Show immediate confirmation
@@ -46,11 +68,11 @@
       }
 
       function checkLibraryMessages() {
-          fetch("/cwa-library-refresh/messages")
-              .then(response => response.json())
-              .then(data => {
-                  if (data.messages.length > 0) {
-                    updateLibraryRefreshMessage(data.messages.join("<br>")); // Show messages
+          cwaFetch("/cwa-library-refresh/messages")
+               .then(response => response.json())
+               .then(data => {
+                   if (data.messages.length > 0) {
+                     updateLibraryRefreshMessage(data.messages.join("<br>")); // Show messages
                       stopCheckingMessages(); // Stop checking once we get a message
                   }
               })

--- a/cps/templates/tasks.html
+++ b/cps/templates/tasks.html
@@ -175,7 +175,7 @@
   }
   function cancelScheduled(id) {
     if (!id) return;
-    fetch('{{ url_for("cwa_stats.cwa_scheduled_cancel") }}', {
+    cwaFetch('{{ url_for("cwa_stats.cwa_scheduled_cancel") }}', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: id })


### PR DESCRIPTION
For some reason, iPhone Safari doesn't properly send the X-CSRFToken header. This adds it to the request body for metadata fetch, which is allowing mobile Safari to search for metadata from the Fetch Metadata button when editing a book.

Also proactively adding the header to other requests using fetch().