### PR TITLE
Status polling cleanup

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -80,7 +80,8 @@ app.config.update(
     REMEMBER_COOKIE_SAMESITE='Strict',
     WTF_CSRF_SSL_STRICT=False,
     SESSION_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "session",
-    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token"
+    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token",
+    TEMPLATES_AUTO_RELOAD=os.environ.get('DEVELOP_ON', 'False').lower() == 'true',
 )
 
 # Fix for running behind reverse proxy (e.g. nginx, apache, caddy, ...)

--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -267,12 +267,10 @@ def create_app():
                 # Explicitly set to None to indicate we checked but found nothing
                 g.flask_httpauth_user = None
 
-        _is_api_request = (
-            request.path.startswith('/duplicates/')
-            or 'application/json' in request.headers.get('Accept', '')
-            or 'application/json' in request.headers.get('Content-Type', '')
+        _is_not_magic_shelf_dependant = (
+            request.path.startswith(('/duplicates/', '/application/', '/static/', '/cover/'))
         )
-        if current_user.is_authenticated and not _is_api_request:
+        if current_user.is_authenticated and not _is_not_magic_shelf_dependant:
             try:
                 # Verify required tables exist before querying
                 from sqlalchemy import inspect
@@ -376,11 +374,18 @@ def create_app():
                 g.magic_shelves_access = []
         else:
             g.magic_shelves_access = []
-        try:
-            calibre_db.ensure_session()
-        except Exception:
-            # Failsafe: let route-level code handle specific DB errors
-            pass
+
+        _is_not_DB_dependant = (
+            request.path.startswith(('/application/', '/static/'))
+        )
+        if current_user.is_authenticated and not _is_not_DB_dependant:
+            try:
+                calibre_db.ensure_session()
+                log.debug(f"DB session check passed for request.path '{request.path}'")
+            except Exception:
+                log.debug("error in DB session check")
+                # Failsafe: let route-level code handle specific DB errors
+                pass
 
     @app.teardown_appcontext
     def shutdown_session(exception=None):

--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -267,7 +267,12 @@ def create_app():
                 # Explicitly set to None to indicate we checked but found nothing
                 g.flask_httpauth_user = None
 
-        if current_user.is_authenticated:
+        _is_api_request = (
+            request.path.startswith('/duplicates/')
+            or 'application/json' in request.headers.get('Accept', '')
+            or 'application/json' in request.headers.get('Content-Type', '')
+        )
+        if current_user.is_authenticated and not _is_api_request:
             try:
                 # Verify required tables exist before querying
                 from sqlalchemy import inspect

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -17,7 +17,7 @@ import time
 from shutil import copyfile
 
 from . import db, calibre_db, logger, ub, csrf, config, helper
-from .services.worker import WorkerThread, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED
+from .services.worker import WorkerThread, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED, STAT_WAITING, STAT_STARTED
 from .admin import admin_required  
 from .usermanagement import login_required_if_no_ano
 from .render_template import render_title_template
@@ -1004,6 +1004,20 @@ def get_common_filters(user_id=None, allow_show_archived=False, return_all_langu
         return true()
 
 
+def _duplicate_scan_in_progress():
+    """Return True if a TaskDuplicateScan is currently queued or running."""
+    try:
+        from cps.tasks.duplicate_scan import TaskDuplicateScan
+        worker = WorkerThread.get_instance()
+        for entry in worker.tasks:
+            queued_task = entry[3]
+            if isinstance(queued_task, TaskDuplicateScan) and queued_task.stat in (STAT_WAITING, STAT_STARTED):
+                return True
+        return False
+    except Exception:
+        return False
+
+
 @duplicates.route("/duplicates/status")
 @login_required_if_no_ano
 @admin_or_edit_required
@@ -1063,9 +1077,10 @@ def get_duplicate_status():
                 'preview': preview,
                 'cached': True,
                 'stale': bool(cache_data.get('scan_pending')),
-                'needs_scan': bool(cache_data.get('scan_pending'))
+                'needs_scan': bool(cache_data.get('scan_pending')),
+                'scan_in_progress': _duplicate_scan_in_progress()
             })
-        
+
         # Cache is missing - DO NOT trigger scan here!
         # This endpoint is called on every page load via duplicate-notifier.js
         # Scans should ONLY be triggered by:
