### PR TITLE
Cover stretching options

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -80,7 +80,8 @@ app.config.update(
     REMEMBER_COOKIE_SAMESITE='Strict',
     WTF_CSRF_SSL_STRICT=False,
     SESSION_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "session",
-    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token"
+    REMEMBER_COOKIE_NAME=os.environ.get('COOKIE_PREFIX', "") + "remember_token",
+    TEMPLATES_AUTO_RELOAD=os.environ.get('DEVELOP_ON', 'False').lower() == 'true',
 )
 
 # Fix for running behind reverse proxy (e.g. nginx, apache, caddy, ...)

--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -225,3 +225,32 @@ a#advanced_search > span.hidden-sm {
     margin-bottom: 2rem;
     padding-left: 2rem;
 }
+
+/* "Normalize covers in books pages" user setting (off): preserve natural aspect
+   ratio, only constrain covers to a 150×225 bounding box. The .cover slot
+   stays 225px tall; flex layout anchors short covers at the bottom. */
+body.covers-natural .container-fluid .book .cover {
+    display: flex;
+    align-items: flex-end;
+    justify-content: left;
+}
+/* caliBlur forces the anchor to height: 100% via ID selectors; let it shrink to
+   the image so flex bottom-alignment actually moves the image down. */
+body.covers-natural #books > .cover > a,
+body.covers-natural #books_rand > .cover > a,
+body.covers-natural .book.isotope-item > .cover > a,
+body.covers-natural .container-fluid .book .cover > a {
+    height: auto;
+}
+/* Selectors mirror caliBlur.css's #books / #books_rand / .book.isotope-item rules
+   so we beat their ID-driven specificity. */
+body.covers-natural .container-fluid .book .cover span img,
+body.covers-natural .container-fluid .book .cover img,
+body.covers-natural #books .cover img,
+body.covers-natural #books_rand .cover img,
+body.covers-natural .book.isotope-item .cover img {
+    width: auto !important;
+    height: auto;
+    max-width: 150px;
+    max-height: 225px;
+}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -90,7 +90,7 @@
 
     </script>
   </head>
-  <body class="{{ page }} {{ bodyClass }}{% if g.current_theme == 1 %} blur{% endif %}{% if cwa_settings and cwa_settings.get('enable_mobile_blur') %} allow-mobile-blur{% endif %}" data-text="{{_('Home')}}" data-textback="{{_('Back')}}">
+  <body class="{{ page }} {{ bodyClass }}{% if g.current_theme == 1 %} blur{% endif %}{% if cwa_settings and cwa_settings.get('enable_mobile_blur') %} allow-mobile-blur{% endif %}{% if current_user.get_view_property('books', 'normalize_covers') == false %} covers-natural{% endif %}" data-text="{{_('Home')}}" data-textback="{{_('Back')}}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Static navbar -->
     <div class="navbar navbar-default navbar-static-top" role="navigation">

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -274,6 +274,12 @@
           <option value="1" selected>caliBlur (Dark)</option>
         </select>
       </div>
+
+      <div style="margin-top: 20px;">
+        <input type="checkbox" id="normalize_covers" name="normalize_covers" {% if normalize_covers %}checked{% endif %} style="accent-color: var(--color-secondary);">
+        <label for="normalize_covers">{{_('Normalize covers in books pages')}}</label>
+        <p class="cwa-settings-tip">{{_('When enabled, all book covers are scaled to a uniform 150 × 225 size by stretching one dimension. When disabled, covers keep their natural aspect ratio and are only constrained to a maximum width of 150 and maximum height of 225.')}}</p>
+      </div>
     </div>
     {% else %}
     <div class="settings-container" style="max-width: none; margin-inline: 0rem;">

--- a/cps/web.py
+++ b/cps/web.py
@@ -1612,6 +1612,12 @@ def publisher_list():
         abort(404)
 
 
+def _get_normalize_covers(user):
+    """User preference for normalizing book-cover sizes; defaults to True when unset."""
+    value = user.get_view_property('books', 'normalize_covers')
+    return True if value is None else bool(value)
+
+
 @web.route("/series")
 @login_required_if_no_ano
 def series_list():
@@ -2532,6 +2538,14 @@ def change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_sta
                     current_user.view_settings.pop('opds', None)
                 flag_modified(current_user, "view_settings")
 
+        # Normalize covers in books pages (checkbox: absent = unchecked = False)
+        if current_user.view_settings is None:
+            current_user.view_settings = {}
+        current_user.view_settings.setdefault('books', {})['normalize_covers'] = (
+            to_save.get("normalize_covers") == "on"
+        )
+        flag_modified(current_user, "view_settings")
+
         # Magic shelf order settings
         magic_shelf_order_raw = to_save.get("magic_shelf_order", "").strip()
         magic_shelf_order_mode = to_save.get("magic_shelf_order_mode", magic_shelf.DEFAULT_MAGIC_SHELF_ORDER_MODE)
@@ -2643,6 +2657,7 @@ def change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_sta
                                      magic_shelf_order_string=magic_shelf_order_string,
                                      magic_shelf_order_labels=magic_shelf_order_labels,
                                      magic_shelf_order_mode=magic_shelf_order_mode,
+                                     normalize_covers=_get_normalize_covers(current_user),
                                      title=_(f"{current_user.name.capitalize()}'s Profile", name=current_user.name),
                                      page="me",
                                      kobo_support=kobo_support,
@@ -2758,6 +2773,7 @@ def profile():
                                  languages=languages,
                                  content=current_user,
                                  config=config,
+                                 normalize_covers=_get_normalize_covers(current_user),
                                  kobo_support=kobo_support,
                                  hardcover_support=hardcover_support,
                                  system_shelf_templates=system_shelf_templates,

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -22,6 +22,12 @@ services:
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
+      # DEV SPECIFIC
+      ### Set DEBUG_ON to true to:
+      ###   1. Have Flask/Jinja2 auto-reload templates on each request (no restart needed)
+      ###   2. Watch cps/ for .py changes and auto-restart the server when any Python file changes
+      ### Requres dev specific binds to be set.
+      - DEVELOP_ON=true
     volumes:
       # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings ect.
       - /path/to/config/folder:/config 
@@ -38,6 +44,7 @@ services:
       ### This will let you see your changes in realtime, test ect. You can use build.sh to prepare images with your changes.
       ### For example:
       # /your/dev/env/cps:/app/calibre-web-automated/cps
+      # /your/dev/env/scripts:/app/calibre-web-automated/scripts
 
     ports:
       # Change the first number to change the port you want to access the Web UI, not the second


### PR DESCRIPTION
Adding user option to not stretch the book cover on book view pages. Defaults to stretching on, so behavior stays as-is unless the stretch to fit option is turned off.