### PR TITLE
fix(uploadprogress): drop Safari skip — $.fn.uploadprogress was never defined, breaking all of main.js in Safari

### DIFF
--- a/cps/static/js/uploadprogress.js
+++ b/cps/static/js/uploadprogress.js
@@ -16,7 +16,7 @@
     var ua = (navigator && navigator.userAgent) ? navigator.userAgent : "";
     var isSafari = /safari/i.test(ua) && !/chrome|chromium|crios|android/i.test(ua);
 
-    if (!$.support.xhrFileUpload || !$.support.xhrFormData || isSafari) {
+    if (!$.support.xhrFileUpload || !$.support.xhrFormData) {
         // skip decorating form
         return;
     }


### PR DESCRIPTION
## Summary

`cps/static/js/uploadprogress.js` (bundled bootstrap-uploadprogress 1.0.0, 2015) returns early when `isSafari` is true, which prevents `$.fn.uploadprogress` from ever being assigned. `cps/static/js/main.js` then calls `$("#form-upload").uploadprogress(...)` at module top-level (line ~153). In Safari this throws `TypeError: $("#form-upload").uploadprogress is not a function`, which halts the rest of `main.js`, including every subsequent `$(...)` event binding.

Net effect for Safari users on CWA:
- The Delete Book confirmation modal opens (Bootstrap-only), but clicking the red Delete button does nothing — the `$("#delete_confirm").click(...)` binding never ran.
- Same for delete-format dropdowns, shelf delete handlers, and other top-level bindings later in `main.js`.

Upstream `janeczku/calibre-web` ships `uploadprogress.js` without the `|| isSafari` guard ([upstream file](https://github.com/janeczku/calibre-web/blob/master/cps/static/js/uploadprogress.js)) and works fine in Safari. The Safari compat issue the 2015 plugin was originally guarding against (broken FileReader / FormData / Blob in pre-`Safari 11`) hasn't been a concern in years — modern Safari (macOS 10.13+, iOS 11+) has full support.

## Diff

One line, `cps/static/js/uploadprogress.js`:

```diff
-    if (!$.support.xhrFileUpload || !$.support.xhrFormData || isSafari) {
+    if (!$.support.xhrFileUpload || !$.support.xhrFormData) {
```

## Repro before patch

1. CWA `latest` image, any user with `role_edit + role_delete_books`.
2. Open `/book/<id>` in Safari (17.x verified).
3. Click trash icon → modal opens with "Delete Book" / "and hard disk" body.
4. Click red Delete button → modal closes, no network request fires, book remains.
5. DevTools Console shows: `TypeError: $("#form-upload").uploadprogress is not a function. ... Global Code — main.js:153`.

## After patch

- Console error gone.
- Click Delete → POST `/delete/<id>` fires → book removed → redirected to `/`.
- All other `main.js` top-level bindings (delete-format, shelf actions, etc.) also work.

## Test plan

- [ ] Verify Delete Book works in Safari on `/book/<id>`.
- [ ] Verify Delete Book works in Safari on `/admin/book/<id>` (Edit Metadata page).
- [ ] Verify Delete Format dropdown works on Edit Metadata page in Safari.
- [ ] Smoke test in Chrome/Firefox to confirm no regression (the change is a pure subtraction of a Safari-only branch).