### PR TITLE
Fix metadata modal crash when provider results have missing fields

### DIFF
--- a/cps/metadata_provider/amazon.py
+++ b/cps/metadata_provider/amazon.py
@@ -68,7 +68,7 @@ class Amazon(Metadata):
             try:
                 match = MetaRecord(
                     title = "",
-                    authors = "",
+                    authors = [],
                     source=MetaSourceInfo(
                         id=self.__id__,
                         description="Amazon Books",
@@ -104,7 +104,7 @@ class Amazon(Metadata):
                                 x.findAll(string=True))).strip()
                                     for x in soup2.findAll("span", attrs={"class": "author"})]
                 except (AttributeError, TypeError, StopIteration):
-                    match.authors = ""
+                    match.authors = []
                 try:
                     match.rating = int(
                         soup2.find(attrs={"id": "acrPopover"})["title"].split(" ")[0].split(".")[

--- a/cps/metadata_provider/amazonjp.py
+++ b/cps/metadata_provider/amazonjp.py
@@ -60,7 +60,7 @@ class AmazonJp(Metadata):
             try:
                 match = MetaRecord(
                     title = "",
-                    authors = "",
+                    authors = [],
                     source=MetaSourceInfo(
                         id=self.__id__,
                         description="Amazon Japan",

--- a/cps/metadata_provider/lubimyczytac.py
+++ b/cps/metadata_provider/lubimyczytac.py
@@ -285,7 +285,7 @@ class LubimyCzytacParser:
                 for w in tags
                 if isinstance(w, str)
             ]
-        return None
+        return []
 
     def _parse_from_summary(self, attribute_name: str) -> Optional[str]:
         value = None

--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -151,7 +151,7 @@ $(function () {
       $("#series_index").val(book.series_index);
     }
     if (typeof book.identifiers !== "undefined") {
-      selectedIdentifiers = Object.keys(book.identifiers)
+      selectedIdentifiers = Object.keys(book.identifiers || {})
         .filter((key) => updateItems[key])
         .reduce((result, key) => {
           result[key] = book.identifiers[key];

--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -93,7 +93,7 @@ $(function () {
     if (presentArray.length === 1 && presentArray[0] === "") {
       presentArray = [];
     }
-    $.each(book[attribute_name], function (i, el) {
+    $.each(book[attribute_name] || [], function (i, el) {
       if ($.inArray(el, presentArray) === -1) presentArray.push(el);
     });
     return presentArray;

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -319,7 +319,7 @@
       <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="title" checked>Title:</dt>
       <dd><a class="meta_title" href="<%= book.url %>" target="_blank" rel="noopener"><%= book.title %></a></dd>
       <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="authors" checked>Author:</dt>
-      <dd class="meta_author"><%= book.authors.join(" & ") %></dd>
+      <dd class="meta_author"><%= (book.authors || []).join(" & ") %></dd>
       <% if (book.publisher) { %>
         <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="publisher" checked>Publisher:</dt>
         <dd class="meta_publisher"><%= book.publisher %></dd>
@@ -348,7 +348,7 @@
         <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="tags" checked>Tags:</dt>
         <dd class="meta_author"><%= book.tags.join(", ") %></dd>
       <% } %>
-      <% if (Object.keys(book.identifiers).length !== 0 ) { %>
+      <% if (book.identifiers && Object.keys(book.identifiers).length !== 0 ) { %>
         <% for (const key in book.identifiers) { %>
           <% if (book.identifiers[key] !== "") { %>
             <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="<%= key %>" checked>Identifier</dt>

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -344,7 +344,7 @@
         <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="description" checked>Description:</dt>
         <dd class="meta_description"><%= book.description %></dd>
       <% } %>
-      <% if (book.tags.length !== 0) { %>
+      <% if (book.tags && book.tags.length !== 0) { %>
         <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="tags" checked>Tags:</dt>
         <dd class="meta_author"><%= book.tags.join(", ") %></dd>
       <% } %>

--- a/tests/unit/test_lubimyczytac_provider.py
+++ b/tests/unit/test_lubimyczytac_provider.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from lxml.html import fromstring
+
+from cps.metadata_provider.lubimyczytac import LubimyCzytac, LubimyCzytacParser
+
+
+def test_parse_tags_returns_empty_list_when_book_has_no_tags():
+    parser = LubimyCzytacParser(
+        root=fromstring("<html><body><section class='container book'></section></body></html>"),
+        metadata=LubimyCzytac(),
+    )
+
+    assert parser._parse_tags() == []


### PR DESCRIPTION
Metadata search could successfully return results from a provider, but the edit-book metadata modal failed to render them if optional fields were missing or null.

This happened with lubimyczytac.pl: the backend returned valid results for Tajemnica tajemnic, but those records had tags: null. The frontend template assumed book.tags was always an array and called book.tags.length, causing a browser-side render error. From the user’s perspective, metadata search appeared to return no results even though the backend response was valid.

Similar provider contract issues existed in Amazon providers, where authors could be set to an empty string even though the UI expects an array.

Fix.
This PR makes provider output and frontend rendering more robust:

- lubimyczytac now returns an empty list for missing tags instead of None.
- Amazon and AmazonJP now use an empty authors list instead of an empty string.
- The metadata modal now defensively handles missing/null authors, tags, and identifiers.
- Added a regression test covering the no-tags lubimyczytac case.
