### PR TITLE
Harden author ordering during book list rendering

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -1084,32 +1084,45 @@ class CalibreDB:
         self.ensure_session()
         for entry in entries:
             if combined:
-                sort_authors = entry.Books.author_sort.split('&')
-                ids = [a.id for a in entry.Books.authors]
-
+                book = entry.Books
             else:
-                sort_authors = entry.author_sort.split('&')
-                ids = [a.id for a in entry.authors]
-            authors_ordered = list()
-            # error = False
+                book = entry
+
+            sort_authors = (book.author_sort or '').split('&')
+            authors_list = [author for author in book.authors if author is not None]
+
+            authors_by_sort = {}
+            authors_by_id = {}
+            for author in authors_list:
+                if author.sort:
+                    authors_by_sort[author.sort] = author
+                if author.id is not None:
+                    authors_by_id[author.id] = author
+
+            authors_ordered = []
+            ids_remaining = set(authors_by_id.keys())
             for auth in sort_authors:
                 auth = strip_whitespaces(auth)
-                # Skip empty author strings to prevent spurious errors
                 if not auth:
                     continue
-                results = self.session.query(Authors).filter(Authors.sort == auth).all()
-                # ToDo: How to handle not found author name
-                if not len(results):
-                    log.error("Author '{}' not found to display name in right order".format(auth))
-                    # error = True
-                    break
-                for r in results:
-                    if r.id in ids:
-                        authors_ordered.append(r)
-                        ids.remove(r.id)
-            for author_id in ids:
-                result = self.session.query(Authors).filter(Authors.id == author_id).first()
-                authors_ordered.append(result)
+
+                author = authors_by_sort.get(auth)
+                if author is None:
+                    log.warning(
+                        "Author sort '%s' of book %s not found in linked authors, skipping in sort order",
+                        auth,
+                        getattr(book, 'id', 'unknown')
+                    )
+                    continue
+
+                authors_ordered.append(author)
+                ids_remaining.discard(author.id)
+
+            for author_id in ids_remaining:
+                authors_ordered.append(authors_by_id[author_id])
+
+            if not authors_ordered:
+                authors_ordered = authors_list
 
             if list_return:
                 if combined:

--- a/tests/unit/test_order_authors.py
+++ b/tests/unit/test_order_authors.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from types import SimpleNamespace
+
+from cps.db import CalibreDB
+
+
+class FakeCalibreDB:
+    def ensure_session(self):
+        pass
+
+
+def author(author_id, name, sort):
+    return SimpleNamespace(id=author_id, name=name, sort=sort)
+
+
+def test_order_authors_uses_linked_authors_without_querying_database():
+    first = author(1, "Jane Alpha", "Alpha, Jane")
+    second = author(2, "Bob Beta", "Beta, Bob")
+    book = SimpleNamespace(
+        id=10,
+        author_sort="Beta, Bob & Alpha, Jane",
+        authors=[first, second],
+    )
+
+    result = CalibreDB.order_authors(FakeCalibreDB(), [book], list_return=False)
+
+    assert result == [second, first]
+
+
+def test_order_authors_tolerates_stale_author_sort_and_none_authors():
+    linked = author(1, "Jane Alpha", "Alpha, Jane")
+    book = SimpleNamespace(
+        id=11,
+        author_sort="Missing, Author & Alpha, Jane",
+        authors=[None, linked],
+    )
+
+    entries = CalibreDB.order_authors(FakeCalibreDB(), [book], list_return=True)
+
+    assert entries == [book]
+    assert book.ordered_authors == [linked]
+
+
+def test_order_authors_falls_back_to_linked_authors_when_sort_is_missing():
+    linked = author(1, "Jane Alpha", "Alpha, Jane")
+    book = SimpleNamespace(
+        id=12,
+        author_sort=None,
+        authors=[linked],
+    )
+
+    entries = CalibreDB.order_authors(FakeCalibreDB(), [book], list_return=True)
+
+    assert entries == [book]
+    assert book.ordered_authors == [linked]


### PR DESCRIPTION
## Summary

This hardens book-list author ordering so rendering does not crash when author metadata is stale, partial, or transiently inconsistent during ingest.

The existing `order_authors()` path re-queries `Authors` by `Books.author_sort` while rendering, then assumes every returned/fallback author object is valid. A downstream user reported a crash in this path while importing books in Calibre-Web-NextGen, which appears to inherit the same implementation from CWA.

Fixes #1358.

## Changes

- Orders authors using the already-linked `book.authors` collection instead of issuing extra render-time author queries.
- Handles missing/empty `author_sort`, stale sort values, missing author sort keys, and `None` author entries without raising.
- Falls back to the linked authors when sort reconstruction cannot produce an ordered list.
- Adds unit coverage for normal ordering, stale `author_sort`, `None` author entries, and missing `author_sort`.

## Notes

Current Calibre-Web uses the same general dictionary-based approach for this method. This PR intentionally keeps the change scoped to `order_authors()` and does not backport broader search/FTS changes.

Related downstream report:

- https://github.com/new-usemame/Calibre-Web-NextGen/issues/234

## Testing

```bash
pytest tests/unit/test_order_authors.py -q
```
