### PR TITLE
Fix Kobo sync in fully-local mode (no Kobo account) on modern firmware

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1304,6 +1304,35 @@ def HandleOauthRequest(subpath=None):
     return make_calibre_web_oauth_response()
 
 
+@kobo.route("/oauth/.well-known/openid-configuration", methods=["GET"])
+@requires_kobo_auth
+def HandleOauthDiscovery():
+    # Recent Kobo firmware performs OpenID Connect discovery against oauth_host
+    # before refreshing an expired access token. When Kobo Store proxying is
+    # disabled CWA hosts the OAuth endpoints itself (see HandleInitRequest ->
+    # oauth_host), so it must advertise them here. Without a token_endpoint the
+    # device requests "a new token from ''", raises a web request error and
+    # cancels the whole sync queue (SyncLibraryCommand included), so
+    # /v1/library/sync is never reached and the device reports "Sync failed".
+    oauth_url = url_for("kobo.HandleOauthRequest",
+                        auth_token=get_auth_token(), _external=True)
+    issuer = oauth_url.rsplit("/oauth", 1)[0] + "/oauth"
+    return make_response(jsonify({
+        "issuer": issuer,
+        "authorization_endpoint": issuer + "/auth",
+        "token_endpoint": issuer + "/token",
+        "userinfo_endpoint": issuer + "/userinfo",
+        "jwks_uri": issuer + "/jwks",
+        "response_types_supported": ["code", "token"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "scopes_supported": ["openid", "offline_access"],
+        "token_endpoint_auth_methods_supported":
+            ["client_secret_post", "client_secret_basic", "none"],
+    }))
+
+
 @kobo.route("/v1/initialization")
 @requires_kobo_auth
 def HandleInitRequest():

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1333,6 +1333,28 @@ def HandleOauthDiscovery():
     }))
 
 
+@kobo.before_app_request
+def _kobo_reading_services_stub():
+    # Kobo firmware treats reading_services_host as scheme+host only: it strips
+    # any path and calls these endpoints at the SITE ROOT (e.g.
+    # https://host/api/UserStorage/Metadata). In fully-local mode (no Kobo
+    # account, so CWA issues a dummy token) those calls would 401 against CWA,
+    # which the device turns into a web request error and uses to abort the sync
+    # batch (notebooks -> SyncNotebookCommand), so nothing -- not even shelves --
+    # commits. Return benign empty responses so the sync completes. Only the Kobo
+    # reading-services paths are matched; every other request falls through.
+    p = request.path
+    if p == "/api/v3/content/checkforchanges":
+        return make_response(jsonify([]))
+    if p.startswith("/api/v3/content/") and p.endswith("/annotations"):
+        return make_response(jsonify({"data": [], "totalResults": 0}))
+    if p.startswith("/api/UserStorage/"):
+        return make_response(jsonify({}))
+    if p.startswith("/api/internal/notebooks"):
+        return make_response(jsonify({"data": [], "totalResults": 0}))
+    return None
+
+
 @kobo.route("/v1/initialization")
 @requires_kobo_auth
 def HandleInitRequest():
@@ -1425,6 +1447,11 @@ def HandleInitRequest():
                                   auth_token=kobo_auth.get_auth_token(),
                                   _external=True)
         kobo_resources["oauth_host"] = oauth_token_url.rsplit("/oauth", 1)[0] + "/oauth"
+        # Device strips reading_services_host to scheme+host; keep it on CWA so its
+        # reading-services calls hit us (see _kobo_reading_services_stub) instead of
+        # Kobo cloud, which 401s our dummy token and aborts the sync.
+        if not (config.config_hardcover_annotations_sync and bool(hardcover)):
+            kobo_resources["reading_services_host"] = url_for("web.index", _external=True).strip("/")
 
     response = make_response(jsonify({"Resources": kobo_resources}))
     response.headers["x-kobo-apitoken"] = "e30="


### PR DESCRIPTION
## Summary

On a fully-local setup (Kobo Store proxying **off**, no real Kobo account), Kobo
sync silently fails on current firmware (reproduced on **4.45.23684**). The web
UI works and `curl`-ing the sync endpoints directly returns 200, but pressing
**Sync** on the device reports **"Sync failed"** and no books/collections appear.

Two independent causes, both only triggered once the device's 1-hour access
token expires (so it can look like it "just stopped working" without any config
change):

### 1. OAuth token refresh can't discover the token endpoint
When proxying is off, CWA points `oauth_host` at itself but `HandleOauthRequest`
returns a *dummy token* for **every** `/oauth/*` path — including
`/oauth/.well-known/openid-configuration`. Modern firmware does OIDC discovery
there before refreshing an expired token; with no `token_endpoint` it logs:

```
oauth.debug  access token expired -- refreshing now
OAuthDiscoveryCommand::execute()
requestNewToken(...) requesting a new token from ""      <- empty
QDebugSyncErrorFilter::applyFilter "WebRequestErr"
QueuedSyncCommand::cancel() ... SyncLibraryCommand        <- whole queue cancelled
```

So `/v1/library/sync` is never even called. (This is why direct `curl` works —
it carries the path token and skips the OAuth gate the device runs first.)

**Fix:** serve a minimal OIDC discovery document whose `token_endpoint` points at
the `/oauth/token` route CWA already implements.

### 2. Cloud reading-services 401 aborts the whole sync
With local OAuth, the device authenticates its **direct** calls to Kobo's cloud
reading-services with CWA's dummy token and gets 401s:

```
"https://<host>/api/UserStorage/Metadata" => "Host requires authentication" (401)
QueuedSyncCommand::cancel() ... SyncNotebookCommand
applyFilter "WebRequestErr"  -> finished sync client    (Sync failed)
```

Kobo sync is transactional, so this aborts the batch and even shelves never
commit. Note the device treats `reading_services_host` as **scheme+host only** —
it strips the path and calls `/api/...` at the site root.

**Fix:** point `reading_services_host` at CWA and add a `before_app_request` hook
returning benign empty responses for the reading-services paths
(`/api/v3/content/checkforchanges`, `/api/v3/content/<uuid>/annotations`,
`/api/UserStorage/*`, `/api/internal/notebooks`). Gated to non-Hardcover setups.

## Result
Device log after the fixes: `SyncLibraryCommand finished` → `finished sync client`
with no `WebRequestErr`; the device reports **"Sync complete"** and books +
collections sync.

## Notes / out of scope
- Reproduced on CWA v4.0.6; `main` has the same code paths.
- Verified end-to-end against a real Kobo (Clara HD, fw 4.45.23684).
- Separately, failed syncs still record books in `kobo_synced_books` (via
  `add_synced_books` during response generation) even though the device discards
  the aborted batch, so they're permanently excluded from `NewEntitlement`. Once
  sync succeeds this no longer accumulates; existing stale rows need a one-time
  `kobo_synced_books` clear (force full re-sync). Could be hardened separately by
  only recording synced books on a committed sync.
