### PR TITLE
feat(cwasync): ui: ensure plugin menu shows up under "tools"

### DIFF
--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -203,6 +203,7 @@ end
 function CWASync:addToMainMenu(menu_items)
     menu_items.cwa_progress_sync = {
         text = _("CWA Progress Sync"),
+        sorting_hint = "tools",
         sub_item_table = {
             {
                 text = _("Set CWA Server"),


### PR DESCRIPTION
Without a `sorting_hint` items added to the main menu are "orphaned", i.e. put into the "navi" menu with a "NEW: " prefix. But plugin menus are typically found in the "tools" menu, and this is where most users will expect to find the "CWASync Progress Sync" menu.

- c.f. https://github.com/koreader/koreader/blob/7b4b759678ac0f62e1be825fb9e9fafa9f7aed54/frontend/ui/menusorter.lua#L15
- c.f. https://github.com/koreader/koreader/blob/7b4b759678ac0f62e1be825fb9e9fafa9f7aed54/frontend/ui/elements/filemanager_menu_order.lua
- c.f. https://github.com/koreader/koreader/blob/7b4b759678ac0f62e1be825fb9e9fafa9f7aed54/frontend/ui/elements/reader_menu_order.lua