@@ -1073,14 +1088,15 @@ def get_duplicate_status():
         # 2. After ingest operations (via cache invalidation + manual trigger)
         # 3. Scheduled background scans (Phase 2 - not yet implemented)
         log.debug("[cwa-duplicates] Cache invalid/pending in status check, returning empty (no auto-scan)")
-        
+
         return jsonify({
             'success': True,
             'enabled': bool(notifications_enabled),
             'count': 0,
             'preview': [],
             'cached': False,
-            'needs_scan': True  # Frontend can optionally show "scan needed" message
+            'needs_scan': True,  # Frontend can optionally show "scan needed" message
+            'scan_in_progress': _duplicate_scan_in_progress()
         })
     except Exception as e:
         log.error("[cwa-duplicates] Error getting duplicate status: %s", str(e))

--- a/cps/static/js/duplicate-notifier.js
+++ b/cps/static/js/duplicate-notifier.js
@@ -184,7 +184,6 @@
         }
 
         if ((data.needs_scan || data.stale) && !isModalActive()) {
-            startStatusPolling();
             return;
         }
 
@@ -193,9 +192,6 @@
             return;
         }
 
-        if (data.enabled) {
-            startStatusPolling();
-        }
     }
     
     /**
@@ -279,6 +275,9 @@
         }
 
         fetchDuplicateStatus().then(handleStatusResponse);
+        // Poll for ~2.5 minutes after page load to catch in-progress ingest/scan
+        // results. handleStatusResponse no longer restarts polling, so once the
+        // 60-attempt cap is hit polling stays stopped.
         startStatusPolling();
 
         document.addEventListener('visibilitychange', function() {

--- a/cps/static/js/duplicate-notifier.js
+++ b/cps/static/js/duplicate-notifier.js
@@ -41,6 +41,17 @@
     }
     
     /**
+     * Clear the per-session suppression so the next time duplicates appear the
+     * modal pops again. Call this after the user has resolved duplicates on the
+     * duplicates page (delete / merge / dismiss / auto-resolve).
+     */
+    function resetNotificationSuppression() {
+        sessionStorage.removeItem(STORAGE_KEY);
+        sessionStorage.removeItem(LAST_COUNT_KEY);
+        lastPreviewSignature = '';
+    }
+
+    /**
      * Update the duplicate count badge in sidebar
      */
     function updateBadge(count) {
@@ -175,6 +186,14 @@
 
         updateBadge(data.count);
 
+        // Server is the source of truth: if it reports zero duplicates, the
+        // user has none outstanding. Clear any lingering session suppression
+        // so a future re-appearance of duplicates re-pops the modal, even if
+        // our optimistic client-side decrement drifted and never reached 0.
+        if (data.count === 0) {
+            resetNotificationSuppression();
+        }
+
         if (data.count > 0 && data.enabled) {
             showNotificationModal(data);
         }
@@ -286,7 +305,8 @@
     window.CWADuplicates = {
         updateBadge: updateBadge,
         fetchStatus: fetchDuplicateStatus,
-        hideModal: hideNotificationModal
+        hideModal: hideNotificationModal,
+        resetNotificationSuppression: resetNotificationSuppression
     };
     
     // Initialize when DOM is ready

--- a/cps/static/js/duplicate-notifier.js
+++ b/cps/static/js/duplicate-notifier.js
@@ -176,22 +176,17 @@
         updateBadge(data.count);
 
         if (data.count > 0 && data.enabled) {
-            stopStatusPolling();
             showNotificationModal(data);
-            if (isModalActive()) {
-                return;
-            }
         }
 
-        if ((data.needs_scan || data.stale) && !isModalActive()) {
-            return;
-        }
-
-        if (data.count > 0) {
+        // Poll only while the server reports a scan is actually running, so we
+        // pick up the result the moment it finishes. The 60-attempt cap inside
+        // startStatusPolling() is a safety net for hung scans.
+        if (data.scan_in_progress) {
+            startStatusPolling();
+        } else {
             stopStatusPolling();
-            return;
         }
-
     }
     
     /**
@@ -274,11 +269,11 @@
             });
         }
 
+        // One fetch on page load. handleStatusResponse starts polling only if
+        // the server reports a scan is currently in progress; otherwise nothing
+        // further is requested until the page is reloaded or the tab regains
+        // focus (visibilitychange listener below).
         fetchDuplicateStatus().then(handleStatusResponse);
-        // Poll for ~2.5 minutes after page load to catch in-progress ingest/scan
-        // results. handleStatusResponse no longer restarts polling, so once the
-        // 60-attempt cap is hit polling stays stopped.
-        startStatusPolling();
 
         document.addEventListener('visibilitychange', function() {
             if (!document.hidden) {

--- a/cps/static/js/duplicates.js
+++ b/cps/static/js/duplicates.js
@@ -231,6 +231,22 @@ $(document).ready(function() {
             },
             success: function(response) {
                 if (response.success) {
+                    // Optimistically decrement the notifier's "last notified
+                    // count" — one merge resolves one duplicate group. When the
+                    // counter hits 0, also flip the "shown" flag so the next
+                    // time duplicates appear the modal pops again. This avoids
+                    // forcing the server to re-run a scan just to learn the
+                    // post-merge count.
+                    var lastCountRaw = sessionStorage.getItem('cwa_duplicates_last_count');
+                    var lastCount = parseInt(lastCountRaw, 10);
+                    if (Number.isFinite(lastCount)) {
+                        var newCount = Math.max(0, lastCount - 1);
+                        sessionStorage.setItem('cwa_duplicates_last_count', String(newCount));
+                        if (newCount === 0) {
+                            sessionStorage.setItem('cwa_duplicates_notification_shown', 'false');
+                        }
+                    }
+
                     // Close the merge confirmation modal
                     $('#merge_selected_modal').modal('hide');
 
@@ -358,6 +374,12 @@ $(document).ready(function() {
                     // Update badge count in real-time
                     if (window.CWADuplicates && window.CWADuplicates.updateBadge) {
                         window.CWADuplicates.updateBadge(response.count);
+                    }
+
+                    // If that was the last duplicate, clear the notifier
+                    // suppression so future re-appearances re-pop the modal.
+                    if (response.count === 0 && window.CWADuplicates && window.CWADuplicates.resetNotificationSuppression) {
+                        window.CWADuplicates.resetNotificationSuppression();
                     }
                     
                     // Show success message (optional)
@@ -649,4 +671,14 @@ $(document).ready(function() {
     // Initialize
     updateSelectionCount();
     updateBookItemVisuals();
-}); 
+
+    // If the duplicates page rendered with no duplicate groups, the user has
+    // resolved them all (via delete/merge/auto-resolve, each of which reloads
+    // back onto this page). Clear notifier suppression so a future scan that
+    // finds new duplicates re-pops the modal.
+    if ($('.duplicate-group').length === 0 &&
+        window.CWADuplicates &&
+        window.CWADuplicates.resetNotificationSuppression) {
+        window.CWADuplicates.resetNotificationSuppression();
+    }
+});

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -22,6 +22,12 @@ services:
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
+      # DEV SPECIFIC
+      ### Set DEBUG_ON to true to:
+      ###   1. Have Flask/Jinja2 auto-reload templates on each request (no restart needed)
+      ###   2. Watch cps/ for .py changes and auto-restart the server when any Python file changes
+      ### Requres dev specific binds to be set.
+      - DEVELOP_ON=true
     volumes:
       # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings ect.
       - /path/to/config/folder:/config 
@@ -38,6 +44,7 @@ services:
       ### This will let you see your changes in realtime, test ect. You can use build.sh to prepare images with your changes.
       ### For example:
       # /your/dev/env/cps:/app/calibre-web-automated/cps
+      # /your/dev/env/scripts:/app/calibre-web-automated/scripts
 
     ports:
       # Change the first number to change the port you want to access the Web UI, not the second


### PR DESCRIPTION
The status-polling check that is used to detect when a duplicate has been found runs constantly every 2.5 seconds. This is very noisy, and not necessary, since duplicates will only show up when a book has been added.
That could happen after automatic ingest, but we can easily pick that up on a page load.

Changed the polling to only check at each page load for duplicates. Ingesting a book triggers the duplicate check, so it is there waiting at the next page load.

Added logic to reduce the browser stored session duplicate count and notification status, so that after duplicates are cleared, the notification will be shown again if more duplicates show up.