### PR TITLE
Configurable second series field

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -80,7 +80,8 @@ app.config.update(
     REMEMBER_COOKIE_SAMESITE='Strict',
     WTF_CSRF_SSL_STRICT=False,
     SESSION_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "session",
-    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token"
+    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token",
+    TEMPLATES_AUTO_RELOAD=os.environ.get('DEVELOP_ON', 'False').lower() == 'true',
 )
 
 # Fix for running behind reverse proxy (e.g. nginx, apache, caddy, ...)

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -199,7 +199,7 @@ def before_request():
     g.config_authors_max = config.config_authors_max
     g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
     g.config_series2_label = config.config_series2_label
-    g.series2_key = (config.config_series2_slug or '').strip() or 'series2'
+    g.series2_key = (config.config_series2_slug or config.config_series2_label or '').strip() or 'series2'
     if '/static/' not in request.path and not config.db_configured and \
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -48,6 +48,56 @@ from .string_helper import strip_whitespaces
 
 log = logger.create()
 
+_SERIES2_ICON_NAMES = [
+    'adjust', 'alert', 'align-center', 'align-justify', 'align-left', 'align-right',
+    'apple', 'arrow-down', 'arrow-left', 'arrow-right', 'arrow-up', 'asterisk',
+    'baby-formula', 'backward', 'ban-circle', 'barcode', 'bed', 'bell', 'bishop',
+    'bitcoin', 'blackboard', 'bold', 'book', 'bookmark', 'briefcase', 'btc',
+    'bullhorn', 'calendar', 'camera', 'cd', 'certificate', 'check', 'chevron-down',
+    'chevron-left', 'chevron-right', 'chevron-up', 'circle-arrow-down',
+    'circle-arrow-left', 'circle-arrow-right', 'circle-arrow-up', 'cloud',
+    'cloud-download', 'cloud-upload', 'cog', 'collapse-down', 'collapse-up',
+    'comment', 'compressed', 'console', 'copy', 'copyright-mark', 'credit-card',
+    'cutlery', 'dashboard', 'download', 'download-alt', 'duplicate', 'earphone',
+    'edit', 'education', 'eject', 'envelope', 'equalizer', 'erase', 'eur', 'euro',
+    'exclamation-sign', 'expand', 'export', 'eye-close', 'eye-open', 'facetime-video',
+    'fast-backward', 'fast-forward', 'file', 'film', 'filter', 'fire', 'flag',
+    'flash', 'floppy-disk', 'floppy-open', 'floppy-remove', 'floppy-save',
+    'floppy-saved', 'folder-close', 'folder-open', 'font', 'forward', 'fullscreen',
+    'gbp', 'gift', 'glass', 'globe', 'grain', 'hand-down', 'hand-left', 'hand-right',
+    'hand-up', 'hdd', 'hd-video', 'header', 'headphones', 'heart', 'heart-empty',
+    'home', 'hourglass', 'ice-lolly', 'ice-lolly-tasted', 'import', 'inbox',
+    'indent-left', 'indent-right', 'info-sign', 'italic', 'jpy', 'king', 'knight',
+    'lamp', 'leaf', 'level-up', 'link', 'list', 'list-alt', 'lock', 'log-in',
+    'log-out', 'magnet', 'map-marker', 'menu-down', 'menu-hamburger', 'menu-left',
+    'menu-right', 'menu-up', 'minus', 'minus-sign', 'modal-window', 'move', 'music',
+    'new-window', 'object-align-bottom', 'object-align-horizontal', 'object-align-left',
+    'object-align-right', 'object-align-top', 'object-align-vertical', 'off', 'oil',
+    'ok', 'ok-circle', 'ok-sign', 'open', 'open-file', 'option-horizontal',
+    'option-vertical', 'paperclip', 'paste', 'pause', 'pawn', 'pencil', 'phone',
+    'phone-alt', 'picture', 'piggy-bank', 'plane', 'play', 'play-circle', 'plus',
+    'plus-sign', 'print', 'pushpin', 'qrcode', 'queen', 'question-sign', 'random',
+    'record', 'refresh', 'registration-mark', 'remove', 'remove-circle', 'remove-sign',
+    'repeat', 'resize-full', 'resize-horizontal', 'resize-small', 'resize-vertical',
+    'retweet', 'road', 'rub', 'ruble', 'save', 'saved', 'save-file', 'scale',
+    'scissors', 'screenshot', 'sd-video', 'search', 'send', 'share', 'share-alt',
+    'shopping-cart', 'signal', 'sort', 'sort-by-alphabet', 'sort-by-alphabet-alt',
+    'sort-by-attributes', 'sort-by-attributes-alt', 'sort-by-order', 'sort-by-order-alt',
+    'sound-5-1', 'sound-6-1', 'sound-7-1', 'sound-dolby', 'sound-stereo', 'star',
+    'star-empty', 'stats', 'step-backward', 'step-forward', 'stop', 'subscript',
+    'subtitles', 'sunglasses', 'superscript', 'tag', 'tags', 'tasks', 'tent',
+    'text-background', 'text-color', 'text-height', 'text-size', 'text-width', 'th',
+    'th-large', 'th-list', 'thumbs-down', 'thumbs-up', 'time', 'tint', 'tower',
+    'transfer', 'trash', 'tree-conifer', 'tree-deciduous', 'triangle-bottom',
+    'triangle-left', 'triangle-right', 'triangle-top', 'unchecked', 'upload', 'usd',
+    'user', 'volume-down', 'volume-off', 'volume-up', 'warning-sign', 'wrench', 'xbt',
+    'yen', 'zoom-in', 'zoom-out',
+]
+SERIES2_ICON_OPTIONS = [
+    ('glyphicon-' + n, ' '.join(w.capitalize() for w in n.split('-')))
+    for n in _SERIES2_ICON_NAMES
+]
+
 feature_support = {
     'ldap': bool(services.ldap),
     'goodreads': bool(services.goodreads_support),
@@ -596,6 +646,7 @@ def view_configuration():
     return render_title_template("config_view_edit.html", conf=config, readColumns=read_column,
                                  restrictColumns=restrict_columns,
                                  series2Columns=series2_columns,
+                                 series2Icons=SERIES2_ICON_OPTIONS,
                                  languages=languages,
                                  translations=translations,
                                  title=_("UI Configuration"), page="uiconfig")
@@ -901,6 +952,7 @@ def update_view_configuration():
         return view_configuration()
     _config_int(to_save, "config_series2_column")
     _config_string(to_save, "config_series2_label")
+    _config_string(to_save, "config_series2_icon")
     _config_checkbox(to_save, "config_show_series2_on_book_list")
 
     if not check_valid_restricted_column(to_save.get("config_restricted_column", "0")):

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -199,6 +199,7 @@ def before_request():
     g.config_authors_max = config.config_authors_max
     g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
     g.config_series2_label = config.config_series2_label
+    g.series2_key = (config.config_series2_slug or '').strip() or 'series2'
     if '/static/' not in request.path and not config.db_configured and \
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',
@@ -952,6 +953,7 @@ def update_view_configuration():
         return view_configuration()
     _config_int(to_save, "config_series2_column")
     _config_string(to_save, "config_series2_label")
+    _config_string(to_save, "config_series2_slug")
     _config_string(to_save, "config_series2_icon")
     _config_checkbox(to_save, "config_show_series2_on_book_list")
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -587,10 +587,13 @@ def view_configuration():
         .filter(and_(db.CustomColumns.datatype == 'bool', db.CustomColumns.mark_for_delete == 0)).all()
     restrict_columns = calibre_db.session.query(db.CustomColumns) \
         .filter(and_(db.CustomColumns.datatype == 'text', db.CustomColumns.mark_for_delete == 0)).all()
+    series2_columns = calibre_db.session.query(db.CustomColumns) \
+        .filter(and_(db.CustomColumns.datatype == 'series', db.CustomColumns.mark_for_delete == 0)).all()
     languages = calibre_db.speaking_language()
     translations = get_available_locale()
     return render_title_template("config_view_edit.html", conf=config, readColumns=read_column,
                                  restrictColumns=restrict_columns,
+                                 series2Columns=series2_columns,
                                  languages=languages,
                                  translations=translations,
                                  title=_("UI Configuration"), page="uiconfig")
@@ -889,6 +892,13 @@ def update_view_configuration():
         log.debug("Invalid Read column")
         return view_configuration()
     _config_int(to_save, "config_read_column")
+
+    if not check_valid_series2_column(to_save.get("config_series2_column", "0")):
+        flash(_("Invalid Second Series Column"), category="error")
+        log.debug("Invalid Series2 column")
+        return view_configuration()
+    _config_int(to_save, "config_series2_column")
+    _config_string(to_save, "config_series2_label")
 
     if not check_valid_restricted_column(to_save.get("config_restricted_column", "0")):
         flash(_("Invalid Restricted Column"), category="error")
@@ -1258,6 +1268,14 @@ def check_valid_read_column(column):
     if column != "0":
         if not calibre_db.session.query(db.CustomColumns).filter(db.CustomColumns.id == column) \
           .filter(and_(db.CustomColumns.datatype == 'bool', db.CustomColumns.mark_for_delete == 0)).all():
+            return False
+    return True
+
+
+def check_valid_series2_column(column):
+    if column != "0":
+        if not calibre_db.session.query(db.CustomColumns).filter(db.CustomColumns.id == column) \
+          .filter(and_(db.CustomColumns.datatype == 'series', db.CustomColumns.mark_for_delete == 0)).all():
             return False
     return True
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -147,6 +147,8 @@ def before_request():
         g.current_theme = getattr(config, 'config_theme', 1)
     g.current_theme = 1
     g.config_authors_max = config.config_authors_max
+    g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
+    g.config_series2_label = config.config_series2_label
     if '/static/' not in request.path and not config.db_configured and \
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',
@@ -899,6 +901,7 @@ def update_view_configuration():
         return view_configuration()
     _config_int(to_save, "config_series2_column")
     _config_string(to_save, "config_series2_label")
+    _config_checkbox(to_save, "config_show_series2_on_book_list")
 
     if not check_valid_restricted_column(to_save.get("config_restricted_column", "0")):
         flash(_("Invalid Restricted Column"), category="error")

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -35,6 +35,7 @@ from sqlalchemy.sql.expression import func, or_, text
 from . import constants, logger, helper, services, cli_param
 from . import db, calibre_db, ub, web_server, config, updater_thread, gdriveutils, \
     kobo_sync_status, schedule
+from .web import _s2_key
 from .helper import check_valid_domain, send_test_mail, reset_password, generate_password_hash, check_email, \
     valid_email, check_username
 from .embed_helper import get_calibre_binarypath
@@ -199,7 +200,7 @@ def before_request():
     g.config_authors_max = config.config_authors_max
     g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
     g.config_series2_label = config.config_series2_label
-    g.series2_key = (config.config_series2_slug or config.config_series2_label or '').strip() or 'series2'
+    g.series2_key = _s2_key
     if '/static/' not in request.path and not config.db_configured and \
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -71,6 +71,8 @@ class _Settings(_Base):
     config_random_books = Column(Integer, default=4)
     config_authors_max = Column(Integer, default=0)
     config_read_column = Column(Integer, default=0)
+    config_series2_column = Column(Integer, default=0)
+    config_series2_label = Column(String, default='')
     config_title_regex = Column(String,
                                 default=r'^(A|The|An|Der|Die|Das|Den|Ein|Eine'
                                         r'|Einen|Dem|Des|Einem|Eines|Le|La|Les|L\'|Un|Une)\s+')

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -73,6 +73,7 @@ class _Settings(_Base):
     config_read_column = Column(Integer, default=0)
     config_series2_column = Column(Integer, default=0)
     config_series2_label = Column(String, default='')
+    config_series2_icon = Column(String, default='glyphicon-bookmark')
     config_show_series2_on_book_list = Column(Boolean, default=True)
     config_title_regex = Column(String,
                                 default=r'^(A|The|An|Der|Die|Das|Den|Ein|Eine'

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -73,6 +73,7 @@ class _Settings(_Base):
     config_read_column = Column(Integer, default=0)
     config_series2_column = Column(Integer, default=0)
     config_series2_label = Column(String, default='')
+    config_series2_slug = Column(String, default='series2')
     config_series2_icon = Column(String, default='glyphicon-bookmark')
     config_show_series2_on_book_list = Column(Boolean, default=True)
     config_title_regex = Column(String,

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -73,6 +73,7 @@ class _Settings(_Base):
     config_read_column = Column(Integer, default=0)
     config_series2_column = Column(Integer, default=0)
     config_series2_label = Column(String, default='')
+    config_show_series2_on_book_list = Column(Boolean, default=True)
     config_title_regex = Column(String,
                                 default=r'^(A|The|An|Der|Die|Das|Den|Ein|Eine'
                                         r'|Einen|Dem|Des|Einem|Eines|Le|La|Les|L\'|Un|Une)\s+')

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -89,6 +89,7 @@ SIDEBAR_ARCHIVED        = 1 << 15
 SIDEBAR_DOWNLOAD        = 1 << 16
 SIDEBAR_LIST            = 1 << 17
 SIDEBAR_DUPLICATES      = 1 << 18
+SIDEBAR_SERIES2         = 1 << 19
 
 sidebar_settings = {
                 "detail_random": DETAIL_RANDOM,
@@ -108,11 +109,12 @@ sidebar_settings = {
                 "sidebar_download": SIDEBAR_DOWNLOAD,
                 "sidebar_list": SIDEBAR_LIST,
                 "sidebar_duplicates": SIDEBAR_DUPLICATES,
+                "sidebar_series2": SIDEBAR_SERIES2,
             }
 
 
 ADMIN_USER_ROLES        = sum(r for r in ALL_ROLES.values()) & ~ROLE_ANONYMOUS
-ADMIN_USER_SIDEBAR      = (SIDEBAR_DUPLICATES << 1) - 1
+ADMIN_USER_SIDEBAR      = (SIDEBAR_SERIES2 << 1) - 1
 
 UPDATE_STABLE       = 0 << 0
 AUTO_UPDATE_STABLE  = 1 << 0

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -89,7 +89,6 @@ SIDEBAR_ARCHIVED        = 1 << 15
 SIDEBAR_DOWNLOAD        = 1 << 16
 SIDEBAR_LIST            = 1 << 17
 SIDEBAR_DUPLICATES      = 1 << 18
-SIDEBAR_SERIES2         = 1 << 19
 
 sidebar_settings = {
                 "detail_random": DETAIL_RANDOM,
@@ -109,12 +108,11 @@ sidebar_settings = {
                 "sidebar_download": SIDEBAR_DOWNLOAD,
                 "sidebar_list": SIDEBAR_LIST,
                 "sidebar_duplicates": SIDEBAR_DUPLICATES,
-                "sidebar_series2": SIDEBAR_SERIES2,
             }
 
 
 ADMIN_USER_ROLES        = sum(r for r in ALL_ROLES.values()) & ~ROLE_ANONYMOUS
-ADMIN_USER_SIDEBAR      = (SIDEBAR_SERIES2 << 1) - 1
+ADMIN_USER_SIDEBAR      = (SIDEBAR_DUPLICATES << 1) - 1
 
 UPDATE_STABLE       = 0 << 0
 AUTO_UPDATE_STABLE  = 1 << 0

--- a/cps/db.py
+++ b/cps/db.py
@@ -94,9 +94,10 @@ def setup_series2_classes(cc_id):
     }
     series2_link_class = type(str(link_table_name), (Base,), dicttable)
 
-    # Attach series2 relationship to Books
-    if not hasattr(Books, 'series2'):
-        setattr(Books, 'series2', relationship(series2_link_class))
+    # Attach series2 relationship to Books, overriding the [] placeholder
+    setattr(Books, 'series2', relationship(series2_link_class))
+    log.debug("setup_series2_classes: cc_id=%s, cc_class=%s, link_class=%s",
+              cc_id, series2_cc_class, series2_link_class)
 
 books_authors_link = Table('books_authors_link', Base.metadata,
                            Column('book', Integer, ForeignKey('books.id'), primary_key=True),

--- a/cps/db.py
+++ b/cps/db.py
@@ -47,7 +47,56 @@ log = logger.create()
 cc_exceptions = ['composite', 'series']
 cc_classes = {}
 
+# Set by setup_series2_classes(); used by web routes and templates
+series2_cc_class = None
+series2_link_class = None
+
 Base = declarative_base()
+
+
+def setup_series2_classes(cc_id):
+    """Create ORM classes for the configured series2 custom column and attach
+    a Books.series2 relationship, mirroring setup_db_cc_classes for series type."""
+    global series2_cc_class, series2_link_class
+
+    if not cc_id:
+        return
+
+    cc_table_name = 'custom_column_' + str(cc_id)
+    link_table_name = 'books_custom_column_' + str(cc_id) + '_link'
+
+    # Build the value table class (custom_column_<id>)
+    if cc_table_name in Base.metadata.tables:
+        existing = cc_classes.get(cc_id)
+        if existing is None:
+            return
+        series2_cc_class = existing
+    else:
+        ccdict = {'__tablename__': cc_table_name,
+                  'id': Column(Integer, primary_key=True),
+                  'value': Column(String)}
+        series2_cc_class = type(str(cc_table_name), (Base,), ccdict)
+        cc_classes[cc_id] = series2_cc_class
+
+    # Build the link table class (books_custom_column_<id>_link)
+    if link_table_name in Base.metadata.tables:
+        return
+    dicttable = {
+        '__tablename__': link_table_name,
+        'id': Column(Integer, primary_key=True),
+        'book': Column(Integer, ForeignKey('books.id'), primary_key=True),
+        'map_value': Column('value', Integer,
+                            ForeignKey(cc_table_name + '.id'),
+                            primary_key=True),
+        'extra': Column(Float),
+        'asoc': relationship(cc_table_name, uselist=False),
+        'value': association_proxy('asoc', 'value'),
+    }
+    series2_link_class = type(str(link_table_name), (Base,), dicttable)
+
+    # Attach series2 relationship to Books
+    if not hasattr(Books, 'series2'):
+        setattr(Books, 'series2', relationship(series2_link_class))
 
 books_authors_link = Table('books_authors_link', Base.metadata,
                            Column('book', Integer, ForeignKey('books.id'), primary_key=True),
@@ -409,6 +458,7 @@ class Books(Base):
     comments = relationship(Comments, backref='books')
     data = relationship(Data, backref='books')
     series = relationship(Series, secondary=books_series_link, backref='books')
+    series2 = []  # replaced by setup_series2_classes() when config_series2_column is set
     ratings = relationship(Ratings, secondary=books_ratings_link, backref='books')
     languages = relationship(Languages, secondary=books_languages_link, backref='books')
     publishers = relationship(Publishers, secondary=books_publishers_link, backref='books')
@@ -698,6 +748,10 @@ class CalibreDB:
                                      secondary=books_custom_column_links[cc_id[0]],
                                      backref='books'))
 
+        # Set up series2 custom column if configured
+        series2_col_id = getattr(cls.config, 'config_series2_column', 0)
+        if series2_col_id:
+            setup_series2_classes(series2_col_id)
         return cc_classes
 
     @classmethod

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -38,7 +38,7 @@ def get_sidebar_config(kwargs=None):
         content = 'conf' in kwargs
     sidebar = list()
     sidebar.append({"glyph": "glyphicon-book", "text": _('Books'), "link": 'web.index', "id": "new",
-                    "visibility": constants.SIDEBAR_RECENT, 'public': True, "page": "root",
+                    "visibility": constants.SIDEBAR_RECENT, 'public': True, "page": "root", "no_param": True,
                     "show_text": _('Show recent books'), "config_show":False})
     sidebar.append({"glyph": "glyphicon-fire", "text": _('Hot Books'), "link": 'web.books_list', "id": "hot",
                     "visibility": constants.SIDEBAR_HOT, 'public': True, "page": "hot",

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -75,7 +75,8 @@ def get_sidebar_config(kwargs=None):
                     "show_text": _('Show Series Section'), "config_show": True})
     if config.config_series2_column:
         series2_label = config.config_series2_label or 'World'
-        sidebar.append({"glyph": "glyphicon-bookmark", "text": series2_label, "link": 'web.series2_list',
+        series2_icon = config.config_series2_icon or 'glyphicon-bookmark'
+        sidebar.append({"glyph": series2_icon, "text": series2_label, "link": 'web.series2_list',
                         "id": "serie2", "visibility": constants.SIDEBAR_SERIES, 'public': True,
                         "page": "series2", "no_param": True,
                         "show_text": _('Show %(label)s Section', label=series2_label), "config_show": True})

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -73,6 +73,12 @@ def get_sidebar_config(kwargs=None):
     sidebar.append({"glyph": "glyphicon-bookmark", "text": _('Series'), "link": 'web.series_list', "id": "serie",
                     "visibility": constants.SIDEBAR_SERIES, 'public': True, "page": "series",
                     "show_text": _('Show Series Section'), "config_show": True})
+    if config.config_series2_column:
+        series2_label = config.config_series2_label or 'World'
+        sidebar.append({"glyph": "glyphicon-bookmark", "text": series2_label, "link": 'web.series2_list',
+                        "id": "serie2", "visibility": constants.SIDEBAR_SERIES2, 'public': True,
+                        "page": "series2", "no_param": True,
+                        "show_text": _('Show %(label)s Section', label=series2_label), "config_show": True})
     sidebar.append({"glyph": "glyphicon-user", "text": _('Authors'), "link": 'web.author_list', "id": "author",
                     "visibility": constants.SIDEBAR_AUTHOR, 'public': True, "page": "author",
                     "show_text": _('Show Author Section'), "config_show": True})

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -76,7 +76,7 @@ def get_sidebar_config(kwargs=None):
     if config.config_series2_column:
         series2_label = config.config_series2_label or 'World'
         sidebar.append({"glyph": "glyphicon-bookmark", "text": series2_label, "link": 'web.series2_list',
-                        "id": "serie2", "visibility": constants.SIDEBAR_SERIES2, 'public': True,
+                        "id": "serie2", "visibility": constants.SIDEBAR_SERIES, 'public': True,
                         "page": "series2", "no_param": True,
                         "show_text": _('Show %(label)s Section', label=series2_label), "config_show": True})
     sidebar.append({"glyph": "glyphicon-user", "text": _('Authors'), "link": 'web.author_list', "id": "author",

--- a/cps/search.py
+++ b/cps/search.py
@@ -437,6 +437,7 @@ def render_prepare_search_form(cc):
                    .all())
     return render_title_template('search_form.html', tags=tags, languages=languages, extensions=extensions,
                                  series=series, series2=series2,
+                                 series2_label=config.config_series2_label or _("Series"),
                                  shelves=shelves, title=_("Advanced Search"), cc=cc, page="advsearch")
 
 

--- a/cps/search.py
+++ b/cps/search.py
@@ -58,8 +58,9 @@ def simple_search():
 @login_required_if_no_ano
 def advanced_search():
     values = dict(request.form)
-    params = ['include_tag', 'exclude_tag', 'include_serie', 'exclude_serie', 'include_shelf', 'exclude_shelf',
-              'include_language', 'exclude_language', 'include_extension', 'exclude_extension']
+    params = ['include_tag', 'exclude_tag', 'include_serie', 'exclude_serie', 'include_serie2', 'exclude_serie2',
+              'include_shelf', 'exclude_shelf', 'include_language', 'exclude_language',
+              'include_extension', 'exclude_extension']
     for param in params:
         values[param] = list(request.form.getlist(param))
     flask_session['query'] = json.dumps(values)
@@ -180,6 +181,18 @@ def adv_search_serie(q, include_series_inputs, exclude_series_inputs):
         q = q.filter(not_(db.Books.series.any(db.Series.id == serie)))
     return q
 
+
+
+def adv_search_serie2(q, include_inputs, exclude_inputs):
+    if db.series2_link_class is None:
+        return q
+    for serie2 in include_inputs:
+        q = q.filter(db.Books.series2.any(db.series2_link_class.map_value == serie2))
+    for serie2 in exclude_inputs:
+        q = q.filter(not_(db.Books.series2.any(db.series2_link_class.map_value == serie2)))
+    return q
+
+
 def adv_search_shelf(q, include_shelf_inputs, exclude_shelf_inputs):
     q = q.outerjoin(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)\
         .filter(or_(ub.BookShelf.shelf == None, ub.BookShelf.shelf.notin_(exclude_shelf_inputs)))
@@ -256,7 +269,7 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
 
     # parse multi selects to a complete dict
     tags = dict()
-    elements = ['tag', 'serie', 'shelf', 'language', 'extension']
+    elements = ['tag', 'serie', 'serie2', 'shelf', 'language', 'extension']
     for element in elements:
         tags['include_' + element] = term.get('include_' + element)
         tags['exclude_' + element] = term.get('exclude_' + element)
@@ -338,6 +351,7 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
             q = q.filter(db.Books.publishers.any(func.lower(db.Publishers.name).ilike("%" + publisher + "%")))
         q = adv_search_tag(q, tags['include_tag'], tags['exclude_tag'])
         q = adv_search_serie(q, tags['include_serie'], tags['exclude_serie'])
+        q = adv_search_serie2(q, tags['include_serie2'], tags['exclude_serie2'])
         q = adv_search_shelf(q, tags['include_shelf'], tags['exclude_shelf'])
         q = adv_search_extension(q, tags['include_extension'], tags['exclude_extension'])
         q = adv_search_language(q, tags['include_language'], tags['exclude_language'])
@@ -412,8 +426,18 @@ def render_prepare_search_form(cc):
         languages = calibre_db.speaking_language()
     else:
         languages = None
+    series2 = []
+    if config.config_series2_column and db.series2_cc_class is not None and db.series2_link_class is not None:
+        series2 = (calibre_db.session.query(db.series2_cc_class)
+                   .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
+                   .join(db.Books, db.Books.id == db.series2_link_class.book)
+                   .filter(calibre_db.common_filters())
+                   .group_by(db.series2_link_class.map_value)
+                   .order_by(db.series2_cc_class.value)
+                   .all())
     return render_title_template('search_form.html', tags=tags, languages=languages, extensions=extensions,
-                                 series=series,shelves=shelves, title=_("Advanced Search"), cc=cc, page="advsearch")
+                                 series=series, series2=series2,
+                                 shelves=shelves, title=_("Advanced Search"), cc=cc, page="advsearch")
 
 
 def render_search_results(term, offset=None, order=None, limit=None):

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -284,6 +284,18 @@ body.blur .discover .row {
     pointer-events: none
 }
 
+.series-section {
+    margin-bottom: 10px;
+}
+
+.series-section p {
+    margin-bottom: 5px;
+}
+
+.series-section p:last-child {
+    margin-bottom: 0;
+}
+
 #scnd-nav > li.active a, .authorlist #nav_author a, .catlist #nav_cat a, .langlist #nav_lang a, .serieslist #nav_serie a {
     color: var(--color-primary)
 }

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -284,18 +284,6 @@ body.blur .discover .row {
     pointer-events: none
 }
 
-.series-section {
-    margin-bottom: 10px;
-}
-
-.series-section p {
-    margin-bottom: 5px;
-}
-
-.series-section p:last-child {
-    margin-bottom: 0;
-}
-
 #scnd-nav > li.active a, .authorlist #nav_author a, .catlist #nav_cat a, .langlist #nav_lang a, .serieslist #nav_serie a {
     color: var(--color-primary)
 }

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -783,3 +783,11 @@ select.cwa-settings-select {
   width: -webkit-fill-available;
   justify-content: space-evenly;
 }
+
+.series-section {
+    margin-bottom: 10px;
+}
+
+.series-section p {
+    margin-bottom: 5px;
+}

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -1040,6 +1040,8 @@ $(function() {
 
     $(".update-view").click(function(e) {
         var view = $(this).data("view");
+        var page = $(this).data("page") || "series";
+        var target = $(this).data("target") || "series_view";
         e.preventDefault();
         e.stopPropagation();
         $.ajax({
@@ -1047,7 +1049,7 @@ $(function() {
             contentType: "application/json; charset=utf-8",
             dataType: "json",
             url: getPath() + "/ajax/view",
-            data: "{\"series\": {\"series_view\": \""+ view +"\"}}",
+            data: "{\"" + page + "\": {\"" + target + "\": \""+ view +"\"}}",
             success: function success() {
                 location.reload();
             }

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -79,6 +79,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.Books.ratings[0].rating/2)|int(2)) %}

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -81,7 +81,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -90,10 +90,11 @@
         <select name="config_series2_column" id="config_series2_column" class="form-control" onchange="updateSeries2Label(this)">
           <option value="0" data-name="" {% if conf.config_series2_column == 0 %}selected{% endif %}></option>
           {% for series2Column in series2Columns %}
-          <option value="{{ series2Column.id }}" data-name="{{ series2Column.name }}" {% if series2Column.id == conf.config_series2_column %}selected{% endif %}>{{ series2Column.name }}</option>
+          <option value="{{ series2Column.id }}" data-name="{{ series2Column.name }}" data-label="{{ series2Column.label }}" {% if series2Column.id == conf.config_series2_column %}selected{% endif %}>{{ series2Column.name }}</option>
           {% endfor %}
         </select>
         <input type="hidden" name="config_series2_label" id="config_series2_label" value="">
+        <input type="hidden" name="config_series2_slug" id="config_series2_slug" value="">
         <div class="checkbox">
           <label>
             <input type="checkbox" name="config_show_series2_on_book_list" id="config_show_series2_on_book_list" {% if conf.config_show_series2_on_book_list %}checked{% endif %} style="accent-color: var(--color-secondary);">
@@ -255,7 +256,9 @@
 <script src="{{ url_for('static', filename='js/libs/bootstrap-select.min.js') }}"></script>
 <script>
 function updateSeries2Label(sel) {
-  document.getElementById('config_series2_label').value = sel.options[sel.selectedIndex].getAttribute('data-name') || '';
+  var opt = sel.options[sel.selectedIndex];
+  document.getElementById('config_series2_label').value = opt.getAttribute('data-name') || '';
+  document.getElementById('config_series2_slug').value = opt.getAttribute('data-label') || '';
   var group = document.getElementById('series2_icon_group');
   if (group) {
     group.hidden = (sel.value === '0' || sel.value === '');

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -2,6 +2,7 @@
 {% block header %}
 <link href="{{ url_for('static', filename='css/libs/bootstrap-table.min.css') }}" rel="stylesheet">
 <link href="{{ url_for('static', filename='css/libs/bootstrap-editable.css') }}" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/libs/bootstrap-select.min.css') }}" rel="stylesheet">
 <style>
   /* Mobile responsive styles for config_view_edit template - triggers below 768px */
   @media (max-width: 768px) {
@@ -11,11 +12,11 @@
       margin-left: 0 !important;
       margin-right: 0 !important;
     }
-    
+
     .form-control {
       font-size: 16px; /* Prevents zoom on iOS */
     }
-    
+
     /* Stack buttons vertically on mobile */
     .btn {
       display: block;
@@ -98,6 +99,18 @@
             <input type="checkbox" name="config_show_series2_on_book_list" id="config_show_series2_on_book_list" {% if conf.config_show_series2_on_book_list %}checked{% endif %} style="accent-color: var(--color-secondary);">
             {{_('Show Second Series on book list pages')}}
           </label>
+        </div>
+        {% set series2_icon = conf.config_series2_icon or 'glyphicon-bookmark' %}
+        <div id="series2_icon_group" {% if not conf.config_series2_column %}hidden{% endif %}>
+          <label for="config_series2_icon">{{_('Sidebar Icon')}}</label>
+          <select name="config_series2_icon" id="config_series2_icon"
+                  class="selectpicker" data-live-search="true" data-width="100%">
+            {% for icon_value, icon_label in series2Icons %}
+            <option value="{{ icon_value }}"
+                    data-content="<span class='glyphicon {{ icon_value }}'></span> {{ icon_label }}"
+                    {% if icon_value == series2_icon %}selected{% endif %}>{{ icon_label }}</option>
+            {% endfor %}
+          </select>
         </div>
         <p class="settings-explanation">{{_('Select a custom column of type "series" to use as a second series display.')}}</p>
       </div>
@@ -239,9 +252,14 @@
 {{ restrict_modal() }}
 {% endblock %}
 {% block js %}
+<script src="{{ url_for('static', filename='js/libs/bootstrap-select.min.js') }}"></script>
 <script>
 function updateSeries2Label(sel) {
   document.getElementById('config_series2_label').value = sel.options[sel.selectedIndex].getAttribute('data-name') || '';
+  var group = document.getElementById('series2_icon_group');
+  if (group) {
+    group.hidden = (sel.value === '0' || sel.value === '');
+  }
 }
 (function() {
   var sel = document.getElementById('config_series2_column');

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -93,6 +93,12 @@
           {% endfor %}
         </select>
         <input type="hidden" name="config_series2_label" id="config_series2_label" value="">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" name="config_show_series2_on_book_list" id="config_show_series2_on_book_list" {% if conf.config_show_series2_on_book_list %}checked{% endif %} style="accent-color: var(--color-secondary);">
+            {{_('Show Second Series on book list pages')}}
+          </label>
+        </div>
         <p class="settings-explanation">{{_('Select a custom column of type "series" to use as a second series display.')}}</p>
       </div>
 

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -30,35 +30,35 @@
   <h2>{{title}}</h2>
   <form role="form" method="POST" autocomplete="off" style="margin-top: 3rem;">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    
+
     <!-- View Configuration Card -->
     <div class="settings-container">
       <h4 class="settings-section-header">{{_('View Configuration')}}</h4>
-      
+
       <div class="form-group">
         <label for="config_calibre_web_title">{{_('Title')}}</label>
         <input type="text" class="form-control" name="config_calibre_web_title" id="config_calibre_web_title" value="{% if conf.config_calibre_web_title != None %}{{ conf.config_calibre_web_title }}{% endif %}" autocomplete="off" required>
         <p class="settings-explanation">{{_('The title displayed in the browser tab and navbar.')}}</p>
       </div>
-      
+
       <div class="form-group">
         <label for="config_books_per_page">{{_('Books per Page')}}</label>
         <input type="number" min="1" max="200" class="form-control" name="config_books_per_page" id="config_books_per_page" value="{% if conf.config_books_per_page != None %}{{ conf.config_books_per_page }}{% endif %}" autocomplete="off">
         <p class="settings-explanation">{{_('Number of books to display per page in list views (1-200).')}}</p>
       </div>
-      
+
       <div class="form-group">
         <label for="config_random_books">{{_('No. of Random Books to Display')}}</label>
         <input type="number" min="1" max="30" class="form-control" name="config_random_books" id="config_random_books" value="{% if conf.config_random_books != None %}{{ conf.config_random_books }}{% endif %}" autocomplete="off">
         <p class="settings-explanation">{{_('Number of random books shown on the home page (1-30).')}}</p>
       </div>
-      
+
       <div class="form-group">
         <label for="config_authors_max">{{_('No. of Authors to Display Before Hiding (0=Disable Hiding)')}}</label>
         <input type="number" min="0" max="999" class="form-control" name="config_authors_max" id="config_authors_max" value="{% if conf.config_authors_max != None %}{{ conf.config_authors_max }}{% endif %}" autocomplete="off">
         <p class="settings-explanation">{{_('Maximum number of authors to show in book details before truncating. Set to 0 to disable.')}}</p>
       </div>
-      
+
       <div class="form-group">
         <label for="config_theme">{{_('Default Theme')}}</label>
         <select name="config_theme" id="config_theme" class="form-control">
@@ -66,13 +66,13 @@
         </select>
         <p class="settings-explanation">{{_('Default theme for new users and anonymous browsing. Users can select their own preferred theme in their profile.')}}</p>
       </div>
-      
+
       <div class="form-group">
         <label for="config_columns_to_ignore">{{_('Regular Expression for Ignoring Columns')}}</label>
         <input type="text" class="form-control" name="config_columns_to_ignore" id="config_columns_to_ignore" value="{% if conf.config_columns_to_ignore != None %}{{ conf.config_columns_to_ignore }}{% endif %}" autocomplete="off">
         <p class="settings-explanation">{{_('Regex pattern to hide custom columns from being displayed in the UI.')}}</p>
       </div>
-      
+
       <div class="form-group">
         <label for="config_read_column">{{_('Link Read/Unread Status to Calibre Column')}}</label>
         <select name="config_read_column" id="config_read_column" class="form-control">
@@ -83,7 +83,19 @@
         </select>
         <p class="settings-explanation">{{_('Sync read/unread status with a Calibre boolean custom column.')}}</p>
       </div>
-      
+
+      <div class="form-group">
+        <label for="config_series2_column">{{_('Second Series Column')}}</label>
+        <select name="config_series2_column" id="config_series2_column" class="form-control" onchange="updateSeries2Label(this)">
+          <option value="0" data-name="" {% if conf.config_series2_column == 0 %}selected{% endif %}></option>
+          {% for series2Column in series2Columns %}
+          <option value="{{ series2Column.id }}" data-name="{{ series2Column.name }}" {% if series2Column.id == conf.config_series2_column %}selected{% endif %}>{{ series2Column.name }}</option>
+          {% endfor %}
+        </select>
+        <input type="hidden" name="config_series2_label" id="config_series2_label" value="">
+        <p class="settings-explanation">{{_('Select a custom column of type "series" to use as a second series display.')}}</p>
+      </div>
+
       <div class="form-group">
         <label for="config_restricted_column">{{_('View Restrictions based on Calibre column')}}</label>
         <select name="config_restricted_column" id="config_restricted_column" class="form-control">
@@ -94,7 +106,7 @@
         </select>
         <p class="settings-explanation">{{_('Restrict book visibility based on values in a Calibre text custom column.')}}</p>
       </div>
-      
+
       <div class="form-group">
         <label for="config_title_regex">{{_('Regular Expression for Title Sorting')}}</label>
         <input type="text" class="form-control" name="config_title_regex" id="config_title_regex" value="{% if conf.config_title_regex != None %}{{ conf.config_title_regex }}{% endif %}" autocomplete="off">
@@ -221,6 +233,15 @@
 {{ restrict_modal() }}
 {% endblock %}
 {% block js %}
+<script>
+function updateSeries2Label(sel) {
+  document.getElementById('config_series2_label').value = sel.options[sel.selectedIndex].getAttribute('data-name') || '';
+}
+(function() {
+  var sel = document.getElementById('config_series2_column');
+  if (sel) { updateSeries2Label(sel); }
+})();
+</script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table-editable.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-editable.min.js') }}"></script>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -655,11 +655,15 @@
                                 </p>
                             {% endif %}
                         </div>
-                        {% if entry.series|length > 0 %}
-                            <p id="book_of">{{ _("Book %(index)s of %(range)s", index=entry.series_index|formatfloat(2), range=(url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id)|escapedlink(entry.series[0].name))|safe) }}</p>
-                        {% endif %}
-                        {% if entry.series2|length > 0 %}
-                            <p id="book_of2">{{ _("Book %(index)s of %(range)s", index=entry.series2[0].extra|formatfloat(2), range=(url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value)|escapedlink(entry.series2[0].value))|safe) }}</p>
+                        {% if entry.series|length > 0 or entry.series2|length > 0 %}
+                        <div class="series-section">
+                            {% if entry.series|length > 0 %}
+                                <p class="series-entry">{{_('Series')}}: <a href="{{ url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id) }}">{{ entry.series[0].name }}</a>, {{_('Book')}} {{ entry.series_index|formatfloat(2) }}</p>
+                            {% endif %}
+                            {% if entry.series2|length > 0 %}
+                                <p class="series2-entry">{{ series2_label }}: <a href="{{ url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value) }}">{{ entry.series2[0].value }}</a>, {{_('Book')}} {{ entry.series2[0].extra|formatfloat(2) }}</p>
+                            {% endif %}
+                        </div>
                         {% endif %}
 
                         <div class="book-metadata">

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -656,14 +656,14 @@
                             {% endif %}
                         </div>
                         {% if entry.series|length > 0 or entry.series2|length > 0 %}
-                        <div class="series-section">
-                            {% if entry.series|length > 0 %}
-                                <p class="series-entry">{{_('Series')}}: <a href="{{ url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id) }}">{{ entry.series[0].name }}</a>, {{_('Book')}} {{ entry.series_index|formatfloat(2) }}</p>
-                            {% endif %}
-                            {% if entry.series2|length > 0 %}
-                                <p class="series2-entry">{{ series2_label }}: <a href="{{ url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value) }}">{{ entry.series2[0].value }}</a>, {{_('Book')}} {{ entry.series2[0].extra|formatfloat(2) }}</p>
-                            {% endif %}
-                        </div>
+                            <div class="series-section">
+                                {% if entry.series|length > 0 %}
+                                    <p class="series-entry">{{_('Series')}}: <a href="{{ url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id) }}">{{ entry.series[0].name }}</a>, {{_('Book')}} {{ entry.series_index|formatfloat(2) }}</p>
+                                {% endif %}
+                                {% if entry.series2|length > 0 %}
+                                    <p class="series2-entry">{{ g.config_series2_label}}: <a href="{{ url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.series2[0].map_value) }}">{{ entry.series2[0].value }}</a>, {{_('Book')}} {{ entry.series2[0].extra|formatfloat(2) }}</p>
+                                {% endif %}
+                            </div>
                         {% endif %}
 
                         <div class="book-metadata">

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -658,6 +658,9 @@
                         {% if entry.series|length > 0 %}
                             <p id="book_of">{{ _("Book %(index)s of %(range)s", index=entry.series_index|formatfloat(2), range=(url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id)|escapedlink(entry.series[0].name))|safe) }}</p>
                         {% endif %}
+                        {% if entry.series2|length > 0 %}
+                            <p id="book_of2">{{ _("Book %(index)s of %(range)s", index=entry.series2[0].extra|formatfloat(2), range=(url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value)|escapedlink(entry.series2[0].value))|safe) }}</p>
+                        {% endif %}
 
                         <div class="book-metadata">
                             <div class="book-id meta-chip">

--- a/cps/templates/grid.html
+++ b/cps/templates/grid.html
@@ -18,7 +18,7 @@
         <div class="btn btn-primary char">{{char.char}}</div>
         {% endfor %}
       </div>
-        <div class="update-view btn btn-primary" data-target="series_view" id="list-button" data-view="list">{{_('List')}}</div>
+        <div class="update-view btn btn-primary" data-page="series" data-target="series_view" id="list-button" data-view="list">{{_('List')}}</div>
     </div>
 
     {% if entries[0] %}

--- a/cps/templates/grid2.html
+++ b/cps/templates/grid2.html
@@ -1,0 +1,39 @@
+{% import 'image.html' as image %}
+{% extends "layout.html" %}
+{% block body %}
+<h1 class="{{page}}">{{_(title)}}</h1>
+
+    <div class="filterheader hidden-xs">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div id="asc" data-id="series2" data-order="{{ order }}" class="btn btn-primary{% if order == 1 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet"></span></div>
+      <div id="desc" data-id="series2" class="btn btn-primary{% if order == 0 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet-alt"></span></div>
+        <div class="update-view btn btn-primary" data-page="series2" data-target="series2_view" id="list-button" data-view="list">{{_('List')}}</div>
+    </div>
+
+    {% if entries[0] %}
+        <div id="list" class="row display-flex">
+          {% for entry in entries %}
+              <div class="col-sm-3 col-lg-2 col-xs-6 book sortable" data-name="{{entry.s2_name}}" data-id="{{entry.s2_name}}">
+                  <div class="cover">
+                      <a href="{{url_for('web.books_list', data=data, sort_param='stored', book_id=entry.s2_id )}}">
+                          <span class="img" title="{{entry.s2_name}}">
+                              {{ image.book_cover(entry[0])}}
+                              <span class="badge">{{entry.count}}</span>
+                            </span>
+                      </a>
+                  </div>
+                  <div class="meta">
+                      <a href="{{url_for('web.books_list', data=data, sort_param='stored', book_id=entry.s2_id )}}">
+                          <p title="{{entry.s2_name|shortentitle}}" class="title">{{entry.s2_name|shortentitle}}</p>
+                      </a>
+                  </div>
+              </div>
+        {% endfor %}
+        </div>
+    {% endif %}
+
+
+{% endblock %}
+{% block js %}
+<script src="{{ url_for('static', filename='js/filter_grid.js') }}"></script>
+{% endblock %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -93,7 +93,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})
@@ -250,7 +250,7 @@
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
         {% if page != "series2" %}
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
         {% else %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -91,6 +91,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.Books.ratings[0].rating/2)|int(2)) %}
@@ -237,6 +245,18 @@
             <span>{{entry.Books.series[0].name}}</span>
         {% endif %}
           ({{entry.Books.series_index|formatfloat(2)}})
+        </p>
+        {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+        {% if page != "series2" %}
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+        {% else %}
+            <span>{{entry.Books.series2[0].value}}</span>
+        {% endif %}
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
         </p>
         {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -283,7 +283,7 @@
               {% for element in sidebar %}
                 {% if current_user.check_visibility(element['visibility']) and element['public'] %}
                     <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %} style="{% if element['id'] == 'duplicates' %}position: relative;{% endif %}">
-                      <a href="{{url_for(element['link'], data=element['page'], sort_param='stored')}}">
+                      <a href="{% if element['no_param'] %}{{url_for(element['link'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}">
                         <span class="glyphicon {{element['glyph']}}"></span> {{_(element['text'])}}
                         {% if element['id'] == 'duplicates' %}
                           {% set dup_count = duplicate_notification.count if duplicate_notification is defined else 0 %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -283,7 +283,7 @@
               {% for element in sidebar %}
                 {% if current_user.check_visibility(element['visibility']) and element['public'] %}
                     <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %} style="{% if element['id'] == 'duplicates' %}position: relative;{% endif %}">
-                      <a href="{% if element['no_param'] %}{{url_for(element['link'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}">
+                      <a href="{% if element['link'] == 'web.books_list' %}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% else %}{{url_for(element['link'])}}{% endif %}">
                         <span class="glyphicon {{element['glyph']}}"></span> {{_(element['text'])}}
                         {% if element['id'] == 'duplicates' %}
                           {% set dup_count = duplicate_notification.count if duplicate_notification is defined else 0 %}

--- a/cps/templates/list.html
+++ b/cps/templates/list.html
@@ -40,7 +40,9 @@ See CONTRIBUTORS for full list of authors. -->
       {% endif %}
 
       {% if data == "series" %}
-      <button class="update-view btn btn-primary" data-target="series_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
+      <button class="update-view btn btn-primary" data-page="series" data-target="series_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
+      {% elif data == "series2" %}
+      <button class="update-view btn btn-primary" data-page="series2" data-target="series2_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
       {% endif %}
     </div>
   <div class="container" id="{{_(title)}}">

--- a/cps/templates/list.html
+++ b/cps/templates/list.html
@@ -41,7 +41,7 @@ See CONTRIBUTORS for full list of authors. -->
 
       {% if data == "series" %}
       <button class="update-view btn btn-primary" data-page="series" data-target="series_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
-      {% elif data == "series2" %}
+      {% elif data == g.series2_key %}
       <button class="update-view btn btn-primary" data-page="series2" data-target="series2_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
       {% endif %}
     </div>

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -89,6 +89,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
 
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -91,7 +91,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/templates/search_form.html
+++ b/cps/templates/search_form.html
@@ -86,7 +86,7 @@
     {% if series2|length > 0 %}
     <div class="row">
       <div class="form-group col-sm-6">
-        <div><label for="include_serie2">{{_('Series')}}</label></div>
+        <div><label for="include_serie2">{{series2_label}}</label></div>
         <select class="selectpicker" name="include_serie2" id="include_serie2" data-live-search="true" data-style="btn-primary" data-dropup-auto="false" data-actions-box="true" multiple>
           {% for serie in series2 %}
           <option value="{{serie.id}}">{{serie.value}}</option>
@@ -94,7 +94,7 @@
         </select>
       </div>
       <div class="form-group col-sm-6">
-        <div><label for="exclude_serie2">{{_('Exclude Series')}}</label></div>
+        <div><label for="exclude_serie2">{{_('Exclude')}} {{series2_label}}</label></div>
         <select class="selectpicker" name="exclude_serie2" id="exclude_serie2" data-live-search="true" data-style="btn-danger" data-dropup-auto="false" data-actions-box="true" multiple>
           {% for serie in series2 %}
           <option value="{{serie.id}}">{{serie.value}}</option>

--- a/cps/templates/search_form.html
+++ b/cps/templates/search_form.html
@@ -83,6 +83,26 @@
         </select>
       </div>
     </div>
+    {% if series2|length > 0 %}
+    <div class="row">
+      <div class="form-group col-sm-6">
+        <div><label for="include_serie2">{{_('Series')}}</label></div>
+        <select class="selectpicker" name="include_serie2" id="include_serie2" data-live-search="true" data-style="btn-primary" data-dropup-auto="false" data-actions-box="true" multiple>
+          {% for serie in series2 %}
+          <option value="{{serie.id}}">{{serie.value}}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group col-sm-6">
+        <div><label for="exclude_serie2">{{_('Exclude Series')}}</label></div>
+        <select class="selectpicker" name="exclude_serie2" id="exclude_serie2" data-live-search="true" data-style="btn-danger" data-dropup-auto="false" data-actions-box="true" multiple>
+          {% for serie in series2 %}
+          <option value="{{serie.id}}">{{serie.value}}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    {% endif %}
      <div class="row">
       <div class="form-group col-sm-6">
         <div><label for="include_shelf">{{_('Shelves')}}</label></div>

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -79,7 +79,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -77,6 +77,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.Books.ratings[0].rating/2)|int(2)) %}

--- a/cps/templates/shelfdown.html
+++ b/cps/templates/shelfdown.html
@@ -48,6 +48,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
       </div>
 
 	  <div class="btn-group" role="group" aria-label="Download, send to eReader, reading">

--- a/cps/templates/shelfdown.html
+++ b/cps/templates/shelfdown.html
@@ -50,7 +50,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/web.py
+++ b/cps/web.py
@@ -1682,7 +1682,7 @@ def series_list():
 def series2_list():
     if not config.config_series2_column or db.series2_link_class is None or db.series2_cc_class is None:
         abort(404)
-    if current_user.check_visibility(constants.SIDEBAR_SERIES2):
+    if current_user.check_visibility(constants.SIDEBAR_SERIES):
         if current_user.get_view_property('series2', 'dir') == 'desc':
             order = db.series2_cc_class.value.desc()
             order_no = 0

--- a/cps/web.py
+++ b/cps/web.py
@@ -61,6 +61,9 @@ import sys
 sys.path.insert(1, '/app/calibre-web-automated/scripts/')
 from cwa_db import CWA_DB
 
+# Computed once at startup. Used for dynamic series2 URL routing.
+_s2_key = (config.config_series2_slug or '').strip() or 'series2'
+
 feature_support = {
     'ldap': bool(services.ldap),
     'goodreads': bool(services.goodreads_support),
@@ -450,7 +453,7 @@ def render_books_list(data, sort_param, book_id, page):
         return render_publisher_books(page, book_id, order)
     elif data == "series":
         return render_series_books(page, book_id, order)
-    elif data == "series2":
+    elif data in (_s2_key, "series2"):
         return render_series2_books(page, book_id, order)
     elif data == "ratings":
         return render_ratings_books(page, book_id, order)
@@ -1677,7 +1680,7 @@ def series_list():
         abort(404)
 
 
-@web.route("/series2")
+@web.route("/{}".format(_s2_key))
 @login_required_if_no_ano
 def series2_list():
     if not config.config_series2_column or db.series2_link_class is None or db.series2_cc_class is None:
@@ -1689,23 +1692,45 @@ def series2_list():
         else:
             order = db.series2_cc_class.value.asc()
             order_no = 1
-        entries_raw = (calibre_db.session.query(db.series2_cc_class,
-                                                func.count(db.series2_link_class.book).label('count'))
-                       .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
-                       .join(db.Books, db.Books.id == db.series2_link_class.book)
-                       .filter(calibre_db.common_filters())
-                       .group_by(db.series2_link_class.map_value)
-                       .order_by(order)
-                       .all())
-        entries = [[db.Category(row[0].value, row[0].id), row[1]] for row in entries_raw]
         label = config.config_series2_label or 'World'
-        return render_title_template('list.html',
-                                     entries=entries,
-                                     folder='web.books_list',
-                                     charlist=[],
-                                     title=label,
-                                     page="series2list",
-                                     data="series2", order=order_no)
+        if current_user.get_view_property('series2', 'series2_view') == 'list':
+            entries_raw = (calibre_db.session.query(db.series2_cc_class,
+                                                    func.count(db.series2_link_class.book).label('count'))
+                           .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
+                           .join(db.Books, db.Books.id == db.series2_link_class.book)
+                           .filter(calibre_db.common_filters())
+                           .group_by(db.series2_link_class.map_value)
+                           .order_by(order)
+                           .all())
+            entries = [[db.Category(row[0].value, row[0].id), row[1]] for row in entries_raw]
+            return render_title_template('list.html',
+                                         entries=entries,
+                                         folder='web.books_list',
+                                         charlist=[],
+                                         title=label,
+                                         page="series2list",
+                                         data="series2", order=order_no)
+        else:
+            entries = (calibre_db.session.query(
+                db.Books,
+                func.count(db.series2_link_class.book).label('count'),
+                func.max(db.series2_link_class.extra),
+                db.series2_cc_class.id.label('s2_id'),
+                db.series2_cc_class.value.label('s2_name')
+            )
+                .join(db.series2_link_class, db.series2_link_class.book == db.Books.id)
+                .join(db.series2_cc_class, db.series2_cc_class.id == db.series2_link_class.map_value)
+                .filter(calibre_db.common_filters())
+                .group_by(db.series2_link_class.map_value)
+                .order_by(order)
+                .all())
+            return render_title_template('grid2.html',
+                                         entries=entries,
+                                         folder='web.books_list',
+                                         charlist=[],
+                                         title=label,
+                                         page="series2list",
+                                         data="series2", bodyClass="grid-view", order=order_no)
     else:
         abort(404)
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -450,6 +450,8 @@ def render_books_list(data, sort_param, book_id, page):
         return render_publisher_books(page, book_id, order)
     elif data == "series":
         return render_series_books(page, book_id, order)
+    elif data == "series2":
+        return render_series2_books(page, book_id, order)
     elif data == "ratings":
         return render_ratings_books(page, book_id, order)
     elif data == "formats":
@@ -664,6 +666,24 @@ def render_publisher_books(page, book_id, order):
                                  title=_("Publisher: %(name)s", name=publisher),
                                  page="publisher",
                                  order=order[1])
+
+
+def render_series2_books(page, book_id, order):
+    if db.series2_link_class is None or db.series2_cc_class is None:
+        abort(404)
+    series2_entry = calibre_db.session.query(db.series2_cc_class).filter(
+        db.series2_cc_class.id == book_id).first()
+    if series2_entry:
+        entries, random, pagination = calibre_db.fill_indexpage(
+            page, 0, db.Books,
+            db.Books.series2.any(db.series2_link_class.map_value == book_id),
+            [order[0][0]], True, config.config_read_column)
+        label = config.config_series2_label or 'World'
+        title = label + ": " + series2_entry.value
+    else:
+        abort(404)
+    return render_title_template('index.html', random=random, pagination=pagination, entries=entries,
+                                 id=book_id, title=title, page="series2", order=order[1])
 
 
 def render_series_books(page, book_id, order):
@@ -1653,6 +1673,39 @@ def series_list():
             return render_title_template('grid.html', entries=entries, folder='web.books_list', charlist=char_list,
                                          title=_("Series"), page="serieslist", data="series", bodyClass="grid-view",
                                          order=order_no)
+    else:
+        abort(404)
+
+
+@web.route("/series2")
+@login_required_if_no_ano
+def series2_list():
+    if not config.config_series2_column or db.series2_link_class is None or db.series2_cc_class is None:
+        abort(404)
+    if current_user.check_visibility(constants.SIDEBAR_SERIES2):
+        if current_user.get_view_property('series2', 'dir') == 'desc':
+            order = db.series2_cc_class.value.desc()
+            order_no = 0
+        else:
+            order = db.series2_cc_class.value.asc()
+            order_no = 1
+        entries_raw = (calibre_db.session.query(db.series2_cc_class,
+                                                func.count(db.series2_link_class.book).label('count'))
+                       .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
+                       .join(db.Books, db.Books.id == db.series2_link_class.book)
+                       .filter(calibre_db.common_filters())
+                       .group_by(db.series2_link_class.map_value)
+                       .order_by(order)
+                       .all())
+        entries = [[db.Category(row[0].value, row[0].id), row[1]] for row in entries_raw]
+        label = config.config_series2_label or 'World'
+        return render_title_template('list.html',
+                                     entries=entries,
+                                     folder='web.books_list',
+                                     charlist=[],
+                                     title=label,
+                                     page="series2list",
+                                     data="series2", order=order_no)
     else:
         abort(404)
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -62,7 +62,7 @@ sys.path.insert(1, '/app/calibre-web-automated/scripts/')
 from cwa_db import CWA_DB
 
 # Computed once at startup. Used for dynamic series2 URL routing.
-_s2_key = (config.config_series2_slug or '').strip() or 'series2'
+_s2_key = (config.config_series2_slug or config.config_series2_label or '').strip() or 'series2'
 
 feature_support = {
     'ldap': bool(services.ldap),
@@ -1709,7 +1709,7 @@ def series2_list():
                                          charlist=[],
                                          title=label,
                                          page="series2list",
-                                         data="series2", order=order_no)
+                                         data=_s2_key, order=order_no)
         else:
             entries = (calibre_db.session.query(
                 db.Books,
@@ -1730,9 +1730,13 @@ def series2_list():
                                          charlist=[],
                                          title=label,
                                          page="series2list",
-                                         data="series2", bodyClass="grid-view", order=order_no)
+                                         data=_s2_key, bodyClass="grid-view", order=order_no)
     else:
         abort(404)
+
+
+if _s2_key != 'series2':
+    web.add_url_rule('/series2', view_func=series2_list)
 
 
 @web.route("/ratings")

--- a/cps/web.py
+++ b/cps/web.py
@@ -2987,6 +2987,9 @@ def show_book(book_id):
             if media_format.format.lower() in constants.EXTENSIONS_AUDIO:
                 entry.audio_entries.append(media_format.format.lower())
 
+        log.debug("series2: link_class=%s, cc_class=%s, entry.series2=%r",
+                  db.series2_link_class, db.series2_cc_class, entry.series2)
+
         kosync_progress = None
         kosync_progress_timestamp = None
         if current_user.is_authenticated:

--- a/cps/web.py
+++ b/cps/web.py
@@ -1040,8 +1040,8 @@ def index(page):
     return render_books_list("newest", sort_param, 1, page)
 
 
-@web.route('/<data>/<sort_param>', defaults={'page': 1, 'book_id': 1})
-@web.route('/<data>/<sort_param>/', defaults={'page': 1, 'book_id': 1})
+@web.route('/<data>/<sort_param>', defaults={'page': 1, 'book_id': 0})
+@web.route('/<data>/<sort_param>/', defaults={'page': 1, 'book_id': 0})
 @web.route('/<data>/<sort_param>/<book_id>', defaults={'page': 1})
 @web.route('/<data>/<sort_param>/<book_id>/<int:page>')
 @login_required_if_no_ano

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -22,6 +22,12 @@ services:
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
+      # DEV SPECIFIC
+      ### Set DEBUG_ON to true to:
+      ###   1. Have Flask/Jinja2 auto-reload templates on each request (no restart needed)
+      ###   2. Watch cps/ for .py changes and auto-restart the server when any Python file changes
+      ### Requres dev specific binds to be set.
+      - DEVELOP_ON=true
     volumes:
       # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings ect.
       - /path/to/config/folder:/config 
@@ -38,6 +44,7 @@ services:
       ### This will let you see your changes in realtime, test ect. You can use build.sh to prepare images with your changes.
       ### For example:
       # /your/dev/env/cps:/app/calibre-web-automated/cps
+      # /your/dev/env/scripts:/app/calibre-web-automated/scripts
 
     ports:
       # Change the first number to change the port you want to access the Web UI, not the second


### PR DESCRIPTION
Configuration option for setting a second series field (for storing world, collection, etc).
Shows in sidebar, and in book details under the primary series. Uses column name as the display name.
Available to select in the advanced search in the same manner as the main series.
Configuration allows for setting the icon to use in the sidebar (defaults to the same as the main series icon)
Sidebar display has the same "Show [SecondSeries] Section" config option in the user's config page as the main series
The "show second series on book list pages" checkbox causes the second series to be displayed below the primary series on all book pages

<img width="878" height="608" alt="image" src="https://github.com/user-attachments/assets/b482a21d-f1b7-4bc1-b8b1-27f575bc374f" />


Copy of changes from https://github.com/janeczku/calibre-web/pull/3647