### PR TITLE
opds.py: request a cacheable resolution for cover images

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -883,10 +883,7 @@ def get_book_cover_internal(book, resolution=None):
     if book and book.has_cover:
 
         # Send the book cover thumbnail if it exists in cache
-        # (resolution=0 is COVER_THUMBNAIL_ORIGINAL -- a plain truthiness check
-        # treats that as "no resolution requested" and skips the cache/on-demand
-        # generation entirely, so this must be `is not None`)
-        if resolution is not None:
+        if resolution:
             cache = fs.FileSystem()
             # Check for both webp and jpg thumbnails, generate missing ones
             webp_thumb = get_book_cover_thumbnail_by_format(book, resolution, 'webp')

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -883,7 +883,10 @@ def get_book_cover_internal(book, resolution=None):
     if book and book.has_cover:
 
         # Send the book cover thumbnail if it exists in cache
-        if resolution:
+        # (resolution=0 is COVER_THUMBNAIL_ORIGINAL -- a plain truthiness check
+        # treats that as "no resolution requested" and skips the cache/on-demand
+        # generation entirely, so this must be `is not None`)
+        if resolution is not None:
             cache = fs.FileSystem()
             # Check for both webp and jpg thumbnails, generate missing ones
             webp_thumb = get_book_cover_thumbnail_by_format(book, resolution, 'webp')

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -712,13 +712,25 @@ def get_database_stats():
     return Response(json.dumps(stat), mimetype="application/json")
 
 
-@opds.route("/opds/thumb_240_240/<book_id>")
-@opds.route("/opds/cover_240_240/<book_id>")
-@opds.route("/opds/cover_90_90/<book_id>")
 @opds.route("/opds/cover/<book_id>")
 @requires_basic_auth_if_no_ano
 def feed_get_cover(book_id):
-    return get_book_cover(book_id)
+    # feed.xml / json.txt link every book's cover AND thumbnail rel to this one
+    # route -- request a cached resolution instead of the uncached original.
+    return get_book_cover(book_id, constants.COVER_THUMBNAIL_LARGE)
+
+
+@opds.route("/opds/thumb_240_240/<book_id>")
+@opds.route("/opds/cover_240_240/<book_id>")
+@requires_basic_auth_if_no_ano
+def feed_get_cover_240(book_id):
+    return get_book_cover(book_id, constants.COVER_THUMBNAIL_MEDIUM)
+
+
+@opds.route("/opds/cover_90_90/<book_id>")
+@requires_basic_auth_if_no_ano
+def feed_get_cover_90(book_id):
+    return get_book_cover(book_id, constants.COVER_THUMBNAIL_SMALL)
 
 
 @opds.route("/opds/readbooks")

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -712,25 +712,15 @@ def get_database_stats():
     return Response(json.dumps(stat), mimetype="application/json")
 
 
+@opds.route("/opds/thumb_240_240/<book_id>")
+@opds.route("/opds/cover_240_240/<book_id>")
+@opds.route("/opds/cover_90_90/<book_id>")
 @opds.route("/opds/cover/<book_id>")
 @requires_basic_auth_if_no_ano
 def feed_get_cover(book_id):
     # feed.xml / json.txt link every book's cover AND thumbnail rel to this one
     # route -- request a cached resolution instead of the uncached original.
     return get_book_cover(book_id, constants.COVER_THUMBNAIL_LARGE)
-
-
-@opds.route("/opds/thumb_240_240/<book_id>")
-@opds.route("/opds/cover_240_240/<book_id>")
-@requires_basic_auth_if_no_ano
-def feed_get_cover_240(book_id):
-    return get_book_cover(book_id, constants.COVER_THUMBNAIL_MEDIUM)
-
-
-@opds.route("/opds/cover_90_90/<book_id>")
-@requires_basic_auth_if_no_ano
-def feed_get_cover_90(book_id):
-    return get_book_cover(book_id, constants.COVER_THUMBNAIL_SMALL)
 
 
 @opds.route("/opds/readbooks")

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -719,8 +719,12 @@ def get_database_stats():
 @requires_basic_auth_if_no_ano
 def feed_get_cover(book_id):
     # feed.xml / json.txt link every book's cover AND thumbnail rel to this one
-    # route -- request a cached resolution instead of the uncached original.
-    return get_book_cover(book_id, constants.COVER_THUMBNAIL_LARGE)
+    # route, and it's used for every book in every catalog page (i.e. mostly
+    # list/grid browsing, not single-cover detail views) -- MEDIUM is truthy
+    # (so it already hits the cache/on-demand generation in
+    # get_book_cover_internal) and keeps per-book cost down for that common
+    # case, while still being plenty for the occasional single-cover view.
+    return get_book_cover(book_id, constants.COVER_THUMBNAIL_MEDIUM)
 
 
 @opds.route("/opds/readbooks")

--- a/tests/unit/test_opds.py
+++ b/tests/unit/test_opds.py
@@ -55,3 +55,11 @@ class TestFeedGetCover:
         called_resolution = mock_get_book_cover.call_args.args[1]
         assert called_resolution, "resolution passed to get_book_cover must be truthy"
         assert called_resolution != constants.COVER_THUMBNAIL_ORIGINAL
+
+
+# ============================================================================
+# Test Markers
+# ============================================================================
+
+# Mark all tests in this module as unit tests
+pytestmark = pytest.mark.unit

