### PR TITLE
fix: add optional Google Books API key to resolve rate-limited metadata fetching

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -2348,6 +2348,9 @@ def _configuration_update_helper():
             services.goodreads_support.connect(config.config_goodreads_api_key,
                                                config.config_use_goodreads)
 
+        # Google Books configuration
+        _config_string(to_save, "config_google_api_key")
+
         # Hardcover configuration
         _config_checkbox(to_save, "config_hardcover_sync")
         _config_checkbox(to_save, "config_hardcover_annotations_sync")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -113,6 +113,7 @@ class _Settings(_Base):
 
     config_use_goodreads = Column(Boolean, default=False)
     config_goodreads_api_key = Column(String)
+    config_google_api_key = Column(String)
     config_hardcover_token = Column(String)
     
     config_register_email = Column(Boolean, default=False)

--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 import requests
 
-from cps import logger
+from cps import logger, config
 from cps.isoLanguages import get_lang3, get_language_name
 from cps.services.Metadata import MetaRecord, MetaSourceInfo, Metadata
 
@@ -39,7 +39,11 @@ class Google(Metadata):
                 tokens = [quote(t.encode("utf-8")) for t in title_tokens]
                 query = "+".join(tokens)
             try:
-                results = requests.get(Google.SEARCH_URL + query, timeout=15)
+                api_key = getattr(config, "config_google_api_key", None)
+                url = Google.SEARCH_URL + query
+                if api_key:
+                    url += "&key=" + api_key
+                results = requests.get(url, timeout=15)
                 results.raise_for_status()
             except Exception as e:
                 log.warning(e)

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -234,6 +234,11 @@
     </div>
     {% endif %}
     <div class="form-group">
+      <label for="config_google_api_key">{{_('Google Books API Key')}}</label>
+      <input type="text" class="form-control" id="config_google_api_key" name="config_google_api_key" value="{% if config.config_google_api_key != None %}{{ config.config_google_api_key }}{% endif %}" autocomplete="off">
+      <div class="help-block">{{_('Optional. Improves Google Books metadata search reliability. Get a key at console.cloud.google.com.')}}</div>
+    </div>
+    <div class="form-group">
       <input type="checkbox" id="config_hardcover_sync" name="config_hardcover_sync" data-control="hardcover-settings" {% if config.config_hardcover_sync %}checked{% endif %}>
       <label for="config_hardcover_sync">{{_('Enable Hardcover Sync')}}</label>
     </div>

