### PR TITLE
fix: reduce metadata background save races

### DIFF
--- a/cps/static/js/duplicate-notifier.js
+++ b/cps/static/js/duplicate-notifier.js
@@ -183,18 +183,9 @@
             }
         }
 
-        if ((data.needs_scan || data.stale) && !isModalActive()) {
-            startStatusPolling();
-            return;
-        }
-
         if (data.count > 0) {
             stopStatusPolling();
             return;
-        }
-
-        if (data.enabled) {
-            startStatusPolling();
         }
     }
     
@@ -279,7 +270,6 @@
         }
 
         fetchDuplicateStatus().then(handleStatusResponse);
-        startStatusPolling();
 
         document.addEventListener('visibilitychange', function() {
             if (!document.hidden) {

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -535,9 +535,75 @@ class Enforcer:
 
         return supported_files
 
-    def enforce_cover(self, book_dir: str) -> list:
+
+    def get_expected_supported_formats(self, book_id: str | int | None) -> list[str]:
+        """Return supported formats that Calibre's DB says should exist for a book."""
+        if book_id in (None, ""):
+            return []
+
+        try:
+            metadb_path = os.path.join(
+                (self.split_library or {}).get("db_path", self.calibre_library),
+                "metadata.db",
+            )
+            with sqlite3.connect(metadb_path, timeout=60) as con:
+                rows = con.execute(
+                    "SELECT format FROM data WHERE book = ?",
+                    (str(book_id),),
+                ).fetchall()
+        except Exception as e:
+            print(f"[cover-metadata-enforcer] Warning: Failed to check expected formats for book {book_id}: {e}", flush=True)
+            return []
+
+        supported = {fmt.upper() for fmt in self.supported_formats}
+        return sorted({str(row[0]).upper() for row in rows if row and str(row[0]).upper() in supported})
+
+
+    def list_files_from_dir(self, dir: str) -> list[str]:
+        """Return files found below a directory for diagnostics."""
+        return [os.path.join(dirpath, f) for (dirpath, _, filenames) in os.walk(dir) for f in filenames]
+
+
+    def get_supported_files_from_dir_with_retries(
+        self,
+        dir: str,
+        expected_formats: list[str] | None = None,
+        attempts: int = 6,
+        delay_seconds: float = 1.0,
+    ) -> list[str]:
+        """Retry supported-file discovery when Calibre's DB says supported formats exist."""
+        expected_formats = expected_formats or []
+        attempts = max(1, attempts if expected_formats else 1)
+
+        for attempt in range(attempts):
+            supported_files = self.get_supported_files_from_dir(dir)
+            if supported_files:
+                return supported_files
+            if attempt < attempts - 1:
+                print(
+                    f"[cover-metadata-enforcer] Expected supported format(s) {', '.join(expected_formats)} "
+                    f"for {dir}, but none are visible yet; retrying ({attempt + 1}/{attempts - 1})...",
+                    flush=True,
+                )
+                time.sleep(delay_seconds)
+
+        if expected_formats:
+            visible_files = self.list_files_from_dir(dir)
+            print(
+                f"[cover-metadata-enforcer] Expected supported format(s) {', '.join(expected_formats)} "
+                f"but none were found in {dir}.",
+                flush=True,
+            )
+            print(
+                f"[cover-metadata-enforcer] Files found in selected directory: "
+                f"{visible_files if visible_files else '[]'}",
+                flush=True,
+            )
+        return []
+
+    def enforce_cover(self, book_dir: str, expected_formats: list[str] | None = None) -> list:
         """Will force the Cover & Metadata to update for the supported book files in the given directory"""
-        supported_files = self.get_supported_files_from_dir(book_dir)
+        supported_files = self.get_supported_files_from_dir_with_retries(book_dir, expected_formats=expected_formats)
         if supported_files:
             if len(supported_files) > 1:
                 print("[cover-metadata-enforcer] Multiple file formats for current book detected...", flush=True)
@@ -831,7 +897,8 @@ def main():
         book_dir = enforcer.get_book_dir_from_log(log_info)
         if enforcer.enforcer_on:
             try:
-                book_objects = enforcer.enforce_cover(book_dir)
+                expected_formats = enforcer.get_expected_supported_formats(log_info.get('book_id'))
+                book_objects = enforcer.enforce_cover(book_dir, expected_formats=expected_formats)
                 if not book_objects:
                     print(f"[cover-metadata-enforcer] Metadata for '{log_info['title']}' not successfully enforced")
                     enforcer.record_failed_enforcement(log_info, "No supported files or enforcement failed")

--- a/tests/unit/test_cover_enforcer_static.py
+++ b/tests/unit/test_cover_enforcer_static.py
@@ -1,0 +1,24 @@
+# Calibre-Web Automated - fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cover_enforcer_retries_supported_file_scan_for_expected_formats():
+    source = (PROJECT_ROOT / "scripts/cover_enforcer.py").read_text(encoding="utf-8")
+
+    assert "def get_expected_supported_formats" in source
+    assert "def get_supported_files_from_dir_with_retries" in source
+    assert "expected_formats" in source
+    assert "time.sleep(delay_seconds)" in source
+
+
+def test_cover_enforcer_logs_directory_files_when_expected_format_missing():
+    source = (PROJECT_ROOT / "scripts/cover_enforcer.py").read_text(encoding="utf-8")
+
+    assert "Expected supported format(s)" in source
+    assert "Files found in selected directory" in source

--- a/tests/unit/test_duplicate_notifier_static.py
+++ b/tests/unit/test_duplicate_notifier_static.py
@@ -1,0 +1,24 @@
+# Calibre-Web Automated - fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_duplicate_notifier_does_not_start_page_load_polling():
+    script = (PROJECT_ROOT / "cps/static/js/duplicate-notifier.js").read_text(encoding="utf-8")
+    init_body = script.split("function init()", 1)[1].split("document.addEventListener('visibilitychange'", 1)[0]
+
+    assert "fetchDuplicateStatus().then(handleStatusResponse);" in init_body
+    assert "startStatusPolling();" not in init_body
+
+
+def test_duplicate_notifier_does_not_poll_stale_cache_status():
+    script = (PROJECT_ROOT / "cps/static/js/duplicate-notifier.js").read_text(encoding="utf-8")
+    handler_body = script.split("function handleStatusResponse(data)", 1)[1].split("function hideNotificationModal()", 1)[0]
+
+    assert "data.needs_scan || data.stale" not in handler_body
+    assert "if (data.enabled) {\n            startStatusPolling();" not in handler_body


### PR DESCRIPTION
Metadata saves can kick off noisy duplicate-status polling and the metadata enforcer can miss supported files immediately after Calibre renames a book folder. In practice this makes metadata edits look stuck or intermittently fail post-save enforcement even though the supported EPUB/AZW3 file exists shortly afterward.

Stop duplicate notifications from continuously polling stale/pending cache states on normal page loads, and make the cover/metadata enforcer retry supported file discovery when Calibre's DB says a supported format should be present. Add diagnostic output listing visible files when the expected format never appears.