### PR TITLE
Redesign the Kobo book syncing flow (multi-device support, 100-250ms per sync request instead of 10-30seconds, etc)

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -787,7 +787,12 @@ def edit_list_user(param):
                 elif param == 'email':
                     user.email = check_email(vals['value'])
                 elif param == 'kobo_only_shelves_sync':
+                    old_val = user.kobo_only_shelves_sync
                     user.kobo_only_shelves_sync = int(vals['value'] == 'true')
+                    if old_val == 0 and user.kobo_only_shelves_sync == 1:
+                        kobo_sync_status.update_on_sync_shelfs(user.id)
+                    elif old_val == 1 and user.kobo_only_shelves_sync == 0:
+                        kobo_sync_status.on_sync_shelves_disabled(user.id)
                 elif param == 'kindle_mail':
                     user.kindle_mail = valid_email(vals['value']) if vals['value'] else ""
                 elif param == 'kindle_mail_subject':
@@ -1248,8 +1253,14 @@ def ajax_pathchooser():
 
 
 def do_full_kobo_sync(userid):
-    count = ub.session.query(ub.KoboSyncedBooks).filter(userid == ub.KoboSyncedBooks.user_id).delete()
-    message = _("{} sync entries deleted").format(count)
+    # Flag this user so the next Kobo sync request ignores its incoming SyncToken
+    # and replays the full library. The flag is cleared when that sync starts.
+    user = ub.session.query(ub.User).filter(ub.User.id == userid).one_or_none()
+    if user is None:
+        message = _("User not found")
+        return Response(json.dumps([{"type": "danger", "message": message}]), mimetype='application/json')
+    user.kobo_force_full_sync = True
+    message = _("Full Kobo sync requested; the next sync from this user's device will replay the library.")
     ub.session_commit(message)
     return Response(json.dumps([{"type": "success", "message": message}]), mimetype='application/json')
 
@@ -2262,7 +2273,6 @@ def _db_configuration_update_helper():
             ub.session.query(ub.Bookmark).delete()
             ub.session.query(ub.KoboReadingState).delete()
             ub.session.query(ub.KoboStatistics).delete()
-            ub.session.query(ub.KoboSyncedBooks).delete()
             helper.delete_thumbnail_cache()
             ub.session_commit()
             # deleted visibilities based on custom column and tags
@@ -2574,7 +2584,6 @@ def _delete_user(content):
             ub.session.query(ub.ArchivedBook).filter(ub.ArchivedBook.user_id == content.id).delete()
             ub.session.query(ub.RemoteAuthToken).filter(ub.RemoteAuthToken.user_id == content.id).delete()
             ub.session.query(ub.User_Sessions).filter(ub.User_Sessions.user_id == content.id).delete()
-            ub.session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.user_id == content.id).delete()
             # delete KoboReadingState and all it's children
             kobo_entries = ub.session.query(ub.KoboReadingState).filter(ub.KoboReadingState.user_id == content.id).all()
             for kobo_entry in kobo_entries:
@@ -2627,11 +2636,10 @@ def _handle_edit_user(to_save, content, languages, translations, kobo_support):
 
     old_state = content.kobo_only_shelves_sync
     content.kobo_only_shelves_sync = int(to_save.get("kobo_only_shelves_sync") == "on") or 0
-    # 1 -> 0: nothing has to be done
-    # 0 -> 1: all synced books have to be added to archived books, + currently synced shelfs
-    # which don't have to be synced have to be removed (added to Shelf archive)
     if old_state == 0 and content.kobo_only_shelves_sync == 1:
         kobo_sync_status.update_on_sync_shelfs(content.id)
+    elif old_state == 1 and content.kobo_only_shelves_sync == 0:
+        kobo_sync_status.on_sync_shelves_disabled(content.id)
     # Auto-send and metadata fetch settings
     content.auto_send_enabled = to_save.get("auto_send_enabled") == "on"
     content.auto_metadata_fetch = to_save.get("auto_metadata_fetch") == "on"
@@ -3060,7 +3068,7 @@ def restore_calibre_db():
         # 4. Wipe all book-linked tables in app.db
         from sqlalchemy import text as sql_text
         book_tables = [
-            "book_shelf_link", "book_read_link", "bookmark", "archived_book", "kobo_synced_books",
+            "book_shelf_link", "book_read_link", "bookmark", "archived_book",
             "kobo_reading_state", "kobo_bookmark", "kobo_statistics", "kobo_annotation_sync",
             "hardcover_book_blacklist", "hardcover_match_queue", "downloads", "magic_shelf_cache"
         ]

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -24,7 +24,7 @@ from sqlalchemy.exc import OperationalError, IntegrityError, InterfaceError, Inv
 from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.sql.expression import func
 
-from . import constants, logger, isoLanguages, gdriveutils, uploader, helper, kobo_sync_status
+from . import constants, logger, isoLanguages, gdriveutils, uploader, helper
 from .clean_html import clean_string
 from . import config, ub, db, calibre_db
 from .services.worker import WorkerThread
@@ -570,10 +570,8 @@ def edit_book_param(param, vals):
             log_key = 'rating'
             log_value = vals.get('value', '')
         elif param == 'is_archived':
-            is_archived = change_archived_books(book.id, vals['value'] == "True",
-                                                message="Book {} archive bit set to: {}".format(book.id, vals['value']))
-            if is_archived:
-                kobo_sync_status.remove_synced_book(book.id)
+            change_archived_books(book.id, vals['value'] == "True",
+                                  message="Book {} archive bit set to: {}".format(book.id, vals['value']))
             return ""
         elif param == 'read_status':
             ret = helper.edit_book_read_status(book.id, vals['value'] == "True")
@@ -686,10 +684,8 @@ def archive_selected_books():
     state = request.get_json().get('archive')
     if vals:
         for book_id in vals:
-            is_archived = change_archived_books(book_id, state,
-                                                message="Book {} archive bit set to: {}".format(book_id, state))
-            if is_archived:
-                kobo_sync_status.remove_synced_book(book_id)
+            change_archived_books(book_id, state,
+                                  message="Book {} archive bit set to: {}".format(book_id, state))
         return json.dumps({'success': True})
     return ""
 
@@ -946,7 +942,6 @@ def do_edit_book(book_id, upload_formats=None):
         # Stage 3: Commit all changes to the database
         if modify_date:
             book.last_modified = datetime.now(timezone.utc)
-            kobo_sync_status.remove_synced_book(book.id, all=True)
             calibre_db.set_metadata_dirty(book.id)
 
         try:
@@ -1382,8 +1377,8 @@ def delete_book_from_table(book_id, book_format, json_response, location=""):
                 else:
                     calibre_db.session.query(db.Data).filter(db.Data.book == book.id).\
                         filter(db.Data.format == book_format).delete()
-                    if book_format.upper() in ['KEPUB', 'EPUB', 'EPUB3']:
-                        kobo_sync_status.remove_synced_book(book.id, True)
+                    # Bump last_modified so that the new format can be picked up by Kobo devices
+                    book.last_modified = datetime.now(timezone.utc)
                 calibre_db.session.commit()
                 
                 # Invalidate duplicate cache after book deletion

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
+import glob
 import os
 import random
 import io
@@ -48,7 +49,7 @@ from . import logger, config, db, ub, fs
 from . import gdriveutils as gd
 from .constants import (STATIC_DIR as _STATIC_DIR, CACHE_TYPE_THUMBNAILS, THUMBNAIL_TYPE_COVER, THUMBNAIL_TYPE_SERIES,
                         SUPPORTED_CALIBRE_BINARIES)
-from .subproc_wrapper import process_wait
+from .subproc_wrapper import process_wait, process_open
 
 # Track books with pending thumbnail generation to prevent duplicate tasks
 _pending_thumbnail_books = set()
@@ -56,7 +57,7 @@ _pending_thumbnail_books = set()
 import sys
 sys.path.insert(1, '/app/calibre-web-automated/scripts/')
 from cwa_db import CWA_DB
-from .services.worker import WorkerThread
+from .services.worker import WorkerThread, STAT_FINISH_SUCCESS
 from .tasks.mail import TaskEmail
 from .tasks.thumbnail import TaskClearCoverThumbnailCache, TaskGenerateCoverThumbnails
 from .tasks.metadata_backup import TaskBackupMetadata
@@ -77,7 +78,8 @@ except (ImportError, RuntimeError) as e:
 
 
 # Convert existing book entry to new format
-def convert_book_format(book_id, calibre_path, old_book_format, new_book_format, user_id, ereader_mail=None, subject=None):
+def convert_book_format(book_id, calibre_path, old_book_format, new_book_format, user_id,
+                        ereader_mail=None, subject=None, blocking=False):
     book = calibre_db.get_book(book_id)
     data = calibre_db.get_book_format(book.id, old_book_format)
     if not data:
@@ -111,7 +113,14 @@ def convert_book_format(book_id, calibre_path, old_book_format, new_book_format,
            link)
     settings['old_book_format'] = old_book_format
     settings['new_book_format'] = new_book_format
-    WorkerThread.add(user_id, TaskConvert(file_path, book.id, txt, settings, ereader_mail, user_id))
+    task = TaskConvert(file_path, book.id, txt, settings, ereader_mail, user_id)
+    WorkerThread.add(user_id, task)
+    if blocking:
+        finished = task.done_event.wait(timeout=120)
+        if not finished:
+            return _("Conversion timed out for book id: %(book)d", book=book_id)
+        if task.stat != STAT_FINISH_SUCCESS:
+            return task.error or _("Conversion failed for book id: %(book)d", book=book_id)
     return None
 
 
@@ -1430,6 +1439,16 @@ def get_download_link(book_id, book_format, client):
         abort(404)
 
     data1 = calibre_db.get_book_format(book.id, book_format.upper())
+    if not data1 and book_format == "kepub" and config.config_kepubifypath:
+        data1 = calibre_db.get_book_format(book.id, "EPUB")
+        if data1:
+            log.info("KEPUB not found for book %d; converting on demand", book.id)
+            err = convert_book_format(book.id, config.get_book_path(), 'EPUB', 'KEPUB', None, blocking=True)
+            if not err:
+                data1 = calibre_db.get_book_format(book.id, "KEPUB")
+            else:
+                log.error("On-demand KEPUB conversion failed for book %d: %s", book.id, err)
+                book_format = "epub"
     if not data1:
         log.error("Requested format %s for book id %s not found in database", book_format.upper(), book_id)
         abort(404)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -598,7 +598,7 @@ def get_metadata(book):
                         "Url": get_download_url_for_book(book.id, book_data.format),
                         # The Kobo forma accepts platforms: (Generic, Android)
                         "Platform": "Generic",
