### PR TITLE
feat: Push KOReader progress to Hardcover

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -974,7 +974,7 @@ def HandleStateRequest(book_uuid):
             ub.session.rollback()
             abort(400, description="Malformed request data is missing 'ReadingStates' key")
 
-        push_reading_state_to_hardcover(book, request_bookmark)
+        push_reading_state_to_hardcover(current_user, book, request_bookmark['ProgressPercent'])
 
         ub.session.merge(kobo_reading_state)
         ub.session_commit()
@@ -984,7 +984,7 @@ def HandleStateRequest(book_uuid):
         })
 
 
-def push_reading_state_to_hardcover(book: db.Books, request_bookmark: dict):
+def push_reading_state_to_hardcover(user, book: db.Books, progress_percentage: int):
     """
     Sync reading progress to Hardcover if enabled for the user and book is not blacklisted.
 
@@ -992,7 +992,7 @@ def push_reading_state_to_hardcover(book: db.Books, request_bookmark: dict):
     the Kobo from clearing its reading state sync queue.
 
     :param book: The book for which to sync reading progress.
-    :param request_bookmark: The bookmark data from the Kobo request.
+    :param progress_percentage: Reading progress percentage.
     :return: None
     """
 
@@ -1008,16 +1008,16 @@ def push_reading_state_to_hardcover(book: db.Books, request_bookmark: dict):
         return
 
     try:
-        hardcoverClient = hardcover.HardcoverClient(current_user.hardcover_token)
+        hardcoverClient = hardcover.HardcoverClient(user.hardcover_token)
     except hardcover.MissingHardcoverToken:
-        log.info(f"User {current_user.name} has no Hardcover token, not syncing reading progress to Hardcover")
+        log.info(f"User {user.name} has no Hardcover token, not syncing reading progress to Hardcover")
         return
     except Exception as e:
-        log.error(f"Failed to create Hardcover client for user {current_user.name}: {e}")
+        log.error(f"Failed to create Hardcover client for user {user.name}: {e}")
         return
 
     try:
-        hardcoverClient.update_reading_progress(book.identifiers, request_bookmark["ProgressPercent"])
+        hardcoverClient.update_reading_progress(book.identifiers, progress_percentage)
     except Exception as e:
         log.error(f"Failed to update reading progress for book {book.id} in Hardcover: {e}")
 

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -193,7 +193,7 @@ def authenticate_user() -> Optional[ub.User]:
         if login_result:
             log.info(f"authenticate_user: Successfully authenticated user via LDAP: {user.name}")
             return user
-        
+
         # Log LDAP failure but continue to local check (fallback)
         # We use debug level here because failure is expected if the user is using a local password
         if error:
@@ -434,17 +434,6 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
 
     # Merge the record (caller commits)
     ub.session.merge(book_read)
-
-    # # Push to Hardcover
-    # # TODO: just pass in the user?
-    # from ... import calibre_db
-    # book = calibre_db.get_book(book_id)
-    
-    # if user is not None:
-    #     log.debug(f"Going to sync book {book_id} to Hardcover.")
-    #     push_reading_state_to_hardcover(user, book, int(percentage))
-    # else:
-    #     log.debug(f"Book {book_id} not syncing to Hardcover, no matched user.")
 
 
 ################################################################################
@@ -737,11 +726,11 @@ def update_progress():
                 ub.session.commit()
                 log.info(f"Updated ReadBook status: user={user.id}, book={book_id} "
                         f"({book_title}), status based on {percentage_float:.1f}%")
-                
+
                 # Push to Hardcover
                 from ... import calibre_db
                 book = calibre_db.get_book(book_id)
-                
+
                 if user is not None:
                     log.debug(f"Going to sync book {book_id} to Hardcover.")
                     push_reading_state_to_hardcover(user, book, int(percentage_float))

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -40,6 +40,9 @@ import base64
 from datetime import datetime, timezone
 from typing import Dict, Optional, Any, Tuple
 
+from ...services import SyncToken as SyncToken, hardcover
+from ...kobo import push_reading_state_to_hardcover
+
 from flask import Blueprint, request, jsonify
 from flask_babel import gettext as _
 from werkzeug.security import check_password_hash