--- a/tests/unit/test_google_metadata.py
+++ b/tests/unit/test_google_metadata.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2025 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Unit tests for cps/metadata_provider/google.py
+
+Loads google.py directly by file path to avoid the heavy cps app stack.
+Verifies:
+- Searches work without an API key (no key= param in URL)
+- The API key is appended when configured
+- Empty string key is treated as no key
+- HTTP errors return an empty list rather than raising
+"""
+
+import importlib.util
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+from unittest.mock import MagicMock, Mock, patch
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for the cps classes google.py depends on
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _MetaSourceInfo:
+    id: str
+    description: str
+    link: str
+
+
+@dataclass
+class _MetaRecord:
+    id: Union[str, int]
+    title: str
+    authors: List[str]
+    url: str
+    source: _MetaSourceInfo
+    cover: str = ""
+    description: Optional[str] = ""
+    series: Optional[str] = None
+    series_index: Optional[Union[int, float]] = 0
+    identifiers: Dict = field(default_factory=dict)
+    publisher: Optional[str] = None
+    publishedDate: Optional[str] = None
+    rating: Optional[int] = 0
+    languages: Optional[List[str]] = field(default_factory=list)
+    tags: Optional[List[str]] = field(default_factory=list)
+
+
+class _Metadata:
+    def __init__(self):
+        self.active = True
+
+    def get_title_tokens(self, query, strip_joiners=False):
+        return query.split()
+
+
+# ---------------------------------------------------------------------------
+# Build mock modules and inject into sys.modules before loading google.py
+# ---------------------------------------------------------------------------
+
+_mock_log = MagicMock()
+_mock_logger = MagicMock()
+_mock_logger.create.return_value = _mock_log
+
+_mock_config = MagicMock()
+_mock_config.config_google_api_key = None
+
+_mock_cps = MagicMock()
+_mock_cps.logger = _mock_logger
+_mock_cps.config = _mock_config
+
+_mock_services_metadata = MagicMock()
+_mock_services_metadata.MetaRecord = _MetaRecord
+_mock_services_metadata.MetaSourceInfo = _MetaSourceInfo
+_mock_services_metadata.Metadata = _Metadata
+
+_mock_iso = MagicMock()
+_mock_iso.get_lang3 = lambda code: code
+_mock_iso.get_language_name = lambda locale, code: code
+
+sys.modules["cps"] = _mock_cps
+sys.modules["cps.isoLanguages"] = _mock_iso
+sys.modules["cps.services"] = MagicMock()
+sys.modules["cps.services.Metadata"] = _mock_services_metadata
+
+# Load google.py directly by file path, bypassing the package hierarchy
+_google_path = Path(__file__).parent.parent.parent / "cps" / "metadata_provider" / "google.py"
+_spec = importlib.util.spec_from_file_location("cps.metadata_provider.google", _google_path)
+_google_module = importlib.util.module_from_spec(_spec)
+sys.modules["cps.metadata_provider.google"] = _google_module
+_spec.loader.exec_module(_google_module)
+
+Google = _google_module.Google
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+SAMPLE_RESPONSE = {
+    "items": [
+        {
+            "id": "abc123",
+            "volumeInfo": {
+                "title": "Looking for Alaska",
+                "authors": ["John Green"],
+                "description": "A great book.",
+                "publisher": "Dutton Books",
+                "publishedDate": "2005-03-03",
+                "averageRating": 4,
+                "categories": ["Young Adult"],
+                "language": "en",
+                "imageLinks": {"thumbnail": "http://books.google.com/cover.jpg"},
+                "industryIdentifiers": [
+                    {"type": "ISBN_13", "identifier": "9780525475361"}
+                ],
+            },
+        }
+    ]
+}
+
+
+def _make_mock_response(json_data):
+    resp = Mock()
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@patch.object(_google_module, "requests")
+def test_search_without_api_key(mock_requests):
+    """No API key configured → key= must not appear in the request URL."""
+    _mock_config.config_google_api_key = None
+    mock_requests.get.return_value = _make_mock_response(SAMPLE_RESPONSE)
+
+    results = Google().search("Looking for Alaska")
+
+    called_url = mock_requests.get.call_args[0][0]
+    assert "key=" not in called_url
+    assert len(results) == 1
+    assert results[0].title == "Looking for Alaska"
+
+
+@patch.object(_google_module, "requests")
+def test_search_with_api_key(mock_requests):
+    """API key configured → key=<value> must be appended to the request URL."""
+    _mock_config.config_google_api_key = "MY_TEST_KEY"
+    mock_requests.get.return_value = _make_mock_response(SAMPLE_RESPONSE)
+
+    results = Google().search("Looking for Alaska")
+
+    called_url = mock_requests.get.call_args[0][0]
+    assert "key=MY_TEST_KEY" in called_url
+    assert len(results) == 1
+
+
+@patch.object(_google_module, "requests")
+def test_search_with_empty_api_key(mock_requests):
+    """Empty string API key → treated as no key, key= must not appear."""
+    _mock_config.config_google_api_key = ""
+    mock_requests.get.return_value = _make_mock_response(SAMPLE_RESPONSE)
+
+    results = Google().search("Looking for Alaska")
+
+    called_url = mock_requests.get.call_args[0][0]
+    assert "key=" not in called_url
+
+
+@patch.object(_google_module, "requests")
+def test_search_returns_empty_on_http_error(mock_requests):
+    """HTTP errors must return an empty list, not raise."""
+    _mock_config.config_google_api_key = None
+    import requests as req
+    mock_requests.get.side_effect = req.exceptions.HTTPError("429 Too Many Requests")
+
+    results = Google().search("Looking for Alaska")
+
+    assert results == []


### PR DESCRIPTION
Google aggressively rate-limits unauthenticated requests to the Books API, causing empty results for many users. This adds a global config field for a Google Books API key (Admin → Configuration) that is appended to search requests when set, restoring reliable metadata results.

Example log: [2026-05-29 01:08:17,501]  WARN {cps.metadata_provider.google:45} 429 Client Error: Too Many Requests for url: https://www.googleapis.com/books/v1/volumes?q=Harry+Potter

- config_sql.py: add config_google_api_key column (auto-migrated on startup)
- admin.py: persist the new field on config save
- config_edit.html: add API key input with help text near Hardcover/Goodreads
- google.py: append &key= to search URL when key is configured
- tests: add unit tests covering key present, absent, and empty cases

Fixes #993

<img width="350" alt="Screenshot 2026-05-28 at 21-26-35 Calibre-Web Automated edit metadata" src="https://github.com/user-attachments/assets/eda11fa7-5753-45f5-874a-0280ef7501ff" />
<img width="350" alt="Screenshot 2026-05-28 at 21-28-28 Calibre-Web Automated Basic Configuration" src="https://github.com/user-attachments/assets/09c9db11-8712-4344-bf9b-df6a28aad360" />