-                        # "DrmType": "None", # Not required
+                        "DrmType": "None",
                     }
                 )
             except (zipfile.BadZipfile, FileNotFoundError) as e:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -31,10 +31,9 @@ from flask import (
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
 from sqlalchemy import func
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
-from sqlalchemy.orm import joinedload
-from sqlalchemy.sql import select
 import requests
 
 from . import config, logger, kobo_auth, db, calibre_db, helper, shelf as shelf_lib, ub, csrf, kobo_sync_status, magic_shelf
@@ -130,27 +129,6 @@ def convert_to_kobo_timestamp_string(timestamp):
         return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def get_magic_shelf_book_ids_for_kobo(user_id):
-    if not config.config_kobo_sync_magic_shelves:
-        return set()
-
-    magic_shelves = ub.session.query(ub.MagicShelf).filter_by(user_id=user_id, kobo_sync=True).all()
-    if not magic_shelves:
-        return set()
-
-    book_ids = set()
-    for shelf in magic_shelves:
-        books, _ = magic_shelf.get_books_for_magic_shelf(
-            shelf.id, page=1, page_size=None
-        )
-        for book in books:
-            book_ids.add(book.id)
-
-    if book_ids:
-        log.debug("Kobo Sync: magic shelf allowed books: %s", len(book_ids))
-
-    return book_ids
-
 
 @kobo.route("/v1/library/sync")
 @requires_kobo_auth
@@ -167,211 +145,165 @@ def HandleSyncRequest():
     if not current_app.wsgi_app.is_proxied:
         log.debug('Kobo: Received unproxied request, changed request port to external server port')
 
-    # if no books synced don't respect sync_token
-    if not ub.session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.user_id == current_user.id).count():
-        sync_token.books_last_modified = datetime.min
-        sync_token.books_last_created = datetime.min
-        sync_token.reading_state_last_modified = datetime.min
-
-    new_books_last_modified = sync_token.books_last_modified  # needed for sync selected shelfs only
-    new_books_last_created = sync_token.books_last_created  # needed to distinguish between new and changed entitlement
-    new_reading_state_last_modified = sync_token.reading_state_last_modified
-
-    new_archived_last_modified = datetime.min
-    sync_results = []
-
-    calibre_db.reconnect_db(config, ub.app_DB_path)
-
-
-    # Two-Way-Sync Deletion Logic
-    magic_shelf_book_ids = set()
-    if current_user.kobo_only_shelves_sync:
-        magic_shelf_book_ids = get_magic_shelf_book_ids_for_kobo(current_user.id)
+    # If a Force Full Sync was requested for this user, drop the incoming token's state
+    # so that the response replays the entire library, then clear the flag.
+    if getattr(current_user, 'kobo_force_full_sync', False):
+        log.info("Kobo Sync: full re-sync requested for user %s; ignoring incoming SyncToken", current_user.name)
+        sync_token = SyncToken.SyncToken(raw_kobo_store_token=sync_token.raw_kobo_store_token)
         try:
-            # Check all books that are on Kobo according to the database
-            synced_books_query = ub.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)
-            synced_book_ids = {item.book_id for item in synced_books_query}
-
-            # Check all books currently on a Kobo Sync shelf
-            allowed_books_query = (ub.session.query(ub.BookShelf.book_id)
-                                   .join(ub.Shelf, ub.BookShelf.shelf == ub.Shelf.id)
-                                   .filter(ub.Shelf.user_id == current_user.id, ub.Shelf.kobo_sync == True))
-            allowed_book_ids = {item.book_id for item in allowed_books_query}
-            if magic_shelf_book_ids:
-                allowed_book_ids |= magic_shelf_book_ids
-
-            # Spot the difference: books that need to be deleted
-            books_to_delete_ids = synced_book_ids - allowed_book_ids
-
-            if books_to_delete_ids:
-                log.info(f"Kobo Sync: Found {len(books_to_delete_ids)} books to remove from device for user {current_user.name}")
-
-                # Go through the “To be deleted” list
-                for book_id in books_to_delete_ids:
-                    book = calibre_db.get_book(book_id)
-                    if book:
-                        # Create a “Remove” command for the Kobo
-                        entitlement = {
-                            "BookEntitlement": create_book_entitlement(book, archived=True),
-                            "BookMetadata": get_metadata(book),
-                        }
-                        sync_results.append({"ChangedEntitlement": entitlement})
-
-                # Remove all books from the tracking table in one go
-                if books_to_delete_ids:
-                    ub.session.query(ub.KoboSyncedBooks).filter(
-                        ub.KoboSyncedBooks.user_id == current_user.id,
-                        ub.KoboSyncedBooks.book_id.in_(books_to_delete_ids)
-                    ).delete(synchronize_session=False)
-                    ub.session_commit()
-
+            user_record = ub.session.query(ub.User).filter(ub.User.id == int(current_user.id)).one_or_none()
+            if user_record is not None:
+                user_record.kobo_force_full_sync = False
+                ub.session_commit()
         except Exception as e:
-            log.error(f"Kobo Sync: Error during deletion logic: {e}")
+            log.error("Kobo Sync: failed to clear kobo_force_full_sync flag: %s", e)
             ub.session.rollback()
+    elif getattr(sync_token, 'migrated_from_v1', False):
+        # First sync after upgrading from a v1 token (pre-KoboBookVisibility).
+        # In the old v1 protocol, the Kobo device is only aware of visible books, where-as in the new v2 protocol the device is aware of all books regardless of visibility. We need to force a full resync to correct the device state for the v2 protocol expectations.
+        log.info("Kobo Sync: v1→v2 token migration for user %s; forcing full re-sync "
+                 "to inform device of non-visible Entitlement Ids", current_user.name)
+        sync_token = SyncToken.SyncToken(raw_kobo_store_token=sync_token.raw_kobo_store_token)
 
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
-    log.debug("Kobo Sync: books last modified: {}".format(sync_token.books_last_modified))
-
-    rstate_join = and_(
-        db.Books.id == ub.KoboReadingState.book_id,
-        ub.KoboReadingState.user_id == current_user.id,
-    )
-    if only_kobo_shelves:
-        changed_entries = calibre_db.session.query(db.Books,
-                                                   ub.ArchivedBook.last_modified,
-                                                   ub.BookShelf.date_added,
-                                                   ub.ArchivedBook.is_archived,
-                                                   ub.KoboReadingState)
-        changed_entries = (changed_entries
-                           .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
-                                                                          ub.ArchivedBook.user_id == current_user.id))
-                           .outerjoin(ub.KoboReadingState, rstate_join)
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
-                          .filter(or_(
-                              ub.BookShelf.date_added > sync_token.books_last_modified,
-                              db.Books.last_modified > sync_token.books_last_modified,
-                              db.Books.id.in_(magic_shelf_book_ids) if magic_shelf_book_ids else False
-                          ))
-                           .filter(db.Data.format.in_(KOBO_FORMATS))
-                           .filter(calibre_db.common_filters(allow_show_archived=True))
-                           .order_by(db.Books.last_modified)
-                           .order_by(db.Books.id)
-                           .outerjoin(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
-                           .outerjoin(ub.Shelf, ub.Shelf.id == ub.BookShelf.shelf)
-                           .filter(or_(
-                               and_(ub.Shelf.user_id == current_user.id, ub.Shelf.kobo_sync == True),
-                               db.Books.id.in_(magic_shelf_book_ids) if magic_shelf_book_ids else False
-                           ))
-                           .options(joinedload(db.Books.authors),
-                                    joinedload(db.Books.publishers),
-                                    joinedload(db.Books.series),
-                                    joinedload(db.Books.languages),
-                                    joinedload(db.Books.comments),
-                                    joinedload(db.Books.data))
-                           .distinct())
+    # Initialize pagination state. Reconnect db and refresh Magic-shelf state on the first request
+    if sync_token.pagination is not None:
+        pagination = sync_token.pagination
     else:
-        changed_entries = calibre_db.session.query(db.Books,
-                                                   ub.ArchivedBook.last_modified,
-                                                   ub.ArchivedBook.is_archived,
-                                                   ub.KoboReadingState)
-        changed_entries = (changed_entries
-                           .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
-                                                                          ub.ArchivedBook.user_id == current_user.id))
-                           .outerjoin(ub.KoboReadingState, rstate_join)
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
-                           .filter(calibre_db.common_filters(allow_show_archived=True))
-                           .filter(db.Data.format.in_(KOBO_FORMATS))
-                           .order_by(db.Books.last_modified)
-                           .order_by(db.Books.id)
-                           .options(joinedload(db.Books.authors),
-                                    joinedload(db.Books.publishers),
-                                    joinedload(db.Books.series),
-                                    joinedload(db.Books.languages),
-                                    joinedload(db.Books.comments),
-                                    joinedload(db.Books.data)))
-    log.debug("Kobo Sync: changed entries: {}".format(changed_entries.count()))
+        calibre_db.reconnect_db(config, ub.app_DB_path)
+        if only_kobo_shelves and config.config_kobo_sync_magic_shelves:
+            magic_shelf.update_kobo_book_visibility_from_magic_shelves(current_user.id)
+        pagination = SyncToken.SyncTokenPagination(snapshot_ts=datetime.utcnow())
 
-    reading_states_in_new_entitlements = []
-    books = changed_entries.limit(SYNC_ITEM_LIMIT)
-    log.debug("Kobo Sync: selected to sync: {}".format(len(books.all())))
-    for book in books:
-        formats = [data.format for data in book.Books.data]
+    sync_results = []
 
-        kobo_reading_state = book.KoboReadingState  # None when no record exists yet
-        entitlement = {
-            "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
-            "BookMetadata": get_metadata(book.Books),
-        }
+    log.debug("Kobo Sync: books last modified: {}, visibility last modified: {}, pagination: {}".format(
+        sync_token.books_last_modified, sync_token.visibility_last_modified, pagination))
 
-        if (kobo_reading_state is not None
-                and kobo_reading_state.last_modified > sync_token.reading_state_last_modified):
-            entitlement["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
-            new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
-            reading_states_in_new_entitlements.append(book.Books.id)
+    book_window = or_(
+        and_(db.Books.last_modified > sync_token.books_last_modified,
+             db.Books.last_modified <= pagination.snapshot_ts),
+        and_(ub.KoboBookVisibility.last_modified > sync_token.visibility_last_modified,
+             ub.KoboBookVisibility.last_modified <= pagination.snapshot_ts),
+        and_(ub.ArchivedBook.last_modified > sync_token.visibility_last_modified,
+             ub.ArchivedBook.last_modified <= pagination.snapshot_ts),
+    )
+    rstate_window = and_(
+        ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified,
+        ub.KoboReadingState.last_modified <= pagination.snapshot_ts,
+    )
+
+    # Iterate over all books in increasing BookId order. If results are too large, the sync process is paginated and the next request will resume starting at the last book_id synced returned in the previous response.
+    changed_entries = (calibre_db.session.query(
+                            db.Books,
+                            ub.ArchivedBook.is_archived.label('is_archived'),
+                            ub.ArchivedBook.last_modified.label('archived_last_modified'),
+                            ub.KoboBookVisibility.is_visible.label('kbv_is_visible'),
+                            ub.KoboBookVisibility.last_modified.label('kbv_last_modified'),
+                            ub.KoboReadingState,
+                       )
+                       .outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
+                                                       ub.ArchivedBook.user_id == current_user.id))
+                       .outerjoin(ub.KoboBookVisibility, and_(db.Books.id == ub.KoboBookVisibility.book_id,
+                                                              ub.KoboBookVisibility.user_id == current_user.id))
+                       .outerjoin(ub.KoboReadingState, and_(
+                           db.Books.id == ub.KoboReadingState.book_id,
+                           ub.KoboReadingState.user_id == current_user.id,
+                        ))
+                       .filter(or_(book_window, rstate_window))
+                       .filter(db.Books.id > pagination.books_last_id)
+                       .filter(calibre_db.common_filters(allow_show_archived=True))
+                       .order_by(db.Books.id))
+
+    # Fetch one extra row to detect whether more pages remain without a separate count query.
+    book_rows = changed_entries.limit(SYNC_ITEM_LIMIT + 1).all()
+    has_more = len(book_rows) > SYNC_ITEM_LIMIT
+    book_rows = book_rows[:SYNC_ITEM_LIMIT]
+    log.debug("Kobo Sync: selected to sync: %s (more=%s)", len(book_rows), has_more)
+
+    for book in book_rows:
+        kobo_reading_state = book.KoboReadingState
+
+        # A book is visible if it's not archived and if it's on a kobo synced shelf
+        is_visible = not bool(book.is_archived)
+        if only_kobo_shelves:
+            is_visible = is_visible and bool(book.kbv_is_visible)
 
         ts_created = get_kobo_created_ts(book)
 
-        if ts_created > sync_token.books_last_created:
-            sync_results.append({"NewEntitlement": entitlement})
-        else:
-            sync_results.append({"ChangedEntitlement": entitlement})
+        book_lm = book.Books.last_modified
+        book_last_modified_naive = book_lm.replace(tzinfo=None) if book_lm else None
 