@@ -326,7 +329,7 @@ def enrich_response_with_book_info(response_data: Dict[str, Any], document_check
     return response_data, book_id, book_format, book_title, checksum_version
 
 
-def update_book_read_status(user_id: int, book_id: int, percentage: float) -> None:
+def update_book_read_status(user, book_id: int, percentage: float) -> None:
     """
     Update the user's ReadBook status based on reading progress percentage.
 
@@ -359,6 +362,8 @@ def update_book_read_status(user_id: int, book_id: int, percentage: float) -> No
         new_status = ub.ReadBook.STATUS_IN_PROGRESS
     else:
         new_status = ub.ReadBook.STATUS_UNREAD
+
+    user_id = user.id
 
     log.debug(f"update_book_read_status: user {user_id}, book {book_id}, "
               f"percentage {percentage:.2f}% -> status {new_status}")
@@ -429,6 +434,17 @@ def update_book_read_status(user_id: int, book_id: int, percentage: float) -> No
 
     # Merge the record (caller commits)
     ub.session.merge(book_read)
+
+    # # Push to Hardcover
+    # # TODO: just pass in the user?
+    # from ... import calibre_db
+    # book = calibre_db.get_book(book_id)
+    
+    # if user is not None:
+    #     log.debug(f"Going to sync book {book_id} to Hardcover.")
+    #     push_reading_state_to_hardcover(user, book, int(percentage))
+    # else:
+    #     log.debug(f"Book {book_id} not syncing to Hardcover, no matched user.")
 
 
 ################################################################################
@@ -717,10 +733,21 @@ def update_progress():
         # This is done AFTER kosync_progress is committed, so sync location is always safe
         if book_id:
             try:
-                update_book_read_status(user.id, book_id, percentage_float)
+                update_book_read_status(user, book_id, percentage_float)
                 ub.session.commit()
                 log.info(f"Updated ReadBook status: user={user.id}, book={book_id} "
                         f"({book_title}), status based on {percentage_float:.1f}%")
+                
+                # Push to Hardcover
+                from ... import calibre_db
+                book = calibre_db.get_book(book_id)
+                
+                if user is not None:
+                    log.debug(f"Going to sync book {book_id} to Hardcover.")
+                    push_reading_state_to_hardcover(user, book, int(percentage_float))
+                else:
+                    log.debug(f"Book {book_id} not syncing to Hardcover, no matched user.")
+
             except SQLAlchemyError as e:
                 log.error(f"Failed to update ReadBook status for book {book_id}: {e}")
                 # Rollback only affects the failed ReadBook update

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -155,12 +155,15 @@ class HardcoverClient:
             book = self.get_user_book(ids)
             # Book doesn't exist, add it in Reading status
             if not book:
+                log.debug(f'Book does not exist, add to reading status')
                 book = self.add_book(ids, status=STATUS_READING)
             # Book is either WTR or Read, and we aren't finished reading
             if book.get("status_id") != STATUS_READING and progress_percent != MAX_PROGRESS_PERCENTAGE:
+                log.debug(f'Book is in either want to read or read, not finished reading.')
                 book = self.change_book_status(book, STATUS_READING)
             # Book is already marked as read, and we are also done
             if book.get("status_id") == STATUS_READ and progress_percent == MAX_PROGRESS_PERCENTAGE:
+                log.debug(f'Book is already marked read and we are done.')
                 return
             pages = book.get("edition", {}).get("pages", 0)
             if pages:
@@ -169,8 +172,10 @@ class HardcoverClient:
                 if not read:
                     # read = self.add_read(book, pages_read)
                     # No read exists for some reason, return since we can't update anything.
+                    log.warning(f'No read status exists for book, not updating.')
                     return
                 else:
+                    log.info(f'Setting {pages_read} pages read at {progress_percent}% done.')
                     mutation = """
                     mutation ($readId: Int!, $pages: Int, $editionId: Int, $startedAt: date, $finishedAt: date) {
                         update_user_book_read(id: $readId, object: {
@@ -196,10 +201,12 @@ class HardcoverClient:
                         ),
                     }
                     if progress_percent == MAX_PROGRESS_PERCENTAGE:
+                        log.debug('Book finished, marking as read')
                         self.change_book_status(book, STATUS_READ)
                     self.execute(query=mutation, variables=variables)
             return
         else:
+            log.info('No Hardcover IDs associated with book, not updating.')
             return
 
     def change_book_status(self, book, status):

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -155,15 +155,12 @@ class HardcoverClient:
             book = self.get_user_book(ids)
             # Book doesn't exist, add it in Reading status
             if not book:
-                log.debug(f'Book does not exist, add to reading status')
                 book = self.add_book(ids, status=STATUS_READING)
             # Book is either WTR or Read, and we aren't finished reading
             if book.get("status_id") != STATUS_READING and progress_percent != MAX_PROGRESS_PERCENTAGE:
-                log.debug(f'Book is in either want to read or read, not finished reading.')
                 book = self.change_book_status(book, STATUS_READING)
             # Book is already marked as read, and we are also done
             if book.get("status_id") == STATUS_READ and progress_percent == MAX_PROGRESS_PERCENTAGE:
-                log.debug(f'Book is already marked read and we are done.')
                 return
             pages = book.get("edition", {}).get("pages", 0)
             if pages:
@@ -172,10 +169,8 @@ class HardcoverClient:
                 if not read:
                     # read = self.add_read(book, pages_read)
                     # No read exists for some reason, return since we can't update anything.
-                    log.warning(f'No read status exists for book, not updating.')
                     return
                 else:
-                    log.info(f'Setting {pages_read} pages read at {progress_percent}% done.')
                     mutation = """
                     mutation ($readId: Int!, $pages: Int, $editionId: Int, $startedAt: date, $finishedAt: date) {
                         update_user_book_read(id: $readId, object: {
@@ -201,12 +196,10 @@ class HardcoverClient:
                         ),
                     }
                     if progress_percent == MAX_PROGRESS_PERCENTAGE:
-                        log.debug('Book finished, marking as read')
                         self.change_book_status(book, STATUS_READ)
                     self.execute(query=mutation, variables=variables)
             return
         else:
-            log.info('No Hardcover IDs associated with book, not updating.')
             return
 
     def change_book_status(self, book, status):


### PR DESCRIPTION
The call to `push_reading_state_to_hardcover` was only being called in the Kobo sync related paths.

This PR adds the same `push_reading_state_to_hardcover` (with some adjustments to the method signature) to the kosync/KOReader sync paths to allow Hardcover updates from KOreader devices.

I'd like to add some kind of unit testing to this but haven't been really able to figure out where to start. Any suggestions? I've been running a build with these changes for the past month now without any issues with progress updates and finishing books.