### PR TITLE
fix(mail): resolve TypeError mismatch during eReader task execution

### DIFF
--- a/cps/tasks/mail.py
+++ b/cps/tasks/mail.py
@@ -167,7 +167,22 @@ class TaskEmail(CalibreTask):
             elif hasattr(e, "message"):
                 text = e.message
             elif hasattr(e, "args"):
-                text = '\n'.join(e.args)
+                if isinstance(e, smtplib.SMTPRecipientsRefused):
+                    refused = []
+                    for recipient, status in e.recipients.items():
+                        code, msg = status
+                        if isinstance(msg, bytes):
+                            msg = msg.decode('utf-8', errors='ignore')
+                        refused.append(f"{recipient}: {code} {msg}")
+                    text = ", ".join(refused)
+                else:
+                    processed_args = []
+                    for arg in e.args:
+                        if isinstance(arg, bytes):
+                            processed_args.append(arg.decode('utf-8', errors='ignore'))
+                        else:
+                            processed_args.append(str(arg))
+                    text = '\n'.join(processed_args)
             else:
                 text = ''
             self._handleError('Smtplib Error sending e-mail: {}'.format(text))


### PR DESCRIPTION
Resolves an unhandled exception inside the background task runner where ad-hoc or alternative recipient routing configurations passed structured dictionaries into string compilation and join blocks instead of raw text strings.  This would cause some "Send to eReader" attempts to fail with a "sequence item 0: expected str instance, dict found"
<img width="1320" height="41" alt="SCR-20260621-cmzp" src="https://github.com/user-attachments/assets/492c381c-59f3-4e7c-98ec-765f08b9a717" />