-        new_books_last_modified = max(
-            book.Books.last_modified.replace(tzinfo=None), new_books_last_modified
+        kbv_lm = book.kbv_last_modified
+        if kbv_lm and hasattr(kbv_lm, 'replace'):
+            kbv_lm = kbv_lm.replace(tzinfo=None)
+        archived_lm = book.archived_last_modified
+        if archived_lm and hasattr(archived_lm, 'replace'):
+            archived_lm = archived_lm.replace(tzinfo=None)
+
+        is_newly_created = ts_created > sync_token.books_last_created
+        visibility_changed = any(
+            t is not None and t > sync_token.visibility_last_modified
+            for t in (kbv_lm, archived_lm)
         )
+        metadata_changed = (book_last_modified_naive is not None
+                            and book_last_modified_naive > sync_token.books_last_modified)
+  
+        if is_newly_created:
+            new_entry = {
+                "BookEntitlement": create_book_entitlement(book.Books, archived=not is_visible),
+                "BookMetadata": get_metadata(book.Books) if is_visible else get_removed_metadata(book.Books.uuid),
+            }
+            if is_visible and kobo_reading_state is not None:
+                new_entry["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
+                if kobo_reading_state.last_modified <= pagination.snapshot_ts:
+                    pagination.reading_state_max_last_modified = max(
+                        pagination.reading_state_max_last_modified, kobo_reading_state.last_modified)
+            sync_results.append({"NewEntitlement": new_entry})
+        elif visibility_changed:
+            sync_results.append({"ChangedEntitlement": {
+                "BookEntitlement": create_book_entitlement(book.Books, archived=not is_visible),
+            }})
+            if is_visible:
+                # Refresh the metadata for a newly visible book, since we previously may have sent a placeholder with empty metadata.
+                sync_results.append({"ChangedProductMetadata": {
+                    "BookMetadata": get_metadata(book.Books),
+                }})
+                if kobo_reading_state is not None:
+                    sync_results.append({"ChangedReadingState": {
+                        "ReadingState": get_kobo_reading_state_response(book.Books, kobo_reading_state),
+                    }})
+                    if kobo_reading_state.last_modified <= pagination.snapshot_ts:
+                        pagination.reading_state_max_last_modified = max(
+                            pagination.reading_state_max_last_modified, kobo_reading_state.last_modified)
+        elif is_visible:
+            # Already visible book that's not newly created, must be a modified book or modified reading state:
+            if metadata_changed:
+                sync_results.append({"ChangedProductMetadata": {
+                    "BookMetadata": get_metadata(book.Books),
+                }})
+            if kobo_reading_state is not None and kobo_reading_state.last_modified > sync_token.reading_state_last_modified:
+                sync_results.append({"ChangedReadingState": {
+                    "ReadingState": get_kobo_reading_state_response(book.Books, kobo_reading_state),
+                }})
+                if kobo_reading_state.last_modified <= pagination.snapshot_ts:
+                    pagination.reading_state_max_last_modified = max(
+                        pagination.reading_state_max_last_modified, kobo_reading_state.last_modified)
 
-        new_books_last_created = max(ts_created, new_books_last_created)
-        kobo_sync_status.add_synced_books(book.Books.id)
+        # Advance all per-signal watermarks unconditionally each iteration.
+        if book_last_modified_naive and book_last_modified_naive <= pagination.snapshot_ts:
+            pagination.books_max_last_modified = max(
+                pagination.books_max_last_modified, book_last_modified_naive)
+        vis_candidates = [t for t in (kbv_lm, archived_lm) if t is not None and t <= pagination.snapshot_ts]
+        if vis_candidates:
+            pagination.visibility_max_last_modified = max(
+                pagination.visibility_max_last_modified, max(vis_candidates))
+        pagination.books_max_last_created = max(pagination.books_max_last_created, ts_created)
+        pagination.books_last_id = book.Books.id
 
-    max_change = changed_entries.filter(ub.ArchivedBook.is_archived)\
-        .filter(ub.ArchivedBook.user_id == current_user.id) \
-        .order_by(func.datetime(ub.ArchivedBook.last_modified).desc()).first()
-
-    max_change = max_change.last_modified if max_change else new_archived_last_modified
-
-    new_archived_last_modified = max(new_archived_last_modified, max_change)
-
-    # no. of books returned
-    book_count = changed_entries.count()
-    # last entry:
-    cont_sync = bool(book_count)
-    log.debug("Kobo Sync: remaining books to sync: {}".format(book_count))
-    # generate reading state data
-    changed_reading_states = ub.session.query(ub.KoboReadingState)
-
-    log.debug("Kobo Sync: rstate last modified: {}".format(sync_token.reading_state_last_modified))
-    if only_kobo_shelves:
-        changed_reading_states = changed_reading_states.outerjoin(ub.BookShelf,
-                                                                  ub.KoboReadingState.book_id == ub.BookShelf.book_id)\
-            .outerjoin(ub.Shelf, ub.Shelf.id == ub.BookShelf.shelf)\
-            .filter(ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified)\
-            .filter(or_(
-                and_(current_user.id == ub.Shelf.user_id, ub.Shelf.kobo_sync == True),
-                ub.KoboReadingState.book_id.in_(magic_shelf_book_ids) if magic_shelf_book_ids else False
-            ))\
-            .distinct()
-    else:
-        changed_reading_states = changed_reading_states.filter(
-            ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified)
-
-    changed_reading_states = changed_reading_states.filter(
-        and_(ub.KoboReadingState.user_id == current_user.id,
-             ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))\
-        .order_by(ub.KoboReadingState.last_modified)
-    log.debug("Kobo Sync: changed states: {}".format(changed_reading_states.count()))
-    cont_sync |= bool(changed_reading_states.count() > SYNC_ITEM_LIMIT)
-    for kobo_reading_state in changed_reading_states.limit(SYNC_ITEM_LIMIT).all():
-        book = calibre_db.session.query(db.Books).filter(db.Books.id == kobo_reading_state.book_id).one_or_none()
-        if book:
-            sync_results.append({
-                "ChangedReadingState": {
-                    "ReadingState": get_kobo_reading_state_response(book, kobo_reading_state)
-                }
-            })
-            new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
+    cont_sync = has_more
+    log.debug("Kobo Sync: more to sync: {}".format(has_more))
 
     sync_shelves(sync_token, sync_results, only_kobo_shelves)
 
@@ -421,12 +353,25 @@ def HandleSyncRequest():
 
         sync_token.tags_last_modified = new_tags_last_modified
 
-    # update last created timestamp to distinguish between new and changed entitlements
-    if not cont_sync:
-        sync_token.books_last_created = new_books_last_created
-    sync_token.books_last_modified = new_books_last_modified
-    sync_token.archive_last_modified = new_archived_last_modified
-    sync_token.reading_state_last_modified = new_reading_state_last_modified
+    # If any section has more pages to send, hand the pagination object back
+    # on the token so the next request can resume against the same snapshot.
+    # When the round is complete, advance each section's watermark to its
+    # max-shipped value that was below snapshot_ts. We use the max-shipped value
+    # instead of snapshot_ts in case a book was concurrently added to the database
+    # outside of calibre-web, in which case it may have a last_created timestamp
+    # larger than all the existing last_created, but smaller than snapshot_ts.
+    if cont_sync:
+        sync_token.pagination = pagination
+    else:
+        sync_token.books_last_modified = max(
+            sync_token.books_last_modified, pagination.books_max_last_modified)
+        sync_token.books_last_created = max(
+            sync_token.books_last_created, pagination.books_max_last_created)
+        sync_token.reading_state_last_modified = max(
+            sync_token.reading_state_last_modified, pagination.reading_state_max_last_modified)
+        sync_token.visibility_last_modified = max(
+            sync_token.visibility_last_modified, pagination.visibility_max_last_modified)
+        sync_token.pagination = None
 
     return generate_sync_response(sync_token, sync_results, cont_sync)
 
@@ -606,6 +551,35 @@ def _get_cover_image_id(book):
         return base_id
 
 
+def get_removed_metadata(book_uuid):
+    book_uuid = str(book_uuid)
+    return {
+        "Categories": ["00000000-0000-0000-0000-000000000001"],
+        "CoverImageId": book_uuid,
+        "CrossRevisionId": book_uuid,
+        "CurrentDisplayPrice": {"CurrencyCode": "USD", "TotalAmount": 0},
+        "CurrentLoveDisplayPrice": {"TotalAmount": 0},
+        "Description": "",
+        "DownloadUrls": [],
+        "EntitlementId": book_uuid,
+        "ExternalIds": [],
+        "Genre": "00000000-0000-0000-0000-000000000001",
+        "IsEligibleForKoboLove": False,
+        "IsInternetArchive": False,
+        "IsPreOrder": False,
+        "IsSocialEnabled": True,
+        "Language": "en",
+        "PhoneticPronunciations": {},
+        "PublicationDate": None,
+        "Publisher": {"Imprint": "", "Name": ""},
+        "RevisionId": book_uuid,
+        "Title": "",
+        "WorkId": book_uuid,
+        "Series": {},
+        "Contributors": None,
+    }
+
+
 def get_metadata(book):
     download_urls = []
 
@@ -752,6 +726,7 @@ def HandleTagUpdate(tag_id):
 def add_items_to_shelf(items, shelf):
     book_ids_already_in_shelf = set([book_shelf.book_id for book_shelf in shelf.books])
     items_unknown_to_calibre = []
+    added_book_ids = []
     for item in items:
         try:
             if item["Type"] != "ProductRevisionTagItem":
@@ -766,8 +741,11 @@ def add_items_to_shelf(items, shelf):
             book_id = book.id
             if book_id not in book_ids_already_in_shelf:
                 shelf.books.append(ub.BookShelf(book_id=book_id))
+                added_book_ids.append(book_id)
         except KeyError:
             items_unknown_to_calibre.append(item)
+    if shelf.kobo_sync and added_book_ids:
+        kobo_sync_status.set_kobo_visibility(added_book_ids, shelf.user_id, is_visible=True)
     return items_unknown_to_calibre
 
 
@@ -824,6 +802,7 @@ def HandleTagRemoveItem(tag_id):
         abort(401, description="User is unauthaurized to edit shelf.")
 
     items_unknown_to_calibre = []
+    removed_book_ids = []
     for item in items:
         try:
             if item["Type"] != "ProductRevisionTagItem":
@@ -836,9 +815,12 @@ def HandleTagRemoveItem(tag_id):
                 continue
 
             shelf.books.filter(ub.BookShelf.book_id == book.id).delete()
+            removed_book_ids.append(book.id)
         except KeyError:
             items_unknown_to_calibre.append(item)
     ub.session_commit()
+    if shelf.kobo_sync and removed_book_ids:
+        kobo_sync_status.recompute_kobo_visibility(removed_book_ids, shelf.user_id)
 
     if items_unknown_to_calibre:
         log.debug("Received request to remove an unknown book to a collecition. Silently ignoring item.")
@@ -1200,7 +1182,6 @@ def HandleBookDeletionRequest(book_uuid):
     elif current_user.check_visibility(32768):
         kobo_sync_status.change_archived_books(book_id, True)
 
-    kobo_sync_status.remove_synced_book(book_id)
     return "", 204
 
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -232,14 +232,20 @@ def HandleSyncRequest():
 
     log.debug("Kobo Sync: books last modified: {}".format(sync_token.books_last_modified))
 
+    rstate_join = and_(
+        db.Books.id == ub.KoboReadingState.book_id,
+        ub.KoboReadingState.user_id == current_user.id,
+    )
     if only_kobo_shelves:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
                                                    ub.BookShelf.date_added,
-                                                   ub.ArchivedBook.is_archived)
+                                                   ub.ArchivedBook.is_archived,
+                                                   ub.KoboReadingState)
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
+                           .outerjoin(ub.KoboReadingState, rstate_join)
                            .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
                                                       .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
                           .filter(or_(
@@ -261,10 +267,12 @@ def HandleSyncRequest():
     else:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
-                                                   ub.ArchivedBook.is_archived)
+                                                   ub.ArchivedBook.is_archived,
+                                                   ub.KoboReadingState)
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
+                           .outerjoin(ub.KoboReadingState, rstate_join)
                            .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
                                                       .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
