### PR TITLE
fix(kobo): correct multi-device sync of NewEntitlements

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -237,16 +237,24 @@ def HandleSyncRequest():
                                                    ub.ArchivedBook.last_modified,
                                                    ub.BookShelf.date_added,
                                                    ub.ArchivedBook.is_archived)
+        # Per-device sync state lives in the `x-kobo-synctoken` cursor
+        # (the last_modified comparisons below). Don't filter by
+        # KoboSyncedBooks here — that table is user-keyed, so it would
+        # lock additional devices on the same user out of receiving
+        # books another device already synced.
+        #
+        # Magic-shelf membership is enforced by the OUTER filter
+        # (kobo_sync shelf OR magic-shelf) further down. Don't add
+        # magic_shelf_book_ids to the inner OR — that bypasses the
+        # timestamp cursor and produces an infinite cont_sync loop on
+        # paginated sync.
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
-                          .filter(or_(
-                              ub.BookShelf.date_added > sync_token.books_last_modified,
-                              db.Books.last_modified > sync_token.books_last_modified,
-                              db.Books.id.in_(magic_shelf_book_ids) if magic_shelf_book_ids else False
-                          ))
+                           .filter(or_(
+                               ub.BookShelf.date_added > sync_token.books_last_modified,
+                               db.Books.last_modified > sync_token.books_last_modified
+                           ))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .order_by(db.Books.last_modified)
@@ -262,11 +270,15 @@ def HandleSyncRequest():
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
                                                    ub.ArchivedBook.is_archived)
+        # Same per-device cursor invariant as the shelf branch above:
+        # don't filter by KoboSyncedBooks (user-keyed, breaks multi-device).
+        # The last_modified > sync_token.books_last_modified filter is the
+        # per-device throttle — without it, this branch returns every book
+        # on every sync and keeps cont_sync True forever.
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
+                           .filter(db.Books.last_modified > sync_token.books_last_modified)
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .order_by(db.Books.last_modified)


### PR DESCRIPTION
## Summary

`HandleSyncRequest` is responsible for telling each Kobo device which books are new to it. The current logic gets multi-device wrong: the first device to sync claims every book at the user level (via `KoboSyncedBooks`), leaving every other device on the same account unable to receive those books as `NewEntitlement`.

## The bug

Two `db.Books.id.notin_(KoboSyncedBooks ...)` filters in `HandleSyncRequest` are keyed by `user_id`, not `(user_id, device_id)`. Once **any** device synced a book, every other device on the user was permanently excluded — both at initial pair (full library) and at steady-state delta sync (newly-added books one device fetched first).

The Kobo protocol already tracks per-device sync state via the `x-kobo-synctoken` cursor (the `last_modified` comparisons already present in the query). That's the correct mechanism for "what's new for this device". The `notin_` filter was a redundant user-level layer doing the wrong thing for multi-device.

## The fix

**Shelf branch** (`kobo_only_shelves_sync == True`):
- Remove the `notin_` filter.
- Also remove `db.Books.id.in_(magic_shelf_book_ids)` from the inner OR. That bypass causes magic-shelf books to re-emit on every paginated request forever (`cont_sync` loop) once `notin_` is gone. Magic-shelf scope is still enforced by the **outer** filter (`kobo_sync` shelf OR magic-shelf membership) — that's "what's in scope". The inner OR is "what changed", which the timestamp cursor handles correctly per-device.

**Full-library branch** (`kobo_only_shelves_sync == False`):
- Remove the `notin_` filter.
- Add the matching `last_modified > books_last_modified` filter that the shelf branch already had. Without it this branch returns every book on every sync, since `notin_` was its only per-device throttle.

`KoboSyncedBooks` is preserved for its other legitimate uses: the two-way deletion logic earlier in `HandleSyncRequest` (set difference to emit `archived=True` when a book leaves a `kobo_sync` shelf), and the `add_synced_books` / `remove_synced_book` bookkeeping that feeds it.

## Compatibility

- No schema changes.
- No wire-format changes.
- `KoboSyncedBooks` table and other call sites unchanged.
- Existing single-device users see identical behavior (they were only getting books once anyway; the change is per-device cursor vs. per-user exclusion list, which converge in the single-device case).

## References

Fixes the multi-device sync issue tracked upstream in janeczku/calibre-web#2230.