### PR TITLE
Fix uncached cover images on shelf reorder, detail, and audio player pages

### DIFF
--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -4,7 +4,7 @@
     <meta property="og:title" content="{{ entry.title|truncate(35) }}" />
     {% if entry.comments|length > 0 and entry.comments[0].text|length > 0 %}
       <meta property="og:description" content="{{ entry.comments[0].text|striptags|truncate(65) }}" />
-      <meta property="og:image" content="{{url_for('web.get_cover', book_id=entry.id, resolution='og', c=entry|last_modified)}}" />
+      <meta property="og:image" content="{{url_for('web.get_cover', book_id=entry.id, resolution='lg', c=entry|last_modified)}}" />
     {% endif %}
     <style>
         .modal-card {
@@ -480,7 +480,7 @@
             <div class="book-detail-main">
                 <div class="book-detail-cover cover">
                 <img id="detailcover" title="{{ entry.title }}"
-                     src="{{ url_for('web.get_cover', book_id=entry.id, resolution='og', c=entry|last_modified) }}"/>
+                     src="{{ url_for('web.get_cover', book_id=entry.id, resolution='lg', c=entry|last_modified) }}"/>
             </div>
                     <div class="book-detail-meta">
                         <div class="book-detail-actions">

--- a/cps/templates/listenmp3.html
+++ b/cps/templates/listenmp3.html
@@ -34,7 +34,7 @@
       
     </div>
     <div class="col-sm-6 col-lg-6 book-meta" style="margin-bottom: 2%;">
-      <img id="detailcover" title="{{entry.title}}" src="{{url_for('web.get_cover', book_id=entry.id, resolution='og', c=entry|last_modified)}}" style="float: right; margin-top: 20px"/>
+      <img id="detailcover" title="{{entry.title}}" src="{{url_for('web.get_cover', book_id=entry.id, resolution='lg', c=entry|last_modified)}}" style="float: right; margin-top: 20px"/>
       <h2 id="title">{{entry.title}}</h2>
       <p class="author">
           {% for author in entry.ordered_authors %}

--- a/cps/templates/shelf_order.html
+++ b/cps/templates/shelf_order.html
@@ -10,7 +10,7 @@
             <div class="row">
               <div class="col-lg-2 col-sm-4 hidden-xs">
                 {% if entry['visible'] %}
-                  <img title="{{entry['Books']['title']}}" class="cover-height" src="{{ url_for('web.get_cover', book_id=entry['Books']['id']) }}">
+                  <img title="{{entry['Books']['title']}}" class="cover-height" src="{{ url_for('web.get_cover', book_id=entry['Books']['id'], resolution='sm') }}">
                 {% else %}
                   <img title="{{entry['Books']['title']}}" class="cover-height" src="{{ url_for('static', filename='generic_cover.svg') }}">
                 {% endif %}

--- a/tests/unit/test_cover_template_resolutions.py
+++ b/tests/unit/test_cover_template_resolutions.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Regression guard for templates that render a single book cover without a
+`srcset` fallback.
+
+cps/templates/image.html's book_cover macro (used by the main library grid,
+search, author, and shelf views) pairs a `resolution='og'` <img src> with a
+`srcset` offering `sm`/`md`/`lg` -- browsers that support srcset (virtually
+all of them) never fetch the src fallback at all, so `og` there is mostly
+harmless.
+
+The templates covered here have no such srcset, so if they ever regress to
+requesting `resolution='og'` (COVER_THUMBNAIL_ORIGINAL, which is falsy) or
+no resolution at all, every render hits get_book_cover_internal()'s
+`if resolution:` check and falls back to serving the raw, uncached cover.jpg
+on every single load. Checked as plain text rather than rendered -- no
+Flask app/DB context needed, matching this project's other file-content
+based unit tests.
+
+Note: cps/templates/book_edit.html deliberately keeps `resolution='og'`
+(see its own "Always use full-sized image for the book edit page" comment)
+and is intentionally not covered here.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATES_DIR = Path(__file__).parent.parent.parent / "cps" / "templates"
+
+# path -> (line-matching substring, required resolution)
+EXPECTATIONS = {
+    "shelf_order.html": ("entry['Books']['id']", "sm"),
+    "listenmp3.html": ("id=\"detailcover\"", "lg"),
+}
+
+
+class TestCoverTemplateResolutions:
+    """Guard against these templates regressing to an uncached cover request"""
+
+    @pytest.mark.parametrize("filename,expected", EXPECTATIONS.items())
+    def test_get_cover_call_requests_a_cacheable_resolution(self, filename, expected):
+        marker, resolution = expected
+        content = (TEMPLATES_DIR / filename).read_text(encoding="utf-8")
+
+        matching_lines = [line for line in content.splitlines() if marker in line and "web.get_cover" in line]
+        assert matching_lines, f"expected a web.get_cover call containing {marker!r} in {filename}"
+
+        for line in matching_lines:
+            assert f"resolution='{resolution}'" in line, (
+                f"{filename}: expected resolution='{resolution}', got: {line.strip()}"
+            )
+
+    def test_detail_html_requests_large_resolution(self):
+        content = (TEMPLATES_DIR / "detail.html").read_text(encoding="utf-8")
+
+        og_image_lines = [line for line in content.splitlines() if "og:image" in line]
+        cover_img_lines = [
+            line for line in content.splitlines()
+            if "web.get_cover" in line and "book-detail-cover" not in line and re.search(r'src="', line)
+        ]
+
+        assert og_image_lines, "expected an og:image meta tag in detail.html"
+        assert any("resolution='lg'" in line for line in og_image_lines), (
+            "detail.html og:image meta tag should request resolution='lg'"
+        )
+
+        assert cover_img_lines, "expected a displayed cover <img> in detail.html"
+        assert any("resolution='lg'" in line for line in cover_img_lines), (
+            "detail.html displayed cover <img> should request resolution='lg'"
+        )
+
+    def test_book_edit_html_intentionally_keeps_original_resolution(self):
+        """book_edit.html has an explicit comment choosing full-sized/original
+        images on purpose -- this test documents that choice so a future
+        cleanup pass doesn't "fix" it by mistake."""
+        content = (TEMPLATES_DIR / "book_edit.html").read_text(encoding="utf-8")
+
+        assert "Always use full-sized image for the book edit page" in content
+        assert "resolution='og'" in content
+
+
+# ============================================================================
+# Test Markers
+# ============================================================================
+
+# Mark all tests in this module as unit tests
+pytestmark = pytest.mark.unit