@@ -281,13 +289,14 @@ def HandleSyncRequest():
         if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
             helper.convert_book_format(book.Books.id, config.get_book_path(), 'EPUB', 'KEPUB', current_user.name)
 
-        kobo_reading_state = get_or_create_reading_state(book.Books.id)
+        kobo_reading_state = book.KoboReadingState  # None when no record exists yet
         entitlement = {
             "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
             "BookMetadata": get_metadata(book.Books),
         }
 
-        if kobo_reading_state.last_modified > sync_token.reading_state_last_modified:
+        if (kobo_reading_state is not None
+                and kobo_reading_state.last_modified > sync_token.reading_state_last_modified):
             entitlement["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
             new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
             reading_states_in_new_entitlements.append(book.Books.id)
@@ -1043,8 +1052,10 @@ def get_ub_read_status(kobo_read_status):
 
 
 def get_or_create_reading_state(book_id):
-    book_read = ub.session.query(ub.ReadBook).filter(ub.ReadBook.book_id == book_id,
-                                                     ub.ReadBook.user_id == int(current_user.id)).one_or_none()
+    book_read = ub.session.query(ub.ReadBook).filter(
+        ub.ReadBook.book_id == book_id,
+        ub.ReadBook.user_id == int(current_user.id),
+    ).one_or_none()
     if not book_read:
         book_read = ub.ReadBook(user_id=current_user.id, book_id=book_id)
     if not book_read.kobo_reading_state:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -315,10 +315,11 @@ def HandleSyncRequest():
     cont_sync = has_more
     log.debug("Kobo Sync: more to sync: {}".format(has_more))
 
-    sync_shelves(sync_token, sync_results, only_kobo_shelves)
+    if not cont_sync:
+        sync_shelves(sync_token, sync_results, only_kobo_shelves)
 
     # Add magic shelves as collections
-    if config.config_kobo_sync_magic_shelves:
+    if not cont_sync and config.config_kobo_sync_magic_shelves:
 
         for shelf in ub.session.query(ub.MagicShelf)\
             .filter_by(user_id=current_user.id, kobo_sync=False)\

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -181,17 +181,17 @@ def HandleSyncRequest():
     log.debug("Kobo Sync: books last modified: {}, visibility last modified: {}, pagination: {}".format(
         sync_token.books_last_modified, sync_token.visibility_last_modified, pagination))
 
-    book_window = or_(
+    query_window = or_(
         and_(db.Books.last_modified > sync_token.books_last_modified,
              db.Books.last_modified <= pagination.snapshot_ts),
         and_(ub.KoboBookVisibility.last_modified > sync_token.visibility_last_modified,
              ub.KoboBookVisibility.last_modified <= pagination.snapshot_ts),
         and_(ub.ArchivedBook.last_modified > sync_token.visibility_last_modified,
              ub.ArchivedBook.last_modified <= pagination.snapshot_ts),
-    )
-    rstate_window = and_(
-        ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified,
-        ub.KoboReadingState.last_modified <= pagination.snapshot_ts,
+        and_(
+            ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified,
+            ub.KoboReadingState.last_modified <= pagination.snapshot_ts,
+        ),
     )
 
     # Iterate over all books in increasing BookId order. If results are too large, the sync process is paginated and the next request will resume starting at the last book_id synced returned in the previous response.
@@ -201,8 +201,8 @@ def HandleSyncRequest():
                             db.Books,
                             ub.ArchivedBook.is_archived.label('is_archived'),
                             ub.ArchivedBook.last_modified.label('archived_last_modified'),
-                            ub.KoboBookVisibility.is_visible.label('kbv_is_visible'),
-                            ub.KoboBookVisibility.last_modified.label('kbv_last_modified'),
+                            ub.KoboBookVisibility.is_visible.label('is_visible'),
+                            ub.KoboBookVisibility.last_modified.label('visible_last_modified'),
                             ub.KoboReadingState,
                        )
                        .options(
@@ -221,7 +221,7 @@ def HandleSyncRequest():
                            db.Books.id == ub.KoboReadingState.book_id,
                            ub.KoboReadingState.user_id == current_user.id,
                         ))
-                       .filter(or_(book_window, rstate_window))
+                       .filter(query_window)
                        .filter(db.Books.id > pagination.books_last_id)
                        .filter(calibre_db.common_filters(allow_show_archived=True))
                        .order_by(db.Books.id))
@@ -238,16 +238,16 @@ def HandleSyncRequest():
         # A book is visible if it's not archived and if it's on a kobo synced shelf
         is_visible = not bool(book.is_archived)
         if only_kobo_shelves:
-            is_visible = is_visible and bool(book.kbv_is_visible)
+            is_visible = is_visible and bool(book.is_visible)
 
         ts_created = get_kobo_created_ts(book)
 
-        book_lm = book.Books.last_modified
-        book_last_modified_naive = book_lm.replace(tzinfo=None) if book_lm else None
+        book_last_modified = book.Books.last_modified
+        book_last_modified = book_last_modified.replace(tzinfo=None) if book_last_modified else None
 
-        kbv_lm = book.kbv_last_modified
-        if kbv_lm and hasattr(kbv_lm, 'replace'):
-            kbv_lm = kbv_lm.replace(tzinfo=None)
+        visible_last_modified = book.visible_last_modified
+        if visible_last_modified and hasattr(visible_last_modified, 'replace'):
+            visible_last_modified = visible_last_modified.replace(tzinfo=None)
         archived_lm = book.archived_last_modified
         if archived_lm and hasattr(archived_lm, 'replace'):
             archived_lm = archived_lm.replace(tzinfo=None)
@@ -255,10 +255,10 @@ def HandleSyncRequest():
         is_newly_created = ts_created > sync_token.books_last_created
         visibility_changed = any(
             t is not None and t > sync_token.visibility_last_modified
-            for t in (kbv_lm, archived_lm)
+            for t in (visible_last_modified, archived_lm)
         )
-        metadata_changed = (book_last_modified_naive is not None
-                            and book_last_modified_naive > sync_token.books_last_modified)
+        metadata_changed = (book_last_modified is not None
+                            and book_last_modified > sync_token.books_last_modified)
   
         if is_newly_created:
             new_entry = {
@@ -293,10 +293,10 @@ def HandleSyncRequest():
                 }})
 
         # Advance all per-signal watermarks unconditionally each iteration.
-        if book_last_modified_naive and book_last_modified_naive <= pagination.snapshot_ts:
+        if book_last_modified and book_last_modified <= pagination.snapshot_ts:
             pagination.books_max_last_modified = max(
-                pagination.books_max_last_modified, book_last_modified_naive)
-        vis_candidates = [t for t in (kbv_lm, archived_lm) if t is not None and t <= pagination.snapshot_ts]
+                pagination.books_max_last_modified, book_last_modified)
+        vis_candidates = [t for t in (visible_last_modified, archived_lm) if t is not None and t <= pagination.snapshot_ts]
         if vis_candidates:
             pagination.visibility_max_last_modified = max(
                 pagination.visibility_max_last_modified, max(vis_candidates))

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -267,9 +267,6 @@ def HandleSyncRequest():
             }
             if is_visible and kobo_reading_state is not None:
                 new_entry["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
-                if kobo_reading_state.last_modified <= pagination.snapshot_ts:
-                    pagination.reading_state_max_last_modified = max(
-                        pagination.reading_state_max_last_modified, kobo_reading_state.last_modified)
             sync_results.append({"NewEntitlement": new_entry})
         elif visibility_changed:
             sync_results.append({"ChangedEntitlement": {
@@ -284,9 +281,6 @@ def HandleSyncRequest():
                     sync_results.append({"ChangedReadingState": {
                         "ReadingState": get_kobo_reading_state_response(book.Books, kobo_reading_state),
                     }})
-                    if kobo_reading_state.last_modified <= pagination.snapshot_ts:
-                        pagination.reading_state_max_last_modified = max(
-                            pagination.reading_state_max_last_modified, kobo_reading_state.last_modified)
         elif is_visible:
             # Already visible book that's not newly created, must be a modified book or modified reading state:
             if metadata_changed:
@@ -297,9 +291,6 @@ def HandleSyncRequest():
                 sync_results.append({"ChangedReadingState": {
                     "ReadingState": get_kobo_reading_state_response(book.Books, kobo_reading_state),
                 }})
-                if kobo_reading_state.last_modified <= pagination.snapshot_ts:
-                    pagination.reading_state_max_last_modified = max(
-                        pagination.reading_state_max_last_modified, kobo_reading_state.last_modified)
 
         # Advance all per-signal watermarks unconditionally each iteration.
         if book_last_modified_naive and book_last_modified_naive <= pagination.snapshot_ts:
@@ -309,6 +300,9 @@ def HandleSyncRequest():
         if vis_candidates:
             pagination.visibility_max_last_modified = max(
                 pagination.visibility_max_last_modified, max(vis_candidates))
+        if kobo_reading_state is not None and kobo_reading_state.last_modified <= pagination.snapshot_ts:
+            pagination.reading_state_max_last_modified = max(
+                pagination.reading_state_max_last_modified, kobo_reading_state.last_modified)
         pagination.books_max_last_created = max(pagination.books_max_last_created, ts_created)
         pagination.books_last_id = book.Books.id
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -631,6 +631,7 @@ def get_metadata(book):
         "RevisionId": book_uuid,
         "Title": book.title,
         "WorkId": book_uuid,
+        "Series": {},
     }
     metadata.update(get_author(book))
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1364,16 +1364,16 @@ def HandleInitRequest():
                                                                url_for("kobo.HandleCoverImageRequest",
                                                                        auth_token=kobo_auth.get_auth_token(),
                                                                        book_uuid="{ImageId}",
-                                                                       width="{width}",
-                                                                       height="{height}",
+                                                                       width="{Width}",
+                                                                       height="{Height}",
                                                                        Quality='{Quality}',
                                                                        isGreyscale='isGreyscale'))
         kobo_resources["image_url_template"] = unquote(calibre_web_url +
                                                        url_for("kobo.HandleCoverImageRequest",
                                                                auth_token=kobo_auth.get_auth_token(),
                                                                book_uuid="{ImageId}",
-                                                               width="{width}",
-                                                               height="{height}",
+                                                               width="{Width}",
+                                                               height="{Height}",
                                                                isGreyscale='false'))
         if config.config_hardcover_annotations_sync and bool(hardcover):
             kobo_resources["reading_services_host"] = calibre_web_url
@@ -1382,16 +1382,16 @@ def HandleInitRequest():
         kobo_resources["image_url_quality_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
                                                                        auth_token=kobo_auth.get_auth_token(),
                                                                        book_uuid="{ImageId}",
-                                                                       width="{width}",
-                                                                       height="{height}",
+                                                                       width="{Width}",
+                                                                       height="{Height}",
                                                                        Quality='{Quality}',
                                                                        isGreyscale='isGreyscale',
                                                                        _external=True))
         kobo_resources["image_url_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
                                                                auth_token=kobo_auth.get_auth_token(),
                                                                book_uuid="{ImageId}",
-                                                               width="{width}",
-                                                               height="{height}",
+                                                               width="{Width}",
+                                                               height="{Height}",
                                                                isGreyscale='false',
                                                                _external=True))
         if config.config_hardcover_annotations_sync and bool(hardcover):

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1147,7 +1147,7 @@ def HandleCoverImageRequest(book_uuid, width, height, Quality, isGreyscale):
         else:
             resolution = COVER_THUMBNAIL_SMALL
     except ValueError:
