### PR TITLE
fix: sync applied metadata descriptions before save

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -106,10 +106,12 @@ $(function () {
       )
     );
     if (updateItems.description) {
+      var description = book.description || "";
       if (typeof tinymce !== "undefined" && tinymce.get("comments")) {
-        tinymce.get("comments").setContent(book.description);
+        tinymce.get("comments").setContent(description);
+        tinymce.get("comments").save();
       } else {
-        $("#comments").val(book.description);
+        $("#comments").val(description);
       }
     }
     if (updateItems.tags) {

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -309,7 +309,7 @@
         <div class="image-dimensions"></div>
         <input type="checkbox" data-meta-index="<%= index %>" data-meta-value="cover" checked>
       </div>
-      <button class="btn btn-default">Save</button>
+      <button class="btn btn-default">{{_("Apply")}}</button>
       <div><a class="meta_source" href="<%= book.source.link %>" target="_blank" rel="noopener"><%= book.source.description %></a></div>
       <% if(book.format) { %>
       <div>Format: <%= book.format %></div>

--- a/tests/unit/test_metadata_ui_static.py
+++ b/tests/unit/test_metadata_ui_static.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_metadata_description_apply_syncs_tinymce_to_textarea():
+    js = (REPO_ROOT / "cps/static/js/get_meta.js").read_text(encoding="utf-8")
+
+    assert 'var description = book.description || "";' in js
+    assert 'tinymce.get("comments").setContent(description);' in js
+    assert 'tinymce.get("comments").save();' in js
+
+
+def test_metadata_result_button_is_apply_not_save():
+    template = (REPO_ROOT / "cps/templates/book_edit.html").read_text(encoding="utf-8")
+
+    assert '<button class="btn btn-default">{{_("Apply")}}</button>' in template


### PR DESCRIPTION
Metadata search results can update the TinyMCE comments editor without updating the backing textarea that the edit form submits. That makes the fetched description visible in the UI while the first save can still post the previous or empty comments value.

Normalize missing provider descriptions to an empty string, save TinyMCE after applying the fetched description, and rename the result button from "Save" to "Apply" so it reflects that the action only copies metadata into the edit form.