--- a/tests/unit/test_opds.py
+++ b/tests/unit/test_opds.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Unit tests for cps/opds.py
+
+Tests cover the OPDS cover-image route contract:
+- feed_get_cover() must request a cacheable (non-original) thumbnail
+  resolution. feed.xml/json.txt reuse this single route for every book's
+  "image" and "image/thumbnail" rel on every catalog page, so if it ever
+  regresses to requesting no resolution (or COVER_THUMBNAIL_ORIGINAL, which
+  is falsy), get_book_cover_internal()'s `if resolution:` check silently
+  skips the thumbnail cache/on-demand generation and every OPDS cover
+  request falls back to reading the raw cover.jpg from disk every time.
+
+Note: calls feed_get_cover.__wrapped__ directly to bypass the
+@requires_basic_auth_if_no_ano decorator, which needs a live Flask request
+context. This is a unit test of the routing contract, not an auth test.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from cps import constants
+from cps.opds import feed_get_cover
+
+
+class TestFeedGetCover:
+    """Test that OPDS cover requests use a cacheable resolution"""
+
+    @patch('cps.opds.get_book_cover')
+    def test_requests_medium_resolution(self, mock_get_book_cover):
+        """feed_get_cover must pass COVER_THUMBNAIL_MEDIUM through to
+        get_book_cover so the request actually reaches the thumbnail
+        cache/on-demand generation path instead of always serving the
+        uncached original file."""
+        mock_get_book_cover.return_value = "sentinel-response"
+
+        result = feed_get_cover.__wrapped__("42")
+
+        mock_get_book_cover.assert_called_once_with("42", constants.COVER_THUMBNAIL_MEDIUM)
+        assert result == "sentinel-response"
+
+    @patch('cps.opds.get_book_cover')
+    def test_resolution_argument_is_truthy(self, mock_get_book_cover):
+        """Regression guard: COVER_THUMBNAIL_ORIGINAL is 0, which is falsy
+        and is silently treated as "no resolution requested" by
+        get_book_cover_internal()'s `if resolution:` check. Whatever
+        resolution feed_get_cover passes must stay nonzero, or OPDS covers
+        silently go back to being served uncached on every request."""
+        feed_get_cover.__wrapped__("1")
+
+        called_resolution = mock_get_book_cover.call_args.args[1]
+        assert called_resolution, "resolution passed to get_book_cover must be truthy"
+        assert called_resolution != constants.COVER_THUMBNAIL_ORIGINAL


### PR DESCRIPTION
## Problem

`feed_get_cover()` in `cps/opds.py` (backing all four `/opds/cover*` routes) calls
`get_book_cover(book_id)` with no resolution argument, which defaults to `None`.
Inside `get_book_cover_internal()` (`cps/helper.py`), the thumbnail cache / on-demand
generation is only consulted when `if resolution:` is truthy -- `None` is falsy, so
every OPDS cover request always falls straight through to serving the raw `cover.jpg`
from disk, uncached, every single time.

`feed.xml`/`json.txt` link every book's cover *and* thumbnail rel to this one route,
so this hits on every book in every OPDS catalog page, regardless of how often
"Refresh Thumbnail Cache" is run.

## Fix

`opds.py`: pass `constants.COVER_THUMBNAIL_MEDIUM` instead of nothing.
`COVER_THUMBNAIL_SMALL/MEDIUM/LARGE` (`1`/`2`/`4`) are all truthy, so this already
engages the existing `if resolution:` cache/on-demand-generation path in
`helper.py` -- no change needed there.

`MEDIUM` over `LARGE`: since this one route serves both the `image` and
`image/thumbnail` rels for every book in every catalog page, the dominant real-world
call pattern is list/grid browsing (many covers per page) rather than single-cover
detail views. `MEDIUM` keeps per-book generation/cache/transfer cost down for that
common case while remaining plenty of resolution for the occasional single-cover
view.

No change to the routes' URLs or behavior on a cache miss -- falls through to the
exact same uncached read as before, so this can only help, not regress.

Note: `cover_90_90`/`cover_240_240`/`thumb_240_240` aren't referenced by
calibre-web's own feed generation (only the plain `/opds/cover/<id>` route is, per
`feed.xml`/`json.txt`), so they share this same handler/resolution here rather than
each getting a distinct size. If any OPDS client is found to hit those routes
directly and would benefit from a smaller size, splitting them into separate
handlers requesting `COVER_THUMBNAIL_SMALL` individually would be an easy, low-risk
follow-up.

## Testing

- `tests/unit/test_opds.py` (new): asserts `feed_get_cover` calls `get_book_cover`
  with `constants.COVER_THUMBNAIL_MEDIUM`, plus a regression guard that the passed
  resolution stays truthy (i.e. never regresses back to `None` or
  `COVER_THUMBNAIL_ORIGINAL`, both of which silently bypass the cache). Calls
  `feed_get_cover.__wrapped__` directly to bypass the `@requires_basic_auth_if_no_ano`
  decorator (needs a live Flask request context) -- a unit test of the routing
  contract, not an auth test.
- Confirmed via CI: 232 passed (up from 230 on `main`), the +2 expected from this
  file, `pytest -m "smoke or unit"`.
- `python3 -m py_compile cps/opds.py` passes.