-        log.error("Requested height %s of book %s is invalid" % (book_uuid, height))
+        log.error("Requested height %s of book %s is invalid" % (height, book_uuid))
         resolution = COVER_THUMBNAIL_SMALL
     book_cover = helper.get_book_cover_with_uuid(book_uuid, resolution=resolution)
     if book_cover:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -33,6 +33,7 @@ from werkzeug.datastructures import Headers
 from sqlalchemy import func
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 import requests
 
@@ -263,6 +264,12 @@ def HandleSyncRequest():
                                and_(ub.Shelf.user_id == current_user.id, ub.Shelf.kobo_sync == True),
                                db.Books.id.in_(magic_shelf_book_ids) if magic_shelf_book_ids else False
                            ))
+                           .options(joinedload(db.Books.authors),
+                                    joinedload(db.Books.publishers),
+                                    joinedload(db.Books.series),
+                                    joinedload(db.Books.languages),
+                                    joinedload(db.Books.comments),
+                                    joinedload(db.Books.data))
                            .distinct())
     else:
         changed_entries = calibre_db.session.query(db.Books,
@@ -278,7 +285,13 @@ def HandleSyncRequest():
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .order_by(db.Books.last_modified)
-                           .order_by(db.Books.id))
+                           .order_by(db.Books.id)
+                           .options(joinedload(db.Books.authors),
+                                    joinedload(db.Books.publishers),
+                                    joinedload(db.Books.series),
+                                    joinedload(db.Books.languages),
+                                    joinedload(db.Books.comments),
+                                    joinedload(db.Books.data)))
     log.debug("Kobo Sync: changed entries: {}".format(changed_entries.count()))
 
     reading_states_in_new_entitlements = []
@@ -643,11 +656,12 @@ def get_metadata(book):
     }
     metadata.update(get_author(book))
 
-    if get_series(book):
-        name = get_series(book)
+    series_name = get_series(book)
+    if series_name:
+        name = series_name
         try:
             metadata["Series"] = {
-                "Name": get_series(book),
+                "Name": series_name,
                 "Number": get_seriesindex(book),        # ToDo Check int() ?
                 "NumberFloat": float(get_seriesindex(book)),
                 # Get a deterministic id based on the series name.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -31,7 +31,7 @@ from flask import (
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
 from sqlalchemy import func
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
 import requests
@@ -195,6 +195,8 @@ def HandleSyncRequest():
     )
 
     # Iterate over all books in increasing BookId order. If results are too large, the sync process is paginated and the next request will resume starting at the last book_id synced returned in the previous response.
+    # selectinload fetches each relationship for all books in one IN-list query rather than
+    # one query per book, turning O(n*r) lazy loads into O(r) batch fetches.
     changed_entries = (calibre_db.session.query(
                             db.Books,
                             ub.ArchivedBook.is_archived.label('is_archived'),
@@ -202,6 +204,14 @@ def HandleSyncRequest():
                             ub.KoboBookVisibility.is_visible.label('kbv_is_visible'),
                             ub.KoboBookVisibility.last_modified.label('kbv_last_modified'),
                             ub.KoboReadingState,
+                       )
+                       .options(
+                           selectinload(db.Books.authors),
+                           selectinload(db.Books.languages),
+                           selectinload(db.Books.series),
+                           selectinload(db.Books.publishers),
+                           selectinload(db.Books.comments),
+                           selectinload(db.Books.data),
                        )
                        .outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                        ub.ArchivedBook.user_id == current_user.id))

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -299,8 +299,6 @@ def HandleSyncRequest():
     log.debug("Kobo Sync: selected to sync: {}".format(len(books.all())))
     for book in books:
         formats = [data.format for data in book.Books.data]
