### PR TITLE
fix: bound healthcheck curls and close gevent keepalives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -299,4 +299,4 @@ VOLUME /calibre-library
 # Health check for container orchestration
 # Uses shell form to support environment variable substitution for CWA_PORT_OVERRIDE
 HEALTHCHECK --interval=30s --timeout=3s --start-period=120s --retries=3 \
-  CMD curl -f http://localhost:${CWA_PORT_OVERRIDE:-8083}/ || curl -f -k https://localhost:${CWA_PORT_OVERRIDE:-8083}/ || exit 1
+  CMD curl --fail --connect-timeout 1 --max-time 2 http://localhost:${CWA_PORT_OVERRIDE:-8083}/ || curl --fail --insecure --connect-timeout 1 --max-time 2 https://localhost:${CWA_PORT_OVERRIDE:-8083}/ || exit 1

--- a/cps/gevent_wsgi.py
+++ b/cps/gevent_wsgi.py
@@ -10,6 +10,11 @@ from gevent.pywsgi import WSGIHandler
 
 
 class MyWSGIHandler(WSGIHandler):
+    def read_request(self, raw_requestline):
+        is_valid = super().read_request(raw_requestline)
+        self.close_connection = True
+        return is_valid
+
     def get_environ(self):
         env = super().get_environ()
         path, __ = self.path.split('?', 1) if '?' in self.path else (self.path, '')
@@ -38,4 +43,3 @@ class MyWSGIHandler(WSGIHandler):
             (self._orig_status or self.status or '000').split()[0],
             length,
             delta)
-

--- a/tests/unit/test_container_healthcheck_static.py
+++ b/tests/unit/test_container_healthcheck_static.py
@@ -1,0 +1,17 @@
+# Calibre-Web Automated - fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_docker_healthcheck_curl_has_own_timeout():
+    dockerfile = (PROJECT_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    healthcheck = dockerfile.split("HEALTHCHECK", 1)[1]
+
+    assert "--connect-timeout" in healthcheck
+    assert "--max-time" in healthcheck
+    assert "curl -f http://localhost" not in healthcheck

--- a/tests/unit/test_gevent_wsgi_static.py
+++ b/tests/unit/test_gevent_wsgi_static.py
@@ -1,0 +1,15 @@
+# Calibre-Web Automated - fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_gevent_wsgi_handler_closes_connections_after_response():
+    source = (PROJECT_ROOT / "cps/gevent_wsgi.py").read_text(encoding="utf-8")
+
+    assert "def read_request" in source
+    assert "self.close_connection = True" in source


### PR DESCRIPTION
When the app stops responding, Docker's shell-form healthcheck can time out while leaving the child curl process behind. Repeated failures accumulate stuck curls, and reverse-proxy keepalive sockets can remain attached to the gevent process after the client side is gone.

Give curl its own connect and total request timeouts so healthcheck children exit before Docker kills the shell, and force gevent request handlers to close HTTP connections after each response. This avoids stale keepalive sockets and makes healthcheck failures bounded.