### PR TITLE
Fix: Restore Calibre Database button submits wrong form (nested <form> bug)

### DIFF
--- a/cps/templates/config_db.html
+++ b/cps/templates/config_db.html
@@ -110,6 +110,7 @@
       <div id="db_submit" name="submit" class="btn btn-default">{{_('Save')}}</div>
       <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-default">{{_('Cancel')}}</a>
     </div>
+  </form>
 
     <hr style="margin: 3rem 0;">
 
@@ -122,7 +123,6 @@
       </form>
     </div>
     </div>
-  </form>
 </div>
 {% endblock %}
 {% block modal %}


### PR DESCRIPTION
## Bug

The "Restore Calibre Database (Last Resort)" button on the DB Configuration
page (`cps/templates/config_db.html`) does nothing when clicked, with no
error shown anywhere.

## Root cause

The restore form (`action="{{ url_for('admin.restore_calibre_db') }}"`) is
nested inside the outer DB Configuration form
(`action="{{ url_for('admin.db_configuration') }}"`), which spans nearly
the whole page. HTML does not allow nested `<form>` elements — per the
HTML5 parsing spec, when a browser encounters a `<form>` start tag while
already inside an open form, it drops the inner tag but keeps its children
(here: the CSRF hidden input and the submit button) as part of the *outer*
form.

The practical effect: clicking "Restore Calibre Database" submits the
outer `db_configuration` form instead — silently re-saving
`config_calibre_dir`/`config_calibre_split_dir`, doing nothing else, and
giving no indication anything went wrong.

Confirmed via a browser HAR capture + container logs: every click POSTs to
`/admin/dbconfig`, never once to `/admin/restore_calibre_db`.

## Fix

Close the outer `<form>` right after the Save/Cancel row, before the
Restore section begins, instead of having it wrap the entire page
including the Restore section. The `settings-container` div still wraps
both sections visually — only the `<form>` boundary moves. No other
markup, styling, JS, or route logic changed. Diff is a single line moved.

## Verification

- Confirmed the bug is real by capturing a HAR of a real click: POST to
  `/admin/dbconfig` with only the basic-config fields, and
  `/config/backup` (which the restore is documented to create) never
  appears.
- Confirmed `/admin/restore_calibre_db` itself works correctly when hit
  directly (bypassing the broken button): it rebuilt `metadata.db` from
  ~130 books' `.opf` files successfully, with a clean post-restore
  `calibredb check_library`.
- After this fix, the button submits only the inner form's fields
  (`csrf_token`) to `/admin/restore_calibre_db` — the same request shape
  already verified to work.
- Checked div/form balance in the modified template (`grep` count) to
  confirm no other markup broke.

I wasn't able to run the full app locally to click through it end-to-end
in a browser against this exact build, so please sanity-check the
rendered page, but this is a minimal, mechanical fix (move one `</form>`
tag) with no behavioral changes intended beyond correcting which form the
button belongs to.