-        if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
-            helper.convert_book_format(book.Books.id, config.get_book_path(), 'EPUB', 'KEPUB', current_user.name)
 
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
         entitlement = {
@@ -603,28 +601,32 @@ def _get_cover_image_id(book):
 
 def get_metadata(book):
     download_urls = []
-    kepub = [data for data in book.data if data.format == 'KEPUB']
 
-    for book_data in kepub if len(kepub) > 0 else book.data:
-        if book_data.format not in KOBO_FORMATS:
-            continue
-        for kobo_format in KOBO_FORMATS[book_data.format]:
-            # log.debug('Id: %s, Format: %s' % (book.id, kobo_format))
-            try:
-                if get_epub_layout(book, book_data) == 'pre-paginated':
-                    kobo_format = 'EPUB3FL'
-                download_urls.append(
-                    {
-                        "Format": kobo_format,
-                        "Size": book_data.uncompressed_size,
-                        "Url": get_download_url_for_book(book.id, book_data.format),
-                        # The Kobo forma accepts platforms: (Generic, Android)
-                        "Platform": "Generic",
-                        # "DrmType": "None", # Not required
-                    }
-                )
-            except (zipfile.BadZipfile, FileNotFoundError) as e:
-                log.error(e)
+    kepub_data = next((d for d in book.data if d.format == 'KEPUB'), None)
+    epub_data  = next((d for d in book.data if d.format == 'EPUB'),  None)
+
+    if kepub_data:
+        book_data, dl_format, published_format = kepub_data, 'kepub', 'KEPUB'
+    elif epub_data and config.config_kepubifypath:
+        book_data, dl_format, published_format = epub_data, 'kepub', 'KEPUB'
+    elif epub_data:
+        book_data, dl_format, published_format = epub_data, 'epub', 'EPUB3'
+    else:
+        book_data = None
+
+    if book_data:
+        try:
+            if get_epub_layout(book, book_data) == 'pre-paginated':
+                published_format = 'EPUB3FL'
+        except (zipfile.BadZipfile, FileNotFoundError) as e:
+            log.error(e)
+        download_urls.append({
+            "Format": published_format,
+            "Size": book_data.uncompressed_size,
+            "Url": get_download_url_for_book(book.id, dl_format),
+            "Platform": "Generic",
+            "DrmType": "None",
+        })
 
     book_uuid = book.uuid
     cover_image_id = _get_cover_image_id(book)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -474,22 +474,29 @@ def HandleMetadataRequest(book_uuid):
 
 
 def get_download_url_for_book(book_id, book_format):
+    endpoint_name = "kobo.download_book"
+    endpoint_path = "download"
+    if request.headers.get("x-kobo-deviceos") == "Android":
+        endpoint_name = "kobo.redirect_download_book"
+        endpoint_path = "redirect_download"
+
     if not current_app.wsgi_app.is_proxied:
         if ':' in request.host and not request.host.endswith(']'):
             host = "".join(request.host.split(':')[:-1])
         else:
             host = request.host
 
-        return "{url_scheme}://{url_base}:{url_port}/kobo/{auth_token}/download/{book_id}/{book_format}".format(
+        return "{url_scheme}://{url_base}:{url_port}/kobo/{auth_token}/{endpoint_path}/{book_id}/{book_format}".format(
             url_scheme=request.scheme,
             url_base=host,
             url_port=config.config_external_port,
             auth_token=get_auth_token(),
+            endpoint_path=endpoint_path,
             book_id=book_id,
             book_format=book_format.lower()
         )
     return url_for(
-        "kobo.download_book",
+        endpoint_name,
         auth_token=kobo_auth.get_auth_token(),
         book_id=book_id,
         book_format=book_format.lower(),
@@ -1409,6 +1416,19 @@ def HandleInitRequest():
 @download_required
 def download_book(book_id, book_format):
     return get_download_link(book_id, book_format, "kobo")
+
+
+@kobo.route("/redirect_download/<book_id>/<book_format>")
+@requires_kobo_auth
+@download_required
+def redirect_download_book(book_id, book_format):
+    return redirect(url_for(
+        "kobo.download_book",
+        auth_token=kobo_auth.get_auth_token(),
+        book_id=book_id,
+        book_format=book_format.lower(),
+        _external=True,
+    ))
 
 
 def NATIVE_KOBO_RESOURCES():

--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -94,13 +94,6 @@ def generate_auth_token(user_id):
         ub.session.add(auth_token)
         ub.session_commit()
 
-    books = calibre_db.session.query(db.Books).join(db.Data).all()
-
-    for book in books:
-        formats = [data.format for data in book.data]
-        if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
-            helper.convert_book_format(book.id, config.config_calibre_dir, 'EPUB', 'KEPUB', current_user.name)
-
     return render_title_template(
         "generate_kobo_auth_url.html",
         title=_("Kobo Setup"),

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -5,72 +5,156 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
-from .cw_login import current_user
-from . import ub
 from datetime import datetime, timezone
-from sqlalchemy.sql.expression import or_, and_, true
-# from sqlalchemy import exc
+
+from sqlalchemy.sql.expression import and_
+
+from .cw_login import current_user
+from . import ub, calibre_db, db
+from . import logger
 
 
-# Add the current book id to kobo_synced_books table for current user, if entry is already present,
-# do nothing (safety precaution)
-def add_synced_books(book_id):
-    is_present = ub.session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.book_id == book_id)\
-        .filter(ub.KoboSyncedBooks.user_id == current_user.id).count()
-    if not is_present:
-        synced_book = ub.KoboSyncedBooks()
-        synced_book.user_id = current_user.id
-        synced_book.book_id = book_id
-        ub.session.add(synced_book)
+log = logger.create()
+
+
+def _is_book_on_any_kobo_shelf(book_id, user_id, session):
+    """Return True if book_id is on at least one kobo_sync=True shelf for user_id."""
+    return session.query(ub.BookShelf).join(
+        ub.Shelf, ub.Shelf.id == ub.BookShelf.shelf
+    ).filter(
+        ub.BookShelf.book_id == book_id,
+        ub.Shelf.user_id == int(user_id),
+        ub.Shelf.kobo_sync == True,
+    ).first() is not None
+
+
+def set_kobo_visibility(book_ids, user_id, is_visible, session=None):
+    """Bulk-set is_visible for a list of books without rechecking shelf membership.
+
+    Use when the visibility value is already known (e.g., book just added to a
+    kobo shelf → True; confirmed not on any shelf after removal → False).
+    Only rows where is_visible actually changes get a new last_modified so the
+    sync cursor only fires for genuine state transitions.
+    """
+    if not book_ids:
+        return
+    s = session or ub.session
+    now = datetime.now(timezone.utc)
+    book_ids = list(book_ids)
+
+    existing = {r.book_id: r for r in s.query(ub.KoboBookVisibility).filter(
+        ub.KoboBookVisibility.user_id == int(user_id),
+        ub.KoboBookVisibility.book_id.in_(book_ids),
+    ).all()}
+
+    for bid in book_ids:
+        if bid in existing:
+            row = existing[bid]
+            if row.is_visible == is_visible:
+                continue
+            row.is_visible = is_visible
+            row.last_modified = now
+        else:
+            s.add(ub.KoboBookVisibility(
+                user_id=int(user_id), book_id=bid,
+                is_visible=is_visible, last_modified=now,
+            ))
+
+    if session is None:
         ub.session_commit()
-
-
-# Select all entries of current book in kobo_synced_books table, which are from current user and delete them
-def remove_synced_book(book_id, all=False, session=None):
-    if not all:
-        user = ub.KoboSyncedBooks.user_id == current_user.id
     else:
-        user = true()
-    if not session:
-        ub.session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.book_id == book_id).filter(user).delete()
+        ub.session_commit(_session=session)
+
+
+def recompute_kobo_visibility(book_ids, user_id, session=None, force_visible=None):
+    """Recompute is_visible for each book by querying current kobo shelf membership.
+
+    Use when a book was removed from a shelf: it might still be on another
+    kobo-sync shelf, so we can't assume is_visible=False.  Issues two bulk
+    queries regardless of how many books are in the list.
+    """
+    if not book_ids:
+        return
+    s = session or ub.session
+    now = datetime.now(timezone.utc)
+    book_ids = list(book_ids)
+
+    # Single query: which of these books are still on any kobo-sync shelf?
+    still_visible = {r.book_id for r in s.query(ub.BookShelf.book_id).join(
+        ub.Shelf, ub.Shelf.id == ub.BookShelf.shelf
+    ).filter(
+        ub.BookShelf.book_id.in_(book_ids),
+        ub.Shelf.user_id == int(user_id),
+        ub.Shelf.kobo_sync == True,
+    ).all()}
+
+    existing = {r.book_id: r for r in s.query(ub.KoboBookVisibility).filter(
+        ub.KoboBookVisibility.user_id == int(user_id),
+        ub.KoboBookVisibility.book_id.in_(book_ids),
+    ).all()}
+
+    for bid in book_ids:
+        vis = bid in still_visible or (force_visible is not None and bid in force_visible)
+        if bid in existing:
+            row = existing[bid]
+            if row.is_visible == vis:
+                continue
+            row.is_visible = vis
+            row.last_modified = now
+        else:
+            s.add(ub.KoboBookVisibility(
+                user_id=int(user_id), book_id=bid,
+                is_visible=vis, last_modified=now,
+            ))
+
+    if session is None:
         ub.session_commit()
     else:
-        session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.book_id == book_id).filter(user).delete()
         ub.session_commit(_session=session)
 
 
 def change_archived_books(book_id, state=None, message=None):
-    archived_book = ub.session.query(ub.ArchivedBook).filter(and_(ub.ArchivedBook.user_id == int(current_user.id),
-                                                                  ub.ArchivedBook.book_id == book_id)).first()
+    archived_book = ub.session.query(ub.ArchivedBook).filter(and_(
+        ub.ArchivedBook.user_id == int(current_user.id),
+        ub.ArchivedBook.book_id == book_id,
+    )).first()
     if not archived_book:
         archived_book = ub.ArchivedBook(user_id=current_user.id, book_id=book_id)
 
     archived_book.is_archived = state if state else not archived_book.is_archived
-    archived_book.last_modified = datetime.now(timezone.utc)        # toDo. Check utc timestamp
+    archived_book.last_modified = datetime.now(timezone.utc)
 
     ub.session.merge(archived_book)
     ub.session_commit(message)
     return archived_book.is_archived
 
 
-# select all books which are synced by the current user and do not belong to a synced shelf and set them to archive
-# select all shelves from current user which are synced and do not belong to the "only sync" shelves
-def update_on_sync_shelfs(user_id):
-    books_to_archive = (ub.session.query(ub.KoboSyncedBooks)
-                        .join(ub.BookShelf, ub.KoboSyncedBooks.book_id == ub.BookShelf.book_id, isouter=True)
-                        .join(ub.Shelf, ub.Shelf.user_id == user_id, isouter=True)
-                        .filter(or_(ub.Shelf.kobo_sync == 0, ub.Shelf.kobo_sync==None))
-                        .filter(ub.KoboSyncedBooks.user_id == user_id).all())
-    for b in books_to_archive:
-        change_archived_books(b.book_id, True)
-        ub.session.query(ub.KoboSyncedBooks) \
-            .filter(ub.KoboSyncedBooks.book_id == b.book_id) \
-            .filter(ub.KoboSyncedBooks.user_id == user_id).delete()
-        ub.session_commit()
+def on_sync_shelves_disabled(user_id):
+    """Called when kobo_only_shelves_sync is turned OFF (ON→OFF).
 
-    # Search all shelf which are currently not synced
-    shelves_to_archive = ub.session.query(ub.Shelf).filter(ub.Shelf.user_id == user_id).filter(
-        ub.Shelf.kobo_sync == 0).all()
-    for a in shelves_to_archive:
-        ub.session.add(ub.ShelfArchive(uuid=a.uuid, user_id=user_id))
+    All non-archived books become visible regardless of shelf membership.
+    Writes KBV rows surgically so only books whose visibility actually changes
+    get a new last_modified, keeping the sync window tight.
+    """
+    all_book_ids = [r for r, in calibre_db.session.query(db.Books.id).all()]
+    set_kobo_visibility(all_book_ids, user_id, is_visible=True)
+
+
+def update_on_sync_shelfs(user_id):
+    """Called when kobo_only_shelves_sync is turned ON (OFF→ON).
+
+    Recomputes KBV visibility for every book based on current kobo-sync shelf
+    membership.  Books no longer on any kobo shelf get is_visible=False with a
+    fresh last_modified so the device sees them disappear on the next sync.
+    Non-kobo shelves are also archived from the device's collection list.
+    """
+    all_book_ids = [r for r, in calibre_db.session.query(db.Books.id).all()]
+    recompute_kobo_visibility(all_book_ids, user_id)
+
+    shelves_to_archive = ub.session.query(ub.Shelf).filter(
+        ub.Shelf.user_id == int(user_id),
+        ub.Shelf.kobo_sync == 0,
+    ).all()
+    for shelf in shelves_to_archive:
+        ub.session.add(ub.ShelfArchive(uuid=shelf.uuid, user_id=user_id))
         ub.session_commit()

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -11,7 +11,6 @@ from sqlalchemy import and_, or_, not_
 from sqlalchemy.sql.expression import func
 from sqlalchemy.exc import SQLAlchemyError
 from datetime import datetime, timedelta, timezone
-
 log = logger.create()
 
 MAGIC_SHELF_ORDER_MODES = {
@@ -699,6 +698,31 @@ def get_book_count_for_magic_shelf(shelf_id):
     except Exception as e:
         log.error(f"Error counting books for magic shelf {shelf_id}: {e}")
         return 0
+
+def update_kobo_book_visibility_from_magic_shelves(user_id):
+    """Update KoboBookVisibility for all kobo_sync=True magic shelves of user_id.
+
+    Called once per sync round start so that books that entered or left a
+    magic shelf have their KoboBookVisibility rows updated.
+
+    Args:
+        user_id: ID of the user
+    """
+    magic_shelves = ub.session.query(ub.MagicShelf).filter_by(user_id=user_id, kobo_sync=True).all()
+    if not magic_shelves:
+        return set()
+
+    from .kobo_sync_status import recompute_kobo_visibility
+
+    book_ids = set()
+    for shelf in magic_shelves:
+        books, _ = get_books_for_magic_shelf(shelf.id, page=1, page_size=None)
+        for book in books:
+            book_ids.add(book.id)
+
+    from . import calibre_db
+    all_book_ids = [r for r, in calibre_db.session.query(db.Books.id).all()]
+    recompute_kobo_visibility(all_book_ids, user_id, force_visible=book_ids)
 
 
 def create_system_magic_shelves(user_id, template_keys=None):

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -35,11 +35,89 @@ def get_datetime_from_json(json_object, field_name):
         return datetime.min
 
 
+class SyncTokenPagination:
+    """In-progress pagination state for a multi-page sync round.
+
+    A ``SyncToken`` carries one of these (or ``None``) to remember where it
+    is mid-round. ``snapshot_ts`` is the upper bound of the round's filter
+    window — captured once at round start, immutable until the round ends —
+    so books or reading states modified mid-round don't disrupt the cursor
+    and instead get picked up cleanly in the next round.
+
+    Each paginated section stores its id cursor and a running
+    ``max_last_modified`` of everything it has shipped so far in this round.
+    When the round completes, the watermarks on the parent ``SyncToken``
+    advance to those max-shipped values. Advancing them to the snapshot_ts
+    would also be a reasonable design choice, but keeping them at max-shipped
+    can allow *some* concurrent changes with backdated timestamps to be picked
+    up (e.g. book addition outside of calibre-web).
+    """
+
+    def __init__(
+        self,
+        snapshot_ts=datetime.min,
+        books_last_id=0,
+        books_max_last_modified=datetime.min,
+        books_max_last_created=datetime.min,
+        reading_state_last_id=0,
+        reading_state_max_last_modified=datetime.min,
+        visibility_max_last_modified=datetime.min,
+    ):
+        self.snapshot_ts = snapshot_ts
+        self.books_last_id = books_last_id
+        self.books_max_last_modified = books_max_last_modified
+        self.books_max_last_created = books_max_last_created
+        self.reading_state_last_id = reading_state_last_id
+        self.reading_state_max_last_modified = reading_state_max_last_modified
+        self.visibility_max_last_modified = visibility_max_last_modified
+
+    def to_dict(self):
+        return {
+            "snapshot_ts": to_epoch_timestamp(self.snapshot_ts),
+            "books_last_id": self.books_last_id,
+            "books_max_last_modified": to_epoch_timestamp(self.books_max_last_modified),
+            "books_max_last_created": to_epoch_timestamp(self.books_max_last_created),
+            "reading_state_last_id": self.reading_state_last_id,
+            "reading_state_max_last_modified": to_epoch_timestamp(self.reading_state_max_last_modified),
+            "visibility_max_last_modified": to_epoch_timestamp(self.visibility_max_last_modified),
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        if not data:
+            return None
+        return cls(
+            snapshot_ts=get_datetime_from_json(data, "snapshot_ts"),
+            books_last_id=int(data.get("books_last_id", 0) or 0),
+            books_max_last_modified=get_datetime_from_json(data, "books_max_last_modified"),
+            books_max_last_created=get_datetime_from_json(data, "books_max_last_created"),
+            reading_state_last_id=int(data.get("reading_state_last_id", 0) or 0),
+            reading_state_max_last_modified=get_datetime_from_json(data, "reading_state_max_last_modified"),
+            visibility_max_last_modified=get_datetime_from_json(data, "visibility_max_last_modified"),
+        )
+
+    def __str__(self):
+        return ("snap={},books=(id>{},max_lm={},max_lc={}),"
+                "rstate=(id>{},max_lm={}),vis_max_lm={}").format(
+            self.snapshot_ts,
+            self.books_last_id,
+            self.books_max_last_modified,
+            self.books_max_last_created,
+            self.reading_state_last_id,
+            self.reading_state_max_last_modified,
+            self.visibility_max_last_modified,
+        )
+
+
 class SyncToken:
     """ The SyncToken is used to persist state across requests.
     When serialized over the response headers, the Kobo device will propagate the token onto following
     requests to the service. As an example use-case, the SyncToken is used to detect books that have been added
     to the library since the last time the device synced to the server.
+
+    The token also carries a ``pagination`` slot that is non-None when a
+    sync response is split across multiple requests. See
+    ``SyncTokenPagination`` for the details of that state.
 
     Attributes:
         books_last_created: Datetime representing the newest book that the device knows about.
@@ -47,8 +125,10 @@ class SyncToken:
     """
 
     SYNC_TOKEN_HEADER = "x-kobo-synctoken"  # nosec
-    VERSION = "1-1-0"
+    VERSION = "1-2-0"
     LAST_MODIFIED_ADDED_VERSION = "1-1-0"
+    PAGINATION_ADDED_VERSION = "1-2-0"
+    VISIBILITY_ADDED_VERSION = "1-2-0"
     MIN_VERSION = "1-0-0"
 
     token_schema = {
@@ -66,8 +146,22 @@ class SyncToken:
             "books_last_created": {"type": "string"},
             "archive_last_modified": {"type": "string"},
             "reading_state_last_modified": {"type": "string"},
-            "tags_last_modified": {"type": "string"}
-            # "books_last_id": {"type": "integer", "optional": True}
+            "tags_last_modified": {"type": "string"},
+        },
+    }
+    # v2 (>= "1-2-0"): visibility_last_modified replaces archive_last_modified, tracking
+    # both KoboBookVisibility.last_modified and ArchivedBook.last_modified under one watermark.
+    # A New Pagination object is added to better track paginated responses.
+    data_schema_v2 = {
+        "type": "object",
+        "properties": {
+            "raw_kobo_store_token": {"type": "string"},
+            "books_last_modified": {"type": "string"},
+            "books_last_created": {"type": "string"},
+            "visibility_last_modified": {"type": "string"},
+            "reading_state_last_modified": {"type": "string"},
+            "tags_last_modified": {"type": "string"},
+            "pagination": {"type": ["object", "null"]},
         },
     }
 
@@ -76,18 +170,20 @@ class SyncToken:
         raw_kobo_store_token="",
         books_last_created=datetime.min,
         books_last_modified=datetime.min,
-        archive_last_modified=datetime.min,
+        visibility_last_modified=datetime.min,
         reading_state_last_modified=datetime.min,
-        tags_last_modified=datetime.min
-        # books_last_id=-1
+        tags_last_modified=datetime.min,
+        pagination=None,
+        migrated_from_v1=False,
     ):  # nosec
         self.raw_kobo_store_token = raw_kobo_store_token
         self.books_last_created = books_last_created
         self.books_last_modified = books_last_modified
-        self.archive_last_modified = archive_last_modified
+        self.visibility_last_modified = visibility_last_modified
         self.reading_state_last_modified = reading_state_last_modified
         self.tags_last_modified = tags_last_modified
-        # self.books_last_id = books_last_id
+        self.pagination = pagination
+        self.migrated_from_v1 = migrated_from_v1  # transient; not serialized into build_sync_token()
 
     @staticmethod
     def from_headers(headers):
@@ -106,11 +202,16 @@ class SyncToken:
                 b64decode(sync_token_header + "=" * (-len(sync_token_header) % 4))
             )
             validate(sync_token_json, SyncToken.token_schema)
