### PR TITLE
feat(kobo): track device_id + device_model on bookmarks for multi-device sync

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -945,6 +945,7 @@ def HandleStateRequest(book_uuid):
                 current_bookmark = kobo_reading_state.current_bookmark
                 current_bookmark.progress_percent = request_bookmark["ProgressPercent"]
                 current_bookmark.content_source_progress_percent = request_bookmark["ContentSourceProgressPercent"]
+                current_bookmark.device_id = request.headers.get('x-kobo-deviceid')
                 location = request_bookmark["Location"]
                 if location:
                     current_bookmark.location_value = location["Value"]
@@ -1106,6 +1107,8 @@ def get_current_bookmark_response(current_bookmark):
             "Type": current_bookmark.location_type,
             "Source": current_bookmark.location_source,
         }
+    if current_bookmark.device_id is not None:
+        resp["DeviceId"] = current_bookmark.device_id
     return resp
 
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -946,6 +946,7 @@ def HandleStateRequest(book_uuid):
                 current_bookmark.progress_percent = request_bookmark["ProgressPercent"]
                 current_bookmark.content_source_progress_percent = request_bookmark["ContentSourceProgressPercent"]
                 current_bookmark.device_id = request.headers.get('x-kobo-deviceid')
+                current_bookmark.device_model = request.headers.get('x-kobo-devicemodel')
                 location = request_bookmark["Location"]
                 if location:
                     current_bookmark.location_value = location["Value"]
@@ -1109,6 +1110,8 @@ def get_current_bookmark_response(current_bookmark):
         }
     if current_bookmark.device_id is not None:
         resp["DeviceId"] = current_bookmark.device_id
+    if current_bookmark.device_model is not None:
+        resp["DeviceModel"] = current_bookmark.device_model
     return resp
 
 

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -602,6 +602,7 @@ class KoboBookmark(Base):
     location_value = Column(String)
     progress_percent = Column(Float)
     content_source_progress_percent = Column(Float)
+    device_id = Column(String)
 
 
 class KoboStatistics(Base):
@@ -1037,6 +1038,16 @@ def migrate_magic_shelf_table(engine, _session):
         _run_ddl_with_retry(engine, "ALTER TABLE magic_shelf ADD column 'kobo_sync' Boolean DEFAULT 0")
 
 
+def migrate_kobo_bookmark_table(engine, _session):
+    """Migrate kobo_bookmark table to add device_id column for multi-device sync."""
+    try:
+        _session.query(exists().where(KoboBookmark.device_id)).scalar()
+        _session.commit()
+    except exc.OperationalError:
+        _safe_session_rollback(_session, "kobo_bookmark.device_id")
+        _run_ddl_with_retry(engine, "ALTER TABLE kobo_bookmark ADD column 'device_id' String")
+
+
 # Migrate database to current version, has to be updated after every database change. Currently migration from
 # maybe 4/5 versions back to current should work.
 # Migration is done by checking if relevant columns are existing, and then adding rows with SQL commands
@@ -1049,6 +1060,7 @@ def migrate_Database(_session):
     migrate_oauth_provider_table(engine, _session)
     migrate_config_table(engine, _session)
     migrate_magic_shelf_table(engine, _session)
+    migrate_kobo_bookmark_table(engine, _session)
 
     # Ensure progress syncing tables in app.db (user-related tables)
     from .progress_syncing.models import ensure_app_db_tables

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -603,6 +603,7 @@ class KoboBookmark(Base):
     progress_percent = Column(Float)
     content_source_progress_percent = Column(Float)
     device_id = Column(String)
+    device_model = Column(String)
 
 
 class KoboStatistics(Base):
@@ -1039,13 +1040,19 @@ def migrate_magic_shelf_table(engine, _session):
 
 
 def migrate_kobo_bookmark_table(engine, _session):
-    """Migrate kobo_bookmark table to add device_id column for multi-device sync."""
+    """Migrate kobo_bookmark table to add device_id and device_model columns for multi-device sync."""
     try:
         _session.query(exists().where(KoboBookmark.device_id)).scalar()
         _session.commit()
     except exc.OperationalError:
         _safe_session_rollback(_session, "kobo_bookmark.device_id")
         _run_ddl_with_retry(engine, "ALTER TABLE kobo_bookmark ADD column 'device_id' String")
+    try:
+        _session.query(exists().where(KoboBookmark.device_model)).scalar()
+        _session.commit()
+    except exc.OperationalError:
+        _safe_session_rollback(_session, "kobo_bookmark.device_model")
+        _run_ddl_with_retry(engine, "ALTER TABLE kobo_bookmark ADD column 'device_model' String")
 
 
 # Migrate database to current version, has to be updated after every database change. Currently migration from


### PR DESCRIPTION
## Summary

Real Kobo devices already send two device-identifying headers on every PUT to `/v1/library/<uuid>/state` that CWA currently discards:

- `x-kobo-deviceid` — opaque per-device identifier (64-char hex on Kobo eReaders; clients like the Kobo iOS app and third-party Kobo-protocol clients may send a UUID instead)
- `x-kobo-devicemodel` — human-readable model name (e.g. `Kobo Libra Colour`)

Capturing both on bookmark writes lets multi-device clients show *who wrote it* with a readable label, not just an opaque ID. Useful for the "you're reading this on Kobo Libra Colour" attribution in cross-device "continue reading" UX, and groundwork for smarter conflict resolution.

## Changes

- **Schema:** two new nullable columns on `KoboBookmark`:
  - `device_id String`
  - `device_model String`
- **Migration:** idempotent `migrate_kobo_bookmark_table` follows the existing `migrate_*_table` pattern in `ub.py` — independent `exists()` probes for each column, so a partial migration from an earlier version of this branch upgrades cleanly.
- **Write path:** `HandleStateRequest` reads both headers on PUT and stores them on the current bookmark. Absence yields `None` and the column stays NULL.
- **Read path:** `get_current_bookmark_response` emits `DeviceId` and `DeviceModel` only when non-null, so legacy NULL rows don't leak empty keys into the response.

## Compatibility

- **Existing rows:** both columns are NULL until the next write. Response omits the new keys for those rows — old client behavior preserved.
- **Old clients:** ignore unknown response keys (the Kobo JSON parser is tolerant), so adding `DeviceId` / `DeviceModel` doesn't break anything.
- **Headers absent on the request:** captured as `None`, stored as NULL — same as legacy rows.

## Test plan

- [x] Fresh install: columns created on first boot via migration.
- [x] Existing install (with prior `kobo_bookmark` data): migration adds both columns, existing rows surface `NULL` for both.
- [x] Real Kobo Libra Colour write: captured headers were `x-kobo-deviceid: af1fbd73…d752e8` and `x-kobo-devicemodel: Kobo Libra Colour` (verified via temporary header-logging build); both stored correctly.
- [x] GET bookmark for unwritten book: response omits `DeviceId` and `DeviceModel`.
- [x] Custom (non-Kobo-firmware) iOS client that also sends both headers: tracked correctly, distinct from Kobo's identifiers.

## Why both columns

`device_id` alone is sufficient for *identity* but always opaque. `device_model` alone is *readable* but not unique (two devices of the same model collide). Storing both keeps the unique identity for write-source tracking *and* gives the client something to display without needing a separate UUID-to-name mapping.

## Note

One-of-two bookmark fixes split from the same internal branch. The companion PR (#1362) preserves `0.0` progress in the bookmark response — independent fix, reviewable separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)