### PR TITLE
Allow kobo without account to sync correctly

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -376,7 +376,7 @@ def HandleSyncRequest():
             .all()
 
         new_tags_last_modified = sync_token.tags_last_modified
-            
+
         for shelf in magic_shelves:
             books, _ = magic_shelf.get_books_for_magic_shelf(
                 shelf.id, page=1, page_size=1000
@@ -1173,6 +1173,7 @@ def HandleBookDeletionRequest(book_uuid):
 @csrf.exempt
 @kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET", "POST"])
 @kobo.route("/v1/library/<dummy>/preview", methods=["POST"])
+@kobo.route("/v1/user/add-device", methods=["POST"])
 def HandleUnimplementedRequest(dummy=None):
     log.debug(f"Unimplemented Library Request received: %s (%s)",
               request.base_url,
@@ -1322,7 +1323,6 @@ def HandleOidcDiscovery():
 def HandleOauthRequest(subpath=None):
     log.debug("Kobo OAuth request: %s", request.path)
     return make_calibre_web_oauth_response()
-
 
 @kobo.route("/v1/initialization")
 @requires_kobo_auth

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1272,7 +1272,7 @@ def make_calibre_web_oauth_response():
         "token_type": "Bearer",
         "expires_in": 3600,
         "scope": content.get("scope", ""),
-        "user_id": content.get("user_id", ""),
+        "user_id": str(current_user.id) if current_user and not current_user.is_anonymous else content.get("user_id", ""),
         # Include legacy field names used by some Kobo requests
         "AccessToken": access_token,
         "RefreshToken": refresh_token,
@@ -1294,8 +1294,28 @@ def HandleAuthRequest():
     return make_calibre_web_auth_response()
 
 
+
+@csrf.exempt
+@kobo.route('/oauth/.well-known/openid-configuration', methods=['GET', 'POST'])
+@requires_kobo_auth
+def HandleOidcDiscovery():
+    base_url = url_for("kobo.HandleOauthRequest",
+                       auth_token=get_auth_token(),
+                       _external=True).rsplit("/oauth", 1)[0]
+    payload = {
+        'issuer': base_url,
+        'authorization_endpoint': base_url + '/oauth/authorize',
+        'token_endpoint': base_url + '/oauth/token',
+        'userinfo_endpoint': base_url + '/oauth/userinfo',
+        'response_types_supported': ['code'],
+        'subject_types_supported': ['public'],
+        'id_token_signing_alg_values_supported': ['RS256'],
+    }
+    return make_response(jsonify(payload))
+
 @csrf.exempt
 @kobo.route("/oauth/token", methods=["GET", "POST"])
+@kobo.route("/oauth/authorize", methods=["GET", "POST"])
 @kobo.route("/oauth/refresh", methods=["GET", "POST"])
 @kobo.route("/oauth/<path:subpath>", methods=["GET", "POST"])
 @requires_kobo_auth


### PR DESCRIPTION
Finally got around to playing with a freshly factory reset Kobo and this patch (which seems to have been scrubbed from the original [owner](https://github.com/mihneabulu)).

I needed the `/v1/user/add-device` route to return 200 on a POST so that's done there and now my fresh device setup following the article below successfully syncs the first time :)
https://jacobalbano.com/2021/06/24/setting-up-a-kobo-without-logging-in/

Happy to make any other required changes, cheers.