### PR TITLE
Fix minor compatibility issues with Kobo's Android app

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -598,7 +598,7 @@ def get_metadata(book):
                         "Url": get_download_url_for_book(book.id, book_data.format),
                         # The Kobo forma accepts platforms: (Generic, Android)
                         "Platform": "Generic",
-                        # "DrmType": "None", # Not required
+                        "DrmType": "None",
                     }
                 )
             except (zipfile.BadZipfile, FileNotFoundError) as e:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -631,6 +631,7 @@ def get_metadata(book):
         "RevisionId": book_uuid,
         "Title": book.title,
         "WorkId": book_uuid,
+        "Series": {},
     }
     metadata.update(get_author(book))
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1364,16 +1364,16 @@ def HandleInitRequest():
                                                                url_for("kobo.HandleCoverImageRequest",
                                                                        auth_token=kobo_auth.get_auth_token(),
                                                                        book_uuid="{ImageId}",
-                                                                       width="{width}",
-                                                                       height="{height}",
+                                                                       width="{Width}",
+                                                                       height="{Height}",
                                                                        Quality='{Quality}',
                                                                        isGreyscale='isGreyscale'))
         kobo_resources["image_url_template"] = unquote(calibre_web_url +
                                                        url_for("kobo.HandleCoverImageRequest",
                                                                auth_token=kobo_auth.get_auth_token(),
                                                                book_uuid="{ImageId}",
-                                                               width="{width}",
-                                                               height="{height}",
+                                                               width="{Width}",
+                                                               height="{Height}",
                                                                isGreyscale='false'))
         if config.config_hardcover_annotations_sync and bool(hardcover):
             kobo_resources["reading_services_host"] = calibre_web_url
@@ -1382,16 +1382,16 @@ def HandleInitRequest():
         kobo_resources["image_url_quality_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
                                                                        auth_token=kobo_auth.get_auth_token(),
                                                                        book_uuid="{ImageId}",
-                                                                       width="{width}",
-                                                                       height="{height}",
+                                                                       width="{Width}",
+                                                                       height="{Height}",
                                                                        Quality='{Quality}',
                                                                        isGreyscale='isGreyscale',
                                                                        _external=True))
         kobo_resources["image_url_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
                                                                auth_token=kobo_auth.get_auth_token(),
                                                                book_uuid="{ImageId}",
-                                                               width="{width}",
-                                                               height="{height}",
+                                                               width="{Width}",
+                                                               height="{Height}",
                                                                isGreyscale='false',
                                                                _external=True))
         if config.config_hardcover_annotations_sync and bool(hardcover):

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -474,22 +474,29 @@ def HandleMetadataRequest(book_uuid):
 
 
 def get_download_url_for_book(book_id, book_format):
+    endpoint_name = "kobo.download_book"
+    endpoint_path = "download"
+    if request.headers.get("x-kobo-deviceos") == "Android":
+        endpoint_name = "kobo.redirect_download_book"
+        endpoint_path = "redirect_download"
+
     if not current_app.wsgi_app.is_proxied:
         if ':' in request.host and not request.host.endswith(']'):
             host = "".join(request.host.split(':')[:-1])
         else:
             host = request.host
 
-        return "{url_scheme}://{url_base}:{url_port}/kobo/{auth_token}/download/{book_id}/{book_format}".format(
+        return "{url_scheme}://{url_base}:{url_port}/kobo/{auth_token}/{endpoint_path}/{book_id}/{book_format}".format(
             url_scheme=request.scheme,
             url_base=host,
             url_port=config.config_external_port,
             auth_token=get_auth_token(),
+            endpoint_path=endpoint_path,
             book_id=book_id,
             book_format=book_format.lower()
         )
     return url_for(
-        "kobo.download_book",
+        endpoint_name,
         auth_token=kobo_auth.get_auth_token(),
         book_id=book_id,
         book_format=book_format.lower(),
@@ -1409,6 +1416,19 @@ def HandleInitRequest():
 @download_required
 def download_book(book_id, book_format):
     return get_download_link(book_id, book_format, "kobo")
+
+
+@kobo.route("/redirect_download/<book_id>/<book_format>")
+@requires_kobo_auth
+@download_required
+def redirect_download_book(book_id, book_format):
+    return redirect(url_for(
+        "kobo.download_book",
+        auth_token=kobo_auth.get_auth_token(),
+        book_id=book_id,
+        book_format=book_format.lower(),
+        _external=True,
+    ))
 
 
 def NATIVE_KOBO_RESOURCES():


### PR DESCRIPTION
The Kobo android app uses the same sync protocol as Kobo devices. For a few small cases it has stricter expectations compared to Kobo devices however (e.g. series field must be set in metadata, even if empty).

This is mostly useful for testing changes to calibre-web's sync implementation against an official Kobo sync client without access to a Kobo device (e.g. by running the Kobo android app in an emulator)