-            if sync_token_json["version"] < SyncToken.MIN_VERSION:
+            token_version = sync_token_json["version"]
+            if token_version < SyncToken.MIN_VERSION:
                 raise ValueError
 
             data_json = sync_token_json["data"]
-            validate(sync_token_json, SyncToken.data_schema_v1)
+            # v1 tokens (< 1-2-0) track archive_last_modified; v2 (>= 1-2-0) replaced it with
+            # visibility_last_modified, which covers both KoboBookVisibility and ArchivedBook.
+            # Pagination and visibility landed in the same release, so the version boundary is the same.
+            is_v1 = token_version < SyncToken.VISIBILITY_ADDED_VERSION
+            validate(sync_token_json, SyncToken.data_schema_v1 if is_v1 else SyncToken.data_schema_v2)
         except (exceptions.ValidationError, ValueError):
             log.error("Sync token contents do not follow the expected json schema.")
             return SyncToken()
@@ -119,20 +220,35 @@ class SyncToken:
         try:
             books_last_modified = get_datetime_from_json(data_json, "books_last_modified")
             books_last_created = get_datetime_from_json(data_json, "books_last_created")
-            archive_last_modified = get_datetime_from_json(data_json, "archive_last_modified")
+            if is_v1:
+                # Migration path: _HandleSyncRequest detects migrated_from_v1=True and resets all
+                # watermarks to datetime.min, forcing a full re-sync.  With watermarks at minimum,
+                # every book passes through the window: non-visible books emit
+                # NewEntitlement(archived=True) via the is_newly_created path (ts_created >
+                # datetime.min is always true), correctly signalling their removal to the device.
+                visibility_last_modified = get_datetime_from_json(data_json, "archive_last_modified")
+            else:
+                visibility_last_modified = get_datetime_from_json(data_json, "visibility_last_modified")
             reading_state_last_modified = get_datetime_from_json(data_json, "reading_state_last_modified")
             tags_last_modified = get_datetime_from_json(data_json, "tags_last_modified")
         except TypeError:
             log.error("SyncToken timestamps don't parse to a datetime.")
             return SyncToken(raw_kobo_store_token=raw_kobo_store_token)
 
+        # Pagination is optional: tokens generated before VERSION 1-2-0
+        # (or the very first sync request from a device) don't carry it,
+        # which means "no round in progress."
+        pagination = SyncTokenPagination.from_dict(data_json.get("pagination"))
+
         return SyncToken(
             raw_kobo_store_token=raw_kobo_store_token,
             books_last_created=books_last_created,
             books_last_modified=books_last_modified,
-            archive_last_modified=archive_last_modified,
+            visibility_last_modified=visibility_last_modified,
             reading_state_last_modified=reading_state_last_modified,
             tags_last_modified=tags_last_modified,
+            pagination=pagination,
+            migrated_from_v1=is_v1,
         )
 
     def set_kobo_store_header(self, store_headers):
@@ -153,17 +269,21 @@ class SyncToken:
                 "raw_kobo_store_token": self.raw_kobo_store_token,
                 "books_last_modified": to_epoch_timestamp(self.books_last_modified),
                 "books_last_created": to_epoch_timestamp(self.books_last_created),
-                "archive_last_modified": to_epoch_timestamp(self.archive_last_modified),
+                "visibility_last_modified": to_epoch_timestamp(self.visibility_last_modified),
                 "reading_state_last_modified": to_epoch_timestamp(self.reading_state_last_modified),
                 "tags_last_modified": to_epoch_timestamp(self.tags_last_modified),
+                "pagination": self.pagination.to_dict() if self.pagination is not None else None,
             },
         }
         return b64encode_json(token)
 
     def __str__(self):
-        return "{},{},{},{},{},{}".format(self.books_last_created,
-                                          self.books_last_modified,
-                                          self.archive_last_modified,
-                                          self.reading_state_last_modified,
-                                          self.tags_last_modified,
-                                          self.raw_kobo_store_token)
+        return "{},{},{},{},{},{},pagination={}".format(
+            self.books_last_created,
+            self.books_last_modified,
+            self.visibility_last_modified,
+            self.reading_state_last_modified,
+            self.tags_last_modified,
+            self.raw_kobo_store_token,
+            self.pagination,
+        )

--- a/cps/services/worker.py
+++ b/cps/services/worker.py
@@ -209,6 +209,7 @@ class CalibreTask:
         self.id = uuid.uuid4()
         self.self_cleanup = False
         self._scheduled = False
+        self.done_event = threading.Event()
 
     @abc.abstractmethod
     def run(self, worker_thread):
@@ -297,10 +298,12 @@ class CalibreTask:
         self.stat = STAT_FAIL
         self.progress = 1
         self.error = error_message
+        self.done_event.set()
 
     def _handleSuccess(self):
         self.stat = STAT_FINISH_SUCCESS
         self.progress = 1
+        self.done_event.set()
 
     def __str__(self):
         return self.name

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import InvalidRequestError, OperationalError
 from sqlalchemy.sql.expression import func, true
 
 from . import calibre_db, config, db, logger, ub
+from .kobo_sync_status import set_kobo_visibility, recompute_kobo_visibility
 from .render_template import render_title_template
 from .usermanagement import login_required_if_no_ano, user_login_required
 from .services import hardcover
@@ -70,7 +71,9 @@ def add_to_shelf(shelf_id, book_id):
     try:
         ub.session.merge(shelf)
         ub.session.commit()
-        
+        if shelf.kobo_sync:
+            set_kobo_visibility([book_id], shelf.user_id, is_visible=True)
+
         # Track shelf activity
         try:
             from scripts.cwa_db import CWA_DB
@@ -160,6 +163,8 @@ def search_to_shelf(shelf_id):
         try:
             ub.session.merge(shelf)
             ub.session.commit()
+            if shelf.kobo_sync:
+                set_kobo_visibility(books_for_shelf, shelf.user_id, is_visible=True)
             flash(_("Books have been added to shelf: %(sname)s", sname=shelf.name), category="success")
         except (OperationalError, InvalidRequestError) as e:
             ub.session.rollback()
@@ -204,7 +209,9 @@ def remove_from_shelf(shelf_id, book_id):
             ub.session.delete(book_shelf)
             shelf.last_modified = datetime.now(timezone.utc)
             ub.session.commit()
-            
+            if shelf.kobo_sync:
+                recompute_kobo_visibility([book_id], shelf.user_id)
+
             # Track shelf activity
             try:
                 from scripts.cwa_db import CWA_DB
@@ -359,12 +366,22 @@ def create_edit_shelf(shelf, page_title, page, shelf_id=False):
             flash(_("Sorry you are not allowed to create a public shelf"), category="error")
             return redirect(url_for('web.index'))
         is_public = 1 if to_save.get("is_public") == "on" else 0
+        kobo_sync_flipped_book_ids = []
+        kobo_sync_new_value = None
         if config.config_kobo_sync:
+            previous_kobo_sync = bool(shelf.kobo_sync) if shelf_id else False
             shelf.kobo_sync = True if to_save.get("kobo_sync") else False
             if shelf.kobo_sync:
                 ub.session.query(ub.ShelfArchive).filter(ub.ShelfArchive.user_id == current_user.id).filter(
                     ub.ShelfArchive.uuid == shelf.uuid).delete()
                 ub.session_commit()
+            # Capture book IDs before commit so visibility can be updated after.
+            if shelf_id and previous_kobo_sync != bool(shelf.kobo_sync):
+                kobo_sync_new_value = bool(shelf.kobo_sync)
+                kobo_sync_flipped_book_ids = [row.book_id for row in (
+                    ub.session.query(ub.BookShelf.book_id)
+                    .filter(ub.BookShelf.shelf == shelf.id).all()
+                )]
         shelf_title = to_save.get("title", "")
         if check_shelf_is_unique(shelf_title, is_public, shelf_id):
             shelf.name = shelf_title
@@ -379,6 +396,13 @@ def create_edit_shelf(shelf, page_title, page, shelf_id=False):
                 flash_text = _("Shelf %(title)s changed", title=shelf_title)
             try:
                 ub.session.commit()
+                # Update KoboBookVisibility after commit so the new kobo_sync
+                # value is visible to the recompute query.
+                if kobo_sync_flipped_book_ids:
+                    if kobo_sync_new_value:
+                        set_kobo_visibility(kobo_sync_flipped_book_ids, shelf.user_id, is_visible=True)
+                    else:
+                        recompute_kobo_visibility(kobo_sync_flipped_book_ids, shelf.user_id)
                 log.info("Shelf {} {}".format(shelf_title, shelf_action))
                 flash(flash_text, category="success")
                 return redirect(url_for('shelf.show_shelf', shelf_id=shelf.id))
@@ -432,10 +456,22 @@ def delete_shelf_helper(cur_shelf):
     if not cur_shelf or not check_shelf_edit_permissions(cur_shelf):
         return False
     shelf_id = cur_shelf.id
+    was_kobo_sync = bool(cur_shelf.kobo_sync)
+    user_id = cur_shelf.user_id
+    # Capture before deletion; BookShelf rows are gone after commit.
+    if was_kobo_sync:
+        affected_book_ids = [r.book_id for r in (
+            ub.session.query(ub.BookShelf.book_id).filter(ub.BookShelf.shelf == shelf_id).all()
+        )]
+    else:
+        affected_book_ids = []
     ub.session.delete(cur_shelf)
     ub.session.query(ub.BookShelf).filter(ub.BookShelf.shelf == shelf_id).delete()
     ub.session.add(ub.ShelfArchive(uuid=cur_shelf.uuid, user_id=cur_shelf.user_id))
     ub.session_commit("successfully deleted Shelf {}".format(cur_shelf.name))
+    # Shelf rows are deleted; recompute checks only remaining kobo shelves.
+    if affected_book_ids:
+        recompute_kobo_visibility(affected_book_ids, user_id)
     return True
 
 
@@ -540,6 +576,7 @@ def add_selected_to_shelf():
         return jsonify({'status': 'error', 'message': 'You are not allowed to add books to this shelf'}), 403
 
     success_count = 0
+    added_book_ids = []
     errors = []
 
     if not book_ids:
@@ -565,6 +602,7 @@ def add_selected_to_shelf():
 
         new_entry = ub.BookShelf(shelf=shelf.id, book_id=book_id, order=maxOrder + 1)
         shelf.books.append(new_entry)
