### PR TITLE
Adding custom columns, shelves, and identifiers to magic shelf rules

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -80,7 +80,8 @@ app.config.update(
     REMEMBER_COOKIE_SAMESITE='Strict',
     WTF_CSRF_SSL_STRICT=False,
     SESSION_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "session",
-    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token"
+    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token",
+    TEMPLATES_AUTO_RELOAD=os.environ.get('DEVELOP_ON', 'False').lower() == 'true',
 )
 
 # Fix for running behind reverse proxy (e.g. nginx, apache, caddy, ...)

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -463,6 +463,7 @@ def reconnect():
         abort(404)
 
 
+
 @admi.route("/ajax/updateThumbnails", methods=['POST'])
 @user_login_required
 @admin_required

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -321,6 +321,152 @@ RELATIONSHIP_MAP = {
     'comments': 'comments',  # For description field - requires join to Comments table
 }
 
+def _convert_cc_value(value, datatype):
+    """Convert a rule value to the appropriate Python type for a custom column."""
+    if datatype == 'bool':
+        if isinstance(value, bool):
+            return value
+        try:
+            return bool(int(value))
+        except (TypeError, ValueError):
+            return None
+    elif datatype == 'int':
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    elif datatype == 'float':
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    elif datatype == 'datetime':
+        if isinstance(value, str):
+            try:
+                return datetime.strptime(value, '%Y-%m-%d')
+            except ValueError:
+                return None
+        return value
+    # text, comments, enumeration, rating, series — return as-is
+    return value
+
+
+def _build_custom_column_filter(cc_id, datatype, operator_name, value):
+    """Build a SQLAlchemy filter for a single custom column rule."""
+    if cc_id not in db.cc_classes:
+        log.warning(f"Custom column {cc_id} not found in cc_classes")
+        return None
+
+    cc_class = db.cc_classes[cc_id]
+    column = cc_class.value
+    relationship = getattr(db.Books, f'custom_column_{cc_id}', None)
+    if relationship is None:
+        log.warning(f"Books model has no relationship 'custom_column_{cc_id}'")
+        return None
+
+    if operator_name in ('is_empty', 'is_null'):
+        return ~relationship.any()
+    if operator_name in ('is_not_empty', 'is_not_null'):
+        return relationship.any()
+
+    converted = _convert_cc_value(value, datatype)
+
+    negated_ops = {
+        'not_equal': 'equal',
+        'not_contains': 'contains',
+        'not_begins_with': 'begins_with',
+        'not_ends_with': 'ends_with',
+        'not_in': 'in',
+        'not_between': 'between',
+    }
+
+    if operator_name in negated_ops:
+        base_op = OPERATOR_MAP.get(negated_ops[operator_name])
+        if not base_op:
+            return None
+        filter_expr = base_op(column, converted)
+        if filter_expr is None:
+            return None
+        return ~relationship.any(filter_expr)
+
+    op = OPERATOR_MAP.get(operator_name)
+    if not op:
+        return None
+    filter_expr = op(column, converted)
+    if filter_expr is None:
+        return None
+    return relationship.any(filter_expr)
+
+
+def get_identifiers_for_rules():
+    """Return all identifier types present in the library, ordered by frequency.
+
+    Queries the Calibre DB directly and uses Identifiers.format_type() for labels.
+    """
+    try:
+        cdb = db.CalibreDB(init=True)
+        rows = (
+            cdb.session.query(db.Identifiers.type, func.count(db.Identifiers.book))
+            .group_by(db.Identifiers.type)
+            .order_by(func.count(db.Identifiers.book).desc())
+            .all()
+        )
+        return [
+            {'type': r[0], 'label': db.Identifiers('', r[0], 0).format_type()}
+            for r in rows
+        ]
+    except Exception as e:
+        log.warning(f"get_identifiers_for_rules: {e}")
+        return []
+
+
+def get_shelves_for_rules(user_id):
+    """Return regular shelves available as magic shelf rule criteria for a given user.
+
+    Returns the owner's own shelves plus any public shelves, sorted by name.
+    """
+    shelves = ub.session.query(ub.Shelf).filter(
+        or_(
+            ub.Shelf.user_id == user_id,
+            ub.Shelf.is_public == 1,
+        )
+    ).order_by(ub.Shelf.name).all()
+    return [{'id': s.id, 'name': s.name} for s in shelves]
+
+
+def get_custom_columns_for_rules():
+    """Return custom column metadata suitable for building magic shelf rule fields.
+
+    Excludes composite and series datatypes (not mapped in cc_classes).
+    Returns a list of dicts with id, name, label, datatype, and enum_values.
+    """
+    import json as _json
+    cdb = db.CalibreDB(init=True)
+    rows = cdb.session.query(db.CustomColumns).filter(
+        db.CustomColumns.datatype.notin_(db.cc_exceptions)
+    ).all()
+
+    result = []
+    for col in rows:
+        if col.id not in db.cc_classes:
+            continue
+        entry = {
+            'id': col.id,
+            'name': col.name,
+            'label': col.label,
+            'datatype': col.datatype,
+            'enum_values': [],
+        }
+        if col.datatype == 'enumeration':
+            try:
+                display = _json.loads(col.display or '{}')
+                entry['enum_values'] = display.get('enum_values', [])
+            except (ValueError, TypeError):
+                pass
+        result.append(entry)
+    return result
+
+
 def build_filter_from_rule(rule, user_id=None):
     """Builds a SQLAlchemy filter condition from a single rule."""
     from . import config
