### PR TITLE
fix(kobo): preserve 0.0 progress on bookmark response

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1096,9 +1096,9 @@ def get_current_bookmark_response(current_bookmark):
     resp = {
         "LastModified": convert_to_kobo_timestamp_string(current_bookmark.last_modified),
     }
-    if current_bookmark.progress_percent:
+    if current_bookmark.progress_percent is not None:
         resp["ProgressPercent"] = current_bookmark.progress_percent
-    if current_bookmark.content_source_progress_percent:
+    if current_bookmark.content_source_progress_percent is not None:
         resp["ContentSourceProgressPercent"] = current_bookmark.content_source_progress_percent
     if current_bookmark.location_value:
         resp["Location"] = {


### PR DESCRIPTION
## Summary

`get_current_bookmark_response` uses a truthy check on `progress_percent`:

```python
if current_bookmark.progress_percent:
    resp["ProgressPercent"] = current_bookmark.progress_percent
```

A legitimate `0.0` (book opened, no progress yet) is falsy in Python, so the field is silently dropped from the JSON response. Kobo clients that receive a response without `ProgressPercent` can't distinguish "I'm at 0%" from "the server doesn't know about this book yet" — multi-device handoff loses state for freshly-opened books.

## Fix

Use `is not None` instead of truthy for both `progress_percent` and `content_source_progress_percent`. This matches upstream `janeczku/calibre-web`'s behavior and faithfully round-trips the stored value to clients.

## Compatibility

- No schema changes
- No new fields in the response
- The only visible difference is `ProgressPercent` / `ContentSourceProgressPercent` now appears for books with stored `0.0` instead of being omitted

## Test plan

- [x] Open a fresh book on a Kobo, sync → `kobo_bookmark.progress_percent = 0.0` stored
- [x] GET `/v1/library/<uuid>/state` for that book — response now includes `"ProgressPercent": 0.0` (previously the key was missing)
- [x] Existing bookmarks with `> 0.0` progress unchanged

## Note

Two-of-two bookmark fixes split from the same internal branch. The companion PR (device_id tracking) is also being opened separately so it can be reviewed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)