+        added_book_ids.append(book_id)
         success_count += 1
 
     if success_count > 0:
@@ -572,6 +610,8 @@ def add_selected_to_shelf():
         try:
             ub.session.merge(shelf)
             ub.session.commit()
+            if shelf.kobo_sync:
+                set_kobo_visibility(added_book_ids, shelf.user_id, is_visible=True)
             log.info(f"Successfully added {success_count} books to shelf: {shelf.name}")
         except (OperationalError, InvalidRequestError) as e:
             ub.session.rollback()

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -8,6 +8,7 @@
 import os
 import re
 import glob
+from datetime import datetime, timezone
 from shutil import copyfile, copyfileobj
 from markupsafe import escape
 from time import time
@@ -21,8 +22,6 @@ from cps import db
 from cps import logger, config
 from cps.subproc_wrapper import process_open
 from flask_babel import gettext as _
-from cps.kobo_sync_status import remove_synced_book
-from cps.ub import init_db_thread
 from cps.file_helper import get_temp_dir
 
 from cps.tasks.mail import TaskEmail
@@ -175,11 +174,13 @@ class TaskConvert(CalibreTask):
                                          book=book_id, uncompressed_size=os.path.getsize(file_path + format_new_ext))
                     try:
                         local_db.session.merge(new_format)
+                        # Adding any format is a metadata change. last_modified is
+                        # the right signal — Kobo sync picks it up via the
+                        # GREATEST(last_change, last_modified) cursor and ships
+                        # ChangedProductMetadata. Format-driven visibility is the
+                        # client's call from BookMetadata.formats.
+                        cur_book.last_modified = datetime.now(timezone.utc)
                         local_db.session.commit()
-                        if self.settings['new_book_format'].upper() in ['KEPUB', 'EPUB', 'EPUB3']:
-                            ub_session = init_db_thread()
-                            remove_synced_book(book_id, True, ub_session)
-                            ub_session.close()
                     except SQLAlchemyError as e:
                         local_db.session.rollback()
                         log.error("Database error: %s", e)

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -280,6 +280,9 @@ class User(UserBase, Base):
     remote_auth_token = relationship('RemoteAuthToken', backref='user', lazy='dynamic')
     view_settings = Column(JSON, default={})
     kobo_only_shelves_sync = Column(Integer, default=0)
+    # When True, the next Kobo sync request ignores the incoming SyncToken and
+    # performs a full library sync. The flag is cleared once that sync starts.
+    kobo_force_full_sync = Column(Boolean, default=False)
     hardcover_token = Column(String, unique=True, default=None)
     # New per-user theme (0=default/light, 1=caliBlur) replacing global-only behavior
     theme = Column(Integer, default=1)
@@ -569,11 +572,24 @@ class ArchivedBook(Base):
     last_modified = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
 
-class KoboSyncedBooks(Base):
-    __tablename__ = 'kobo_synced_books'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(Integer, ForeignKey('user.id'))
-    book_id = Column(Integer)
+# Per-(user, book) Kobo visibility state.  is_visible tracks whether the book
+# is currently on at least one kobo-sync shelf (regular or magic) for this user.
+# last_modified is bumped whenever visibility changes, feeding the sync cursor so
+# shelf add/remove events surface on the device without a separate state table.
+# A missing row means the book has never been on any kobo shelf for this user;
+# the sync query treats that as is_visible=False via the OUTER JOIN NULL.
+class KoboBookVisibility(Base):
+    __tablename__ = 'kobo_book_visibility'
+
+    user_id = Column(Integer, ForeignKey('user.id'), primary_key=True, nullable=False)
+    book_id = Column(Integer, primary_key=True, nullable=False)
+    is_visible = Column(Boolean, nullable=False)
+    last_modified = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index('idx_kobo_book_visibility_user_lm', 'user_id', 'last_modified', 'book_id'),
+    )
+
 
 # The Kobo ReadingState API keeps track of 4 timestamped entities:
 #   ReadingState, StatusInfo, Statistics, CurrentBookmark
@@ -796,6 +812,8 @@ def add_missing_tables(engine, _session):
         MagicShelfCache.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "hidden_magic_shelf_templates"):
         HiddenMagicShelfTemplate.__table__.create(bind=engine, checkfirst=True)
+    if not engine.dialect.has_table(engine.connect(), "kobo_book_visibility"):
+        KoboBookVisibility.__table__.create(bind=engine, checkfirst=True)
 
 
 # migrate all settings missing in registration table
@@ -893,6 +911,14 @@ def migrate_user_table(engine, _session):
     except exc.OperationalError:
         _safe_session_rollback(_session, "user.kindle_mail_subject")
         _run_ddl_with_retry(engine, "ALTER TABLE user ADD column 'kindle_mail_subject' String DEFAULT ''")
+
+    # Migration to add the Kobo force-full-sync flag (replaces kobo_synced_books-based reset)
+    try:
+        _session.query(exists().where(User.kobo_force_full_sync)).scalar()
+        _session.commit()
+    except exc.OperationalError:
+        _safe_session_rollback(_session, "user.kobo_force_full_sync")
+        _run_ddl_with_retry(engine, "ALTER TABLE user ADD column 'kobo_force_full_sync' Boolean DEFAULT 0")
 
     # Migration to enable duplicates sidebar for existing admin users (one-time)
     try:
@@ -1049,6 +1075,19 @@ def migrate_Database(_session):
     migrate_oauth_provider_table(engine, _session)
     migrate_config_table(engine, _session)
     migrate_magic_shelf_table(engine, _session)
+
+    # Drop legacy sync-state tables that have been superseded by KoboBookVisibility.
+    try:
+        with engine.begin() as conn:
+            for legacy_table in ("kobo_synced_books", "kobo_book_sync_state"):
+                exists = conn.execute(text(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=:t"
+                ), {"t": legacy_table}).first() is not None
+                if exists:
+                    conn.execute(text(f"DROP TABLE {legacy_table}"))
+                    log.info("Dropped legacy Kobo table: %s", legacy_table)
+    except Exception as e:
+        log.warning("Could not drop legacy Kobo tables: %s", e)
 
     # Ensure progress syncing tables in app.db (user-related tables)
     from .progress_syncing.models import ensure_app_db_tables

--- a/cps/web.py
+++ b/cps/web.py
@@ -42,7 +42,6 @@ from .pagination import Pagination
 from .redirect import get_redirect_location
 from .cw_babel import get_available_locale
 from .usermanagement import login_required_if_no_ano
-from .kobo_sync_status import remove_synced_book
 from . import magic_shelf
 from .render_template import render_title_template
 from .kobo_sync_status import change_archived_books
@@ -210,8 +209,6 @@ def toggle_read(book_id):
 @user_login_required
 def toggle_archived(book_id):
     change_archived_books(book_id, message="Book {} archive bit toggled".format(book_id))
-    # Remove book from syncd books list to force resync (?)
-    remove_synced_book(book_id)
     return ""
 
 
@@ -2421,12 +2418,14 @@ def change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_sta
         current_user.default_language = to_save.get("default_language", "all")
         current_user.locale = to_save.get("locale", "en")
         old_state = current_user.kobo_only_shelves_sync
-        # 1 -> 0: nothing has to be done
-        # 0 -> 1: all synced books have to be added to archived books, + currently synced shelfs which
-        # don't have to be synced have to be removed (added to Shelf archive)
         current_user.kobo_only_shelves_sync = int(to_save.get("kobo_only_shelves_sync") == "on") or 0
         if old_state == 0 and current_user.kobo_only_shelves_sync == 1:
+            # OFF→ON: archive non-shelf books on the device and remove non-kobo shelves.
             kobo_sync_status.update_on_sync_shelfs(current_user.id)
+        elif old_state == 1 and current_user.kobo_only_shelves_sync == 0:
+            # ON→OFF: mark all books visible in KBV so the device picks them up
+            # through the normal visibility_last_modified watermark.
+            kobo_sync_status.on_sync_shelves_disabled(current_user.id)
         current_user.hardcover_token = to_save.get("hardcover_token","" ).replace("Bearer ","" ) or None
         # Auto-send and metadata fetch settings
         current_user.auto_send_enabled = to_save.get("auto_send_enabled") == "on"


### PR DESCRIPTION
The previous implementation relied on server-side tracking of each sync request which suffered from the following issues:
- Slow sync responses because of database changes on each request
- Race conditions between a paginated sync response and concurrent server side change
- Race conditions on a dropped sync response (book considered synced by server but not client)
- Multiple devices can't use the sync endpoint
- Difficulty distinguishing metadata changes from other changes

The new design changes the pagination method to improve robustness, and eliminates (nearly) all server side side-effects on a sync request.
In testing, this implementation can sync a 5000 book library from scratch in 45 seconds with all books in kobo shelves. Syncing the same library from scratch again but this time with 0 books in kobo syncable shelves took 20 seconds. For comparison, I was seeing latencies of up to 30 seconds just for syncing the first 100 books of this library before this change.
This implementation also let's multiple devices sync to the same kobo endpoint, and enables client-side reset of the SyncToken to trigger a full resync.

Note: This pull request contains  #1344 and #1343 in its history.

High level design changes:

**1. A new KoboBookVisibility table is added to track which books are visible to kobo**
 - Kobo shelf membership changes update the KoboBookVisibility table
 - The first Sync before pagination re-computes magic shelf memberships and updates the KoboBookVisibility table based on its result.

**2. The sync handler now makes a single database query to build NewEntitlement, ChangedEntitlement and ChangedProductMetadata responses:**
 - A ChangedEntitlement entry is emitted whenever a book becomes visible or invisible (i.e removed)
 - A NewEntitlement entry is emitted whenever a new book is added (vis-a-vis the device SyncToken). If the book shouldn't be visible, a blank BookMetadata is included so that the device can process a later ChangedEntitlement entry that makes the book visible (devices won't accept a ChangedEntitlement entry if no entitlement existed before). This allows us to remove the server-side tracking of which books have been synced to the device. Instead we only need track visibility changes using the SyncToken's book_visibility_last_modified field
 - A ChangedProductMetadata entry is emitted whenever a book metadata is changed, or whenever a book becomes visible (to override the previously blank metadata we may have sent on a non-visible NewEntitlement)

**3. Pagination of large sync responses is rewritten for robustness against race conditions:**
 - A snapshot timestamp is recorded at the beginning of a multi-round response and recorded in a new SyncTokenPagination object in the SyncToken.
 - All queries accross paged-sync requests are filtered to entries with modifications below that snapshot timestamp.
 - Once we've gotten through all books in the table, we can update the tokens last_created/last_modified/etc timestamps to the snapshoted timestamp and clear out the SyncTokenPagination object.
 - If any modifications to the library were concurrently made server side during these exchanges, they will be picked up on the next request after we cleared SyncTokenPagination.

**For backwards compatibility:**
 - "Force full sync" is now implemented as a kobo_force_full_sync boolean on the User model. Setting it causes the next sync request to discard the device's incoming token and replay the library; the flag is cleared once that sync starts. This isn't really necessary anymore, since Kobo devices have a setting to "repair" the sync state which resets the SyncToken on the client side.
 - The kobo_synced_books and kobo_book_sync_state tables are dropped on startup.
 - The SyncToken version number is incremented, and a full sync is forced to ensure no compatibility issues with the previous state.

**Out of scope:**
 - Syncing of tag/collection membership to the device is kept out of scope of this pull request since it's already grown quite large. But note that it is bug prone and could use a similar effort. The only extent to which it is touched here is ensuring that shelf membership correctly affects book visibility. Oh and tag memberships are only computed and returned on the final request of a pagination exchange instead of every request.

Related issues:
https://github.com/janeczku/calibre-web/issues/1276
https://github.com/janeczku/calibre-web/issues/3331
https://github.com/crocodilestick/Calibre-Web-Automated/issues/1112