@@ -331,6 +477,54 @@ def build_filter_from_rule(rule, user_id=None):
 
     if not all([field_name, operator_name]):
         return None
+
+    # Handle dynamic custom column rules (id format: "cc_<column_id>")
+    if field_name.startswith('cc_'):
+        try:
+            cc_id = int(field_name[3:])
+        except ValueError:
+            return None
+        cdb = db.CalibreDB(init=True)
+        cc_col = cdb.session.query(db.CustomColumns).filter(
+            db.CustomColumns.id == cc_id
+        ).first()
+        if cc_col is None or cc_col.datatype in db.cc_exceptions:
+            return None
+        return _build_custom_column_filter(cc_id, cc_col.datatype, operator_name, value)
+
+    # Handle identifier presence rules (id format: "identifier_<type>")
+    if field_name.startswith('identifier_'):
+        id_type = field_name[len('identifier_'):]
+        try:
+            has_id = bool(int(value)) if value is not None else True
+        except (TypeError, ValueError):
+            has_id = True
+        condition = db.Books.identifiers.any(db.Identifiers.type == id_type)
+        if operator_name in ('equal', 'not_equal'):
+            negate = (operator_name == 'not_equal') ^ (not has_id)
+            return ~condition if negate else condition
+        return condition if has_id else ~condition
+
+    # Handle shelf membership rules (id format: "shelf_<shelf_id>")
+    if field_name.startswith('shelf_'):
+        try:
+            shelf_id = int(field_name[6:])
+        except ValueError:
+            return None
+        try:
+            on_shelf = bool(int(value)) if value is not None else True
+        except (TypeError, ValueError):
+            on_shelf = True
+        books_on_shelf = ub.session.query(ub.BookShelf.book_id).filter(
+            ub.BookShelf.shelf == shelf_id
+        ).subquery()
+        condition = db.Books.id.in_(books_on_shelf)
+        if operator_name == 'equal':
+            return condition if on_shelf else ~condition
+        elif operator_name == 'not_equal':
+            return ~condition if on_shelf else condition
+        else:
+            return condition if on_shelf else ~condition
 
     field_info = FIELD_MAP.get(field_name)
     if not field_info:

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -431,7 +431,7 @@ def get_shelves_for_rules(user_id):
             ub.Shelf.is_public == 1,
         )
     ).order_by(ub.Shelf.name).all()
-    return [{'id': s.id, 'name': s.name} for s in shelves]
+    return [{'id': s.id, 'name': s.name, 'is_public': s.is_public} for s in shelves]
 
 
 def get_custom_columns_for_rules():

--- a/cps/search.py
+++ b/cps/search.py
@@ -181,10 +181,14 @@ def adv_search_serie(q, include_series_inputs, exclude_series_inputs):
     return q
 
 def adv_search_shelf(q, include_shelf_inputs, exclude_shelf_inputs):
-    q = q.outerjoin(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)\
-        .filter(or_(ub.BookShelf.shelf == None, ub.BookShelf.shelf.notin_(exclude_shelf_inputs)))
-    if len(include_shelf_inputs) > 0:
-        q = q.filter(ub.BookShelf.shelf.in_(include_shelf_inputs))
+    for shelf_id in include_shelf_inputs:
+        q = q.filter(db.Books.id.in_(
+            ub.session.query(ub.BookShelf.book_id).filter(ub.BookShelf.shelf == shelf_id)
+        ))
+    for shelf_id in exclude_shelf_inputs:
+        q = q.filter(~db.Books.id.in_(
+            ub.session.query(ub.BookShelf.book_id).filter(ub.BookShelf.shelf == shelf_id)
+        ))
     return q
 
 def extend_search_term(searchterm,
@@ -353,7 +357,10 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
             log.debug_or_exception(ex)
             flash(_("Error on search for custom columns, please restart Calibre-Web"), category="error")
 
-    q = q.order_by(*sort)
+    # Collapse duplicate rows that may be produced by the browse outerjoins (e.g.
+    # the series listing at line 253). Without this, the SQL LIMIT below counts
+    # duplicate rows and a full page collapses to fewer distinct books.
+    q = q.group_by(db.Books.id).order_by(*sort)
     flask_session['query'] = json.dumps(term)
 
     # Perform a count query for pagination, which is much faster than fetching all results.

--- a/cps/server.py
+++ b/cps/server.py
@@ -199,8 +199,40 @@ class WebServer(object):
             rv = ['"{}"'.format(a) for a in rv]
         return rv
 
+    def _dev_py_watcher(self):
+        """Greenlet: poll cps/ for .py changes and trigger restart when DEBUG_ON=true."""
+        from gevent import sleep
+        import glob
+
+        watch_root = os.path.dirname(os.path.abspath(__file__))
+
+        def mtimes():
+            result = {}
+            for f in glob.glob(os.path.join(watch_root, '**', '*.py'), recursive=True):
+                try:
+                    result[f] = os.path.getmtime(f)
+                except OSError:
+                    pass
+            return result
+
+        baseline = mtimes()
+        while True:
+            sleep(1)
+            current = mtimes()
+            changed = [f for f in current if current[f] != baseline.get(f)]
+            changed += [f for f in baseline if f not in current]
+            if changed:
+                log.info("Dev reload: %s changed, restarting...", os.path.basename(changed[0]))
+                self.stop(restart=True)
+                return
+            baseline = current
+
     def _start_gevent(self):
         ssl_args = self.ssl_args or {}
+
+        if os.environ.get('DEBUG_ON', 'False').lower() == 'true':
+            from gevent import spawn
+            spawn(self._dev_py_watcher)
 
         try:
             sock, output = self._make_gevent_listener()

--- a/cps/templates/magic_shelf_edit.html
+++ b/cps/templates/magic_shelf_edit.html
@@ -250,6 +250,15 @@ div.help-panel > .panel-body {
     padding-inline: 1rem;
 }
 
+/* Custom Columns separator option in field dropdowns */
+.query-builder .rule-filter-container select option.cc-header {
+    color: #cc7b19;
+    font-weight: bold;
+    text-align: center;
+    background: #21252b;
+    cursor: default;
+}
+
 /* Date format hint styling - matches preview results box */
 .date-format-hint {
     display: none;
@@ -465,6 +474,9 @@ div.help-panel > .panel-body {
 
 {% set rules_json = shelf.rules|tojson if shelf and shelf.rules else 'null' %}
 {% set languages_json = languages|tojson if languages else '{}' %}
+{% set custom_columns_json = custom_columns|tojson if custom_columns else '[]' %}
+{% set shelves_json = shelves|tojson if shelves else '[]' %}
+{% set identifiers_json = identifiers|tojson if identifiers else '[]' %}
 {% block js %}
 {{ super() }}
 <script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
@@ -473,21 +485,21 @@ div.help-panel > .panel-body {
 $(function() {
     // Initialize tooltips
     $('[data-toggle="tooltip"]').tooltip();
-    
+
     // Character counter for shelf name
     $('#shelf-name').on('input', function() {
         $('#char-count').text($(this).val().length);
     }).trigger('input');
-    
+
     // Icon Picker Logic
     var $iconInput = $('#shelf-icon');
     var $iconOptions = $('.icon-option');
     var $iconSearch = $('#icon-search');
-    
+
     // Set initial selected icon in grid
     var currentIcon = $iconInput.val();
     $('.icon-option[data-icon="' + currentIcon + '"]').addClass('selected');
-    
+
     // When user clicks a quick-pick icon, populate the input field
     $iconOptions.on('click', function() {
         var icon = $(this).data('icon');
@@ -502,7 +514,7 @@ $(function() {
         $iconOptions.removeClass('selected');
         $('.icon-option[data-icon="' + icon + '"]').addClass('selected');
     });
-    
+
     // Icon search filter
     $iconSearch.on('input', function() {
         var searchTerm = $(this).val().toLowerCase();
@@ -515,9 +527,12 @@ $(function() {
             }
         });
     });
-    
+
     // Query Builder Configuration
     var languages = {{ languages_json|safe }};
+    var customColumns = {{ custom_columns_json|safe }};
+    var shelves = {{ shelves_json|safe }};
+    var identifiers = {{ identifiers_json|safe }};
     var fields = [
         {
             id: 'title', 
@@ -613,9 +628,74 @@ $(function() {
             type: 'integer',
             input: 'radio',
             values: {1: 'Yes', 0: 'No'},
-            description: 'Whether book has Hardcover identifier'
+            optgroup: 'Identifiers',
+            description: 'Whether book has a Hardcover identifier (any type)'
         }
     ];
+
+    // Append custom column fields (from Calibre custom columns, excluding composite)
+    customColumns.forEach(function(cc) {
+        var field = {
+            id: 'cc_' + cc.id,
+            label: cc.name,
+            optgroup: 'Custom Columns',
+            description: 'Custom column: #' + cc.label
+        };
+        if (cc.datatype === 'bool') {
+            field.type = 'integer';
+            field.input = 'radio';
+            field.values = {1: 'Yes', 0: 'No'};
+        } else if (cc.datatype === 'int') {
+            field.type = 'integer';
+        } else if (cc.datatype === 'float') {
+            field.type = 'double';
+        } else if (cc.datatype === 'datetime') {
+            field.type = 'date';
+            field.validation = {format: 'YYYY-MM-DD'};
+        } else if (cc.datatype === 'rating') {
+            field.type = 'integer';
+        } else if (cc.datatype === 'enumeration') {
+            field.type = 'string';
+            field.input = 'select';
+            var vals = {};
+            (cc.enum_values || []).forEach(function(v) { vals[v] = v; });
+            field.values = vals;
+        } else {
+            // text, comments
+            field.type = 'string';
+        }
+        fields.push(field);
+    });
+
+    // Append identifier presence fields (populated from cwa.db scan)
+    identifiers.forEach(function(ident) {
+        fields.push({
+            id: 'identifier_' + ident.type,
+            label: 'Has ' + ident.label,
+            optgroup: 'Identifiers',
+            type: 'integer',
+            input: 'radio',
+            values: {1: 'Yes', 0: 'No'},
+            operators: ['equal']
+        });
+    });
+
+    // Append shelf membership fields
+    shelves.forEach(function(s) {
+        fields.push({
+            id: 'shelf_' + s.id,
+            label: s.name,
+            optgroup: 'Shelves',
+            type: 'integer',
+            input: 'radio',
+            values: {1: 'On', 0: 'Not On'},
+            operators: ['equal']
+        });
+    });
+
+    var customDateFieldIds = customColumns
+        .filter(function(cc) { return cc.datatype === 'datetime'; })
+        .map(function(cc) { return 'cc_' + cc.id; });
 
     var operators = [
         {type: 'equal', optgroup: 'basic'},
@@ -656,16 +736,17 @@ $(function() {
     // Show/hide date format hint based on rules
     function checkForDateFields() {
         var hasDateField = false;
-        
+        var builtinDateIds = ['pubdate', 'timestamp'];
+
         // Check all filter dropdowns for date fields
         $('#builder .rule-filter-container select').each(function() {
             var filterId = $(this).val();
-            if (filterId === 'pubdate' || filterId === 'timestamp') {
+            if (builtinDateIds.indexOf(filterId) !== -1 || customDateFieldIds.indexOf(filterId) !== -1) {
                 hasDateField = true;
                 return false; // break out of each loop
             }
         });
-        
+
         if (hasDateField) {
             $('#date-format-hint').addClass('show');
         } else {
@@ -673,11 +754,45 @@ $(function() {
         }
     }
 
+    // Replace QueryBuilder's native <optgroup> with a styled disabled separator option.
+    // Native optgroup always indents child options and can't be un-indented via CSS.
+    var OPTGROUP_LABELS = {
+        'Identifiers':    '── Identifiers ──',
+        'Custom Columns': '── Custom Columns ──',
+        'Shelves':        '── Shelves ──'
+    };
+    function transformOptgroups() {
+        $('#builder .rule-filter-container select').each(function() {
+            var $select = $(this);
+            $select.find('optgroup').each(function() {
+                var $optgroup = $(this);
+                if ($optgroup.data('transformed')) return;
+                var label = $optgroup.attr('label');
+                var separatorText = OPTGROUP_LABELS[label];
+                if (!separatorText) return;
+                $optgroup.data('transformed', true);
+
+                var $separator = $('<option>')
+                    .attr('disabled', 'disabled')
+                    .addClass('cc-header')
+                    .text(separatorText);
+
+                var $options = $optgroup.children('option').detach();
+                $optgroup.replaceWith($separator.add($options));
+            });
+        });
+    }
+
     $('#builder').queryBuilder({
         plugins: ['bt-tooltip-errors'],
         filters: fields,
         operators: operators,
         rules: rules
+    });
+
+    transformOptgroups();
+    $('#builder').on('afterAddRule.queryBuilder afterUpdateRuleFilter.queryBuilder', function() {
+        setTimeout(transformOptgroups, 0);
     });
     
     // Check for date fields on initialization and after changes
@@ -691,8 +806,10 @@ $(function() {
             var $input = $(this);
             var $rule = $input.closest('.rule-container');
             var filterId = $rule.find('.rule-filter-container select').val();
-            
-            if (filterId === 'pubdate' || filterId === 'timestamp') {
+            var isDateField = filterId === 'pubdate' || filterId === 'timestamp' ||
+                              customDateFieldIds.indexOf(filterId) !== -1;
+
+            if (isDateField) {
                 $input.off('blur.dateValidation').on('blur.dateValidation', function() {
                     var value = $(this).val();
                     if (value && !isValidDate(value)) {
@@ -815,7 +932,8 @@ $(function() {
             data: JSON.stringify(shelfData),
             success: function(response) {
                 if (response.success) {
-                    window.location.href = "{{ url_for('web.index') }}";
+                    var shelfId = response.shelf_id || {{ shelf.id if shelf else 'null' }};
+                    window.location.href = "/magicshelf/" + shelfId;
                 } else {
                     alert('Error saving shelf: ' + (response.message || 'Unknown error'));
                 }

--- a/cps/templates/magic_shelf_edit.html
+++ b/cps/templates/magic_shelf_edit.html
@@ -680,6 +680,10 @@ $(function() {
         });
     });
 
+    // Build a set of public shelf IDs for filtering
+    var publicShelfIds = new Set();
+    shelves.forEach(function(s) { if (s.is_public) publicShelfIds.add(s.id); });
+
     // Append shelf membership fields
     shelves.forEach(function(s) {
         fields.push({
@@ -792,7 +796,12 @@ $(function() {
 
     transformOptgroups();
     $('#builder').on('afterAddRule.queryBuilder afterUpdateRuleFilter.queryBuilder', function() {
-        setTimeout(transformOptgroups, 0);
+        setTimeout(function() {
+            transformOptgroups();
+            if ($('#shelf-is-public').is(':checked')) {
+                applyShelfPublicFilter(true);
+            }
+        }, 0);
     });
     
     // Check for date fields on initialization and after changes
@@ -837,6 +846,52 @@ $(function() {
     setTimeout(function() {
         checkForDateFields();
     }, 100);
+
+    // Shelf public-filter helpers
+    function applyShelfPublicFilter(publicOnly) {
+        $('#builder .rule-filter-container select').each(function() {
+            $(this).find('option').each(function() {
+                var val = $(this).val();
+                if (val && val.startsWith('shelf_')) {
+                    var shelfId = parseInt(val.replace('shelf_', ''), 10);
+                    if (publicOnly && !publicShelfIds.has(shelfId)) {
+                        $(this).prop('disabled', true).css('display', 'none');
+                    } else {
+                        $(this).prop('disabled', false).css('display', '');
+                    }
+                }
+            });
+        });
+    }
+
+    function purgeNonPublicShelfRules() {
+        var toDelete = [];
+        $('#builder .rule-container').each(function() {
+            var filterId = $(this).find('.rule-filter-container select').val();
+            if (filterId && filterId.startsWith('shelf_')) {
+                var shelfId = parseInt(filterId.replace('shelf_', ''), 10);
+                if (!publicShelfIds.has(shelfId)) {
+                    toDelete.push($(this));
+                }
+            }
+        });
+        toDelete.forEach(function($rule) {
+            $rule.find('.rule-actions .btn-danger').first().trigger('click');
+        });
+    }
+
+    $('#shelf-is-public').on('change', function() {
+        var publicOnly = $(this).is(':checked');
+        if (publicOnly) {
+            purgeNonPublicShelfRules();
+        }
+        applyShelfPublicFilter(publicOnly);
+    });
+
+    // Apply initial filter state if the shelf is already public
+    if ($('#shelf-is-public').is(':checked')) {
+        setTimeout(function() { applyShelfPublicFilter(true); }, 150);
+    }
 
     // Preview Rules Functionality
     $('#preview-btn').on('click', function() {
@@ -906,6 +961,24 @@ $(function() {
         if (!shelfName) {
             alert('Please enter a shelf name.');
             return;
+        }
+
+        if ($('#shelf-is-public').is(':checked')) {
+            var nonPublicShelfNames = [];
+            $('#builder .rule-container').each(function() {
+                var filterId = $(this).find('.rule-filter-container select').val();
+                if (filterId && filterId.startsWith('shelf_')) {
+                    var shelfId = parseInt(filterId.replace('shelf_', ''), 10);
+                    if (!publicShelfIds.has(shelfId)) {
+                        var shelfObj = shelves.find(function(s) { return s.id === shelfId; });
+                        nonPublicShelfNames.push(shelfObj ? shelfObj.name : 'Shelf #' + shelfId);
+                    }
+                }
+            });
+            if (nonPublicShelfNames.length > 0) {
+                alert('Cannot save as public: the following shelves used in your rules are private and would not be visible to other users:\n\n• ' + nonPublicShelfNames.join('\n• ') + '\n\nPlease remove those rules or make this shelf private.');
+                return;
+            }
         }
 
         var shelfData = {

--- a/cps/web.py
+++ b/cps/web.py
@@ -1149,11 +1149,18 @@ def create_magic_shelf():
         except:
             language_map[lang.lang_code] = lang.lang_code
 
-    return render_title_template('magic_shelf_edit.html', 
-                                 title=_("Create Magic Shelf"), 
+    custom_columns = magic_shelf.get_custom_columns_for_rules()
+    shelves = magic_shelf.get_shelves_for_rules(current_user.id)
+    identifiers = magic_shelf.get_identifiers_for_rules()
+
+    return render_title_template('magic_shelf_edit.html',
+                                 title=_("Create Magic Shelf"),
                                  page="magic_shelf_create",
                                  allowed_icons=ALLOWED_ICONS,
-                                 languages=language_map)
+                                 languages=language_map,
+                                 custom_columns=custom_columns,
+                                 shelves=shelves,
+                                 identifiers=identifiers)
 
 
 @web.route("/magicshelf/<int:shelf_id>/edit", methods=["GET", "POST"])
@@ -1255,12 +1262,19 @@ def edit_magic_shelf(shelf_id):
         except:
             language_map[lang.lang_code] = lang.lang_code
 
-    return render_title_template('magic_shelf_edit.html', 
-                                 shelf=shelf, 
-                                 title=_("Edit Magic Shelf"), 
+    custom_columns = magic_shelf.get_custom_columns_for_rules()
+    shelves = magic_shelf.get_shelves_for_rules(shelf.user_id)
+    identifiers = magic_shelf.get_identifiers_for_rules()
+
+    return render_title_template('magic_shelf_edit.html',
+                                 shelf=shelf,
+                                 title=_("Edit Magic Shelf"),
                                  page="magic_shelf_edit",
                                  allowed_icons=ALLOWED_ICONS,
-                                 languages=language_map)
+                                 languages=language_map,
+                                 custom_columns=custom_columns,
+                                 shelves=shelves,
+                                 identifiers=identifiers)
 
 
 @web.route("/magicshelf/<int:shelf_id>/duplicate", methods=["POST"])

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -22,6 +22,12 @@ services:
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
+      # DEV SPECIFIC
+      ### Set DEBUG_ON to true to:
+      ###   1. Have Flask/Jinja2 auto-reload templates on each request (no restart needed)
+      ###   2. Watch cps/ for .py changes and auto-restart the server when any Python file changes
+      ### Requres dev specific binds to be set.
+      - DEVELOP_ON=true
     volumes:
       # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings ect.
       - /path/to/config/folder:/config 
@@ -38,6 +44,7 @@ services:
       ### This will let you see your changes in realtime, test ect. You can use build.sh to prepare images with your changes.
       ### For example:
       # /your/dev/env/cps:/app/calibre-web-automated/cps
+      # /your/dev/env/scripts:/app/calibre-web-automated/scripts
 
     ports:
       # Change the first number to change the port you want to access the Web UI, not the second


### PR DESCRIPTION
Allows for the selection of any custom column except composite columns as a magic shelf rule.

Shelves added as option for magic shelves.
If magic shelf is public, only public shelves can be selected

Any identifier found in the library is added as well, using the label defined in the Identifiers class, and the raw ID if it is not set there.

Issue #1237