### PR DESCRIPTION
Fixes #1034.

Web UI counterpart to crocodilestick/Calibre-Web-Automated#1447, which fixed the
same underlying bug for OPDS. Same root cause (`get_book_cover_internal()`'s
`if resolution:` check silently treating a falsy resolution as "not requested"),
different call sites -- that PR covers the OPDS cover routes, this one covers the
web UI templates that hit the same problem with no `srcset` fallback to mask it.

## Problem

`cps/web.py`'s `get_cover` route maps `resolution='og'` to
`constants.COVER_THUMBNAIL_ORIGINAL` (`0`). `get_book_cover_internal()`'s
`if resolution:` check treats `0` as falsy -- same as no resolution at all --
and skips the thumbnail cache/on-demand generation entirely, falling back to
reading the raw `cover.jpg` from disk on every single request.

Three templates hit this with nothing masking it:
- `shelf_order.html`: no resolution argument at all (defaults to `None`)
- `detail.html`: `resolution='og'`, both the `og:image` meta tag and the
  displayed cover
- `listenmp3.html`: `resolution='og'`

`image.html`'s `book_cover` macro (used by the main library grid, search,
author, and shelf views -- probably what most people mean by "library page")
also requests `resolution='og'`, but pairs it with a `srcset` offering
`sm`/`md`/`lg`. Browsers that support `srcset` (virtually all of them) pick a
density-matched candidate from there and never fetch the plain `src`
fallback at all, so that one's left alone here -- it's a much smaller,
partially-masked instance of the same bug, not an unmitigated one.

`book_edit.html` also requests `resolution='og'`, but has its own explicit
`<!-- Always use full-sized image for the book edit page -->` comment --
that's a deliberate choice (viewing the true source file while editing
metadata/cover), not a bug, so it's untouched. Added a test that documents
this so a future cleanup pass doesn't "fix" it by mistake.

## Fix

- `shelf_order.html` -> `resolution='sm'` (renders many small covers in a
  reorderable list, similar reasoning to the `MEDIUM` choice in the earlier
  OPDS fix)
- `detail.html` / `listenmp3.htmlrenders one
  cover as the primary visual element on the page)

No change to `helper.py` -- `SMALL`/`MEDIUM`/`LARGE` (`1`/`2`/`4`) are all
truthy, so they already work fineolution:`
check.

## Testing

- `tests/unit/test_cover_template_resolutions.py` (new): checks the raw
  template text for the expected hanged line,
  plus a test asserting `book_edit.html`'s original-resolution choice stays
  intact. No Flask/DB context neeject's other
  file-content-based unit tests -- template rendering itself isn't covered
  by this project's unit test laypy`, which
  only tests filter functions, not rendering).
- `python3 -m py_compile` on the e logic was
  hand-verified by replaying the test's string-matching against the actual
  files before committing.