### PR TITLE
French (fr): complete translation — 62 untranslated strings, 89 fuzzy resolved

### DIFF
--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -20,14 +20,15 @@
 # Thomas <thovi98@gmail.com>, 2021
 # DeadBone <deadbone2000@yahoo.fr>, 2025
 # Tex <tex@grosist.fr>, 2025
+# zdeubeu <laurent@zdeub.eu>, 2026
 msgid ""
 msgstr ""
 "Project-Id-Version: Calibre-Web Automated\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
 "POT-Creation-Date: 2026-07-05 13:13+0000\n"
-"PO-Revision-Date: 2025-11-17 21:51+0100\n"
-"Last-Translator: Tex <tex@grosist.fr>\n"
+"PO-Revision-Date: 2026-07-30 06:58+0200\n"
+"Last-Translator: zdeubeu <laurent@zdeub.eu>\n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -44,6 +45,8 @@ msgstr "Statistiques"
 #: cps/admin.py:128
 msgid "Calibre database unavailable. Please reconfigure the library path."
 msgstr ""
+"Base de données Calibre indisponible. Veuillez reconfigurer le chemin de "
+"la bibliothèque."
 
 #: cps/admin.py:180
 msgid "Server restarted, please reload page."
@@ -112,12 +115,12 @@ msgstr "Correspond à %(action)s"
 
 #: cps/admin.py:439
 msgid "No pending matches to reject"
-msgstr ""
+msgstr "Aucune correspondance en attente à rejeter"
 
 #: cps/admin.py:445
 #, python-format
 msgid "Rejected %(count)s match(es)"
-msgstr ""
+msgstr "%(count)s correspondance(s) rejetée(s)"
 
 #: cps/admin.py:482
 #, python-brace-format
@@ -485,7 +488,6 @@ msgid "Settings DB is not Writeable"
 msgstr "La base de données des paramètres n'est pas accessible en écriture"
 
 #: cps/admin.py:1843 cps/opds.py:199 cps/web.py:2604 cps/web.py:2729
-#, fuzzy
 msgid "title"
 msgstr "Titre"
 
@@ -682,7 +684,6 @@ msgid "User '%(user)s' created"
 msgstr "Utilisateur '%(user)s' créé"
 
 #: cps/admin.py:2554
-#, fuzzy
 msgid "Oops! An account already exists for this Email. or name."
 msgstr "Oups ! Un compte existe déjà pour cette adresse e-mail ou ce nom."
 
@@ -731,7 +732,6 @@ msgstr ""
 "Echec de la connexion: Le serveur a retourné le code de status %(code)s"
 
 #: cps/admin.py:2895
-#, fuzzy
 msgid ""
 "Connection failed: Could not connect to server. Check the URL and network "
 "connectivity."
@@ -740,7 +740,6 @@ msgstr ""
 "l'URL et la connexion réseau."
 
 #: cps/admin.py:2897
-#, fuzzy
 msgid ""
 "Connection failed: Request timed out. The server may be slow or unreachable."
 msgstr ""
@@ -748,7 +747,6 @@ msgstr ""
 "lent ou inaccessible."
 
 #: cps/admin.py:2899
-#, fuzzy
 msgid ""
 "Connection failed: Server returned invalid JSON. This may not be an OIDC "
 "endpoint."
@@ -757,12 +755,12 @@ msgstr ""
 "s'agit peut-être pas d'un point de terminaison OIDC."
 
 #: cps/admin.py:2902
-#, fuzzy, python-format
+#, python-format
 msgid "Connection failed: %(error)s"
 msgstr "Échec de la connexion : %(error)s"
 
 #: cps/admin.py:2928
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Metadata is missing required OIDC fields: %(fields)s. This may not be a "
 "valid OIDC metadata endpoint."
@@ -772,14 +770,13 @@ msgstr ""
 "valide."
 
 #: cps/admin.py:2939
-#, fuzzy, python-format
+#, python-format
 msgid "Metadata URL is valid! Found %(count)s OAuth endpoints."
 msgstr ""
 "L'URL des métadonnées est valide ! %(count)s points de terminaison OAuth "
 "trouvés."
 
 #: cps/admin.py:2941
-#, fuzzy
 msgid " User info endpoint is available."
 msgstr " Le point de terminaison des informations utilisateur est disponible."
 
@@ -797,7 +794,6 @@ msgstr ""
 "correcte."
 
 #: cps/admin.py:2952
-#, fuzzy
 msgid ""
 "Connection failed: Could not connect to metadata URL. Check the URL and "
 "network connectivity."
@@ -818,32 +814,35 @@ msgid "An unknown error occurred."
 msgstr "Une erreur inconnue est survenue."
 
 #: cps/admin.py:2971
-#, fuzzy
 msgid "Restore already in progress."
-msgstr "Échec de la connexion : %(error)s"
+msgstr "Une restauration est déjà en cours."
 
 #: cps/admin.py:2975
 msgid "Restore failed: Calibre library path is not configured."
 msgstr ""
+"Échec de la restauration : le chemin de la bibliothèque Calibre n'est pas"
+" configuré."
 
 #: cps/admin.py:2980
 #, python-format
 msgid "Restore failed: metadata.db not found at %(path)s"
-msgstr ""
+msgstr "Échec de la restauration : metadata.db introuvable dans %(path)s"
 
 #: cps/admin.py:2985
 #, python-format
 msgid "Restore failed: app.db not found at %(path)s"
-msgstr ""
+msgstr "Échec de la restauration : app.db introuvable dans %(path)s"
 
 #: cps/admin.py:3057 cps/admin.py:3097
-#, fuzzy, python-format
+#, python-format
 msgid "Restore failed: %(err)s"
-msgstr "Échec de la connexion : %(error)s"
+msgstr "Échec de la restauration : %(err)s"
 
 #: cps/admin.py:3074
 msgid "Restore completed but app.db cleanup failed. See logs for details."
 msgstr ""
+"Restauration terminée, mais le nettoyage de app.db a échoué. Consultez "
+"les journaux pour plus de détails."
 
 #: cps/admin.py:3093
 #, python-format
@@ -851,6 +850,9 @@ msgid ""
 "Restore complete. Backups and restore log saved to %(dir)s. All book-linked "
 "data was reset."
 msgstr ""
+"Restauration terminée. Les sauvegardes et le journal de restauration ont "
+"été enregistrés dans %(dir)s. Toutes les données liées aux livres ont été"
+" réinitialisées."
 
 #: cps/constants.py:207
 msgid "Czech"
@@ -1120,42 +1122,38 @@ msgid "Calibre-Web Automated - Convert Library"
 msgstr "Calibre-Web Automated - Convertir la bibliothèque"
 
 #: cps/cwa_functions.py:2095 cps/cwa_functions.py:2119
-#, fuzzy
 msgid "Calibre-Web Automated - EPUB Fixer Service"
-msgstr "Calibre-Web Automated - Service de correction EPUB Send-to-Kindle"
+msgstr "Calibre-Web Automated - Service EPUB Fixer"
 
 #: cps/cwa_functions.py:2173
 msgid "Single-book EPUB Fixer is not supported with Google Drive libraries."
 msgstr ""
+"EPUB Fixer sur un seul livre n'est pas pris en charge avec les "
+"bibliothèques Google Drive."
 
 #: cps/cwa_functions.py:2180
-#, fuzzy
 msgid "Invalid book selection."
-msgstr "Identifiant du livre invalide."
+msgstr "Sélection de livre invalide."
 
 #: cps/cwa_functions.py:2186
-#, fuzzy
 msgid "Book not found."
-msgstr "Jeton non trouvé"
+msgstr "Livre introuvable."
 
 #: cps/cwa_functions.py:2192
-#, fuzzy
 msgid "Selected book has no EPUB format."
-msgstr "Marquer les livres sélectionnés comme non-lus"
+msgstr "Le livre sélectionné n'a pas de format EPUB."
 
 #: cps/cwa_functions.py:2196
-#, fuzzy
 msgid "EPUB file not found on disk."
-msgstr "Format %(format)s non trouvé sur le disque"
+msgstr "Fichier EPUB introuvable sur le disque."
 
 #: cps/cwa_functions.py:2211
-#, fuzzy
 msgid "EPUB Fixer started for selected book."
-msgstr "Editer les livres sélectionnés"
+msgstr "EPUB Fixer a été lancé pour le livre sélectionné."
 
 #: cps/cwa_functions.py:2214
 msgid "Failed to start EPUB Fixer for selected book."
-msgstr ""
+msgstr "Impossible de démarrer EPUB Fixer pour le livre sélectionné."
 
 #: cps/cwa_functions.py:2261
 msgid "You must be an admin to access this page."
@@ -1233,6 +1231,8 @@ msgstr "Le groupe en double n'a pas été supprimé"
 #: cps/duplicates.py:1314
 msgid "Import is in progress. Run a full duplicate scan after ingest finishes."
 msgstr ""
+"Une importation est en cours. Lancez un scan complet des doublons une "
+"fois l'ingestion terminée."
 
 #: cps/duplicates.py:1335
 msgid "Duplicate scan queued"
@@ -1250,12 +1250,16 @@ msgstr "Stratégie de résolution non valide"
 msgid ""
 "Import is in progress. Execute duplicate resolution after ingest finishes."
 msgstr ""
+"Une importation est en cours. Exécutez la résolution des doublons une "
+"fois l'ingestion terminée."
 
 #: cps/editbooks.py:112 cps/editbooks.py:169
 msgid ""
 "Ingest folder is not writable. Check your /cwa-book-ingest volume "
 "permissions."
 msgstr ""
+"Le dossier d'ingestion n'est pas accessible en écriture. Vérifiez les "
+"permissions de votre volume /cwa-book-ingest."
 
 #: cps/editbooks.py:121
 msgid "Missing or invalid book id for format upload"
@@ -1382,7 +1386,7 @@ msgid "edit metadata"
 msgstr "modifier les métadonnées"
 
 #: cps/editbooks.py:1546
-#, fuzzy, python-format
+#, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
 msgstr "Index de série : %(seriesindex)s n'est pas un nombre valide, ignoré"
 
@@ -1441,7 +1445,6 @@ msgstr "%(format)s introuvable : %(fn)s"
 
 #: cps/helper.py:110 cps/helper.py:234 cps/templates/detail.html:516
 #: cps/templates/detail.html:520
-#, fuzzy
 msgid "Send to eReader"
 msgstr "Envoyer à l'eReader"
 
@@ -1565,7 +1568,7 @@ msgstr ""
 #: cps/helper.py:1067 cps/helper.py:1075
 #, python-format
 msgid "Cover image exceeds maximum size of %(size)s MB"
-msgstr ""
+msgstr "L'image de couverture dépasse la taille maximale de %(size)s Mo"
 
 #: cps/helper.py:1086
 msgid "Error Downloading Cover"
@@ -1760,7 +1763,6 @@ msgstr ""
 "l'administrateur."
 
 #: cps/oauth_bb.py:574
-#, fuzzy
 msgid "OAuth system error. Please contact administrator."
 msgstr "Erreur système OAuth. Veuillez contacter l'administrateur."
 
@@ -1848,7 +1850,6 @@ msgid "OAuth error: {}"
 msgstr "Erreur OAuth  : {}"
 
 #: cps/opds.py:200
-#, fuzzy
 msgid "description"
 msgstr "Description"
 
@@ -1880,6 +1881,9 @@ msgid ""
 "Duplicate scanning needs a one-time full scan before fast duplicate checks "
 "can run after imports and metadata changes. "
 msgstr ""
+"La détection des doublons nécessite un scan complet initial avant que les"
+" vérifications rapides puissent s'exécuter après les importations et les "
+"modifications de métadonnées. "
 
 #: cps/render_template.py:74
 msgid "Books"
@@ -2459,9 +2463,8 @@ msgid "No email addresses selected"
 msgstr "Aucune adresse email sélectionnée"
 
 #: cps/web.py:2024
-#, fuzzy
 msgid "Additional email addresses are disabled for your account."
-msgstr "Choisissez l'adresse de courriel:"
+msgstr "Les adresses e-mail supplémentaires sont désactivées pour votre compte."
 
 #: cps/web.py:2046
 msgid "Success! Book queued for sending to the selected address(es)!"
@@ -2705,38 +2708,34 @@ msgid "Duplicate scan"
 msgstr "Scan en double"
 
 #: cps/tasks/duplicate_scan.py:82
-#, fuzzy
 msgid "Duplicate scan skipped: import in progress"
-msgstr "Scan des doublons terminé : %(count)s nouveaux groupes"
+msgstr "Scan des doublons ignoré : importation en cours"
 
 #: cps/tasks/duplicate_scan.py:90
 msgid "Building duplicate index"
-msgstr ""
+msgstr "Construction de l'index des doublons"
 
 #: cps/tasks/duplicate_scan.py:98
 #, python-format
 msgid "Building duplicate index: %(processed)s/%(total)s books"
-msgstr ""
+msgstr "Construction de l'index des doublons : %(processed)s/%(total)s livres"
 
 #: cps/tasks/duplicate_scan.py:104
 msgid "Building duplicate index: no books"
-msgstr ""
+msgstr "Construction de l'index des doublons : aucun livre"
 
 #: cps/tasks/duplicate_scan.py:108
-#, fuzzy
 msgid "Finding duplicate groups"
-msgstr "Supprimer ce groupe en double"
+msgstr "Recherche des groupes de doublons"
 
 #: cps/tasks/duplicate_scan.py:124
-#, fuzzy
 msgid "Updating duplicate cache"
-msgstr "Décompression de la mise à jour"
+msgstr "Mise à jour du cache des doublons"
 
 #: cps/tasks/duplicate_scan.py:153 cps/tasks/duplicate_scan.py:163
 #: cps/tasks/duplicate_scan.py:203 cps/tasks/duplicate_scan.py:212
-#, fuzzy
 msgid "Duplicate scan pending: manual scan required"
-msgstr "Scan en double mis en file d'attente"
+msgstr "Scan des doublons en attente : un scan manuel est requis"
 
 #: cps/tasks/duplicate_scan.py:231
 #, python-format
@@ -2821,9 +2820,8 @@ msgid "Send to eReader Email"
 msgstr "Envoyer à l'eReader E-mail"
 
 #: cps/templates/admin.html:17 cps/templates/user_edit.html:221
-#, fuzzy
 msgid "Send to eReader Subject"
-msgstr "Envoyer à l'eReader Objet"
+msgstr "Objet de l'e-mail « Envoyer à l'eReader »"
 
 #: cps/templates/admin.html:19 cps/templates/layout.html:166
 #: cps/templates/user_table.html:144
@@ -3023,9 +3021,8 @@ msgid "CWA Library Conversion Service"
 msgstr "CWA Service de Conversion de Librairie"
 
 #: cps/templates/admin.html:215
-#, fuzzy
 msgid "CWA EPUB Fixer Service"
-msgstr "CWA Send-to-Kindle Service de correction EPUB"
+msgstr "Service EPUB Fixer de CWA"
 
 #: cps/templates/admin.html:218
 msgid "CWA GitHub"
@@ -3356,6 +3353,8 @@ msgstr "Rechercher le mot-clé"
 #: cps/templates/book_edit.html:282
 msgid "Selected metadata fields were applied to the edit form."
 msgstr ""
+"Les champs de métadonnées sélectionnés ont été appliqués au formulaire "
+"d'édition."
 
 #: cps/templates/book_edit.html:288 cps/templates/book_edit.html:368
 msgid "Loading..."
@@ -3395,7 +3394,7 @@ msgstr "Désarchiver"
 
 #: cps/templates/book_table.html:56 cps/templates/book_table.html:250
 msgid "Mark as read"
-msgstr "Marquer comme non lu"
+msgstr "Marquer comme lu"
 
 #: cps/templates/book_table.html:59 cps/templates/book_table.html:270
 msgid "Mark as unread"
@@ -3690,9 +3689,8 @@ msgid "Revoke"
 msgstr "Révoquer"
 
 #: cps/templates/config_db.html:117
-#, fuzzy
 msgid "Last Resort: Restore Calibre Database (experimental)"
-msgstr "Reconnecter la base de données Calibre"
+msgstr "Dernier recours : restaurer la base de données Calibre (expérimental)"
 
 #: cps/templates/config_db.html:118
 msgid ""
@@ -3703,16 +3701,23 @@ msgid ""
 "databases will be automatically backed up in /config/backup before any "
 "destructive action.</b> A restore log will be saved alongside the backups."
 msgstr ""
+"Si votre bibliothèque Calibre est corrompue et ne peut pas être ouverte, "
+"vous pouvez tenter de la restaurer à partir des fichiers OPF de votre "
+"bibliothèque. Cette opération <b>effacera toutes les données propres à "
+"chaque livre</b> (progression de lecture, marque-pages, liens vers les "
+"étagères, téléchargements, etc.) dans la base de données de "
+"l'application, mais n'affectera ni les comptes utilisateurs ni les "
+"paramètres. <b>Les deux bases de données seront automatiquement "
+"sauvegardées dans /config/backup avant toute action destructive.</b> Un "
+"journal de restauration sera enregistré à côté des sauvegardes."
 
 #: cps/templates/config_db.html:121
-#, fuzzy
 msgid "Are you sure? This cannot be undone."
-msgstr "Voulez-vous vraiment arrêter Calibre-Web?"
+msgstr "Voulez-vous vraiment continuer ? Cette action est irréversible."
 
 #: cps/templates/config_db.html:121
-#, fuzzy
 msgid "Restore Calibre Database (Last Resort)"
-msgstr "Reconnecter la base de données Calibre"
+msgstr "Restaurer la base de données Calibre (dernier recours)"
 
 #: cps/templates/config_db.html:137
 msgid "New db location is invalid, please enter valid path"
@@ -3773,10 +3778,8 @@ msgid "Logfile Configuration"
 msgstr "Configuration du fichier journal"
 
 #: cps/templates/config_edit.html:149
-#, fuzzy
 msgid "Location and name of logfile (/dev/stdout for no entry)"
-msgstr ""
-"Emplacement et nom du fichier journal d’accès (access.log pour aucune entrée)"
+msgstr "Emplacement et nom du fichier journal (/dev/stdout si aucune entrée)"
 
 #: cps/templates/config_edit.html:154
 msgid "Enable Access Log"
@@ -4536,16 +4539,15 @@ msgstr "Erreur de planification Convertir la bibliothèque"
 
 #: cps/templates/cwa_epub_fixer.html:22
 msgid "Run on a single book"
-msgstr ""
+msgstr "Exécuter sur un seul livre"
 
 #: cps/templates/cwa_epub_fixer.html:24
 msgid "Search by title/author"
-msgstr ""
+msgstr "Rechercher par titre/auteur"
 
 #: cps/templates/cwa_epub_fixer.html:29
-#, fuzzy
 msgid "Run on selected book"
-msgstr "Editer les livres sélectionnés"
+msgstr "Exécuter sur le livre sélectionné"
 
 #: cps/templates/cwa_epub_fixer.html:120
 msgid "EPUB Fixer scheduled successfully"
@@ -4556,34 +4558,28 @@ msgid "Error scheduling EPUB Fixer"
 msgstr "Erreur de planification EPUB Fixer"
 
 #: cps/templates/cwa_epub_fixer.html:132
-#, fuzzy
 msgid "No matches found"
 msgstr "Aucun résultat trouvé"
 
 #: cps/templates/cwa_epub_fixer.html:167
-#, fuzzy
 msgid "Enter a search term"
-msgstr "Entrer le nom d'utilisateur"
+msgstr "Saisissez un terme de recherche"
 
 #: cps/templates/cwa_epub_fixer.html:175
-#, fuzzy
 msgid "Failed to search library"
-msgstr "Impossible d’ignorer la correspondance"
+msgstr "Échec de la recherche dans la bibliothèque"
 
 #: cps/templates/cwa_epub_fixer.html:182
-#, fuzzy
 msgid "Select a book first"
-msgstr "Sélectionner une étagère"
+msgstr "Sélectionnez d'abord un livre"
 
 #: cps/templates/cwa_epub_fixer.html:195
-#, fuzzy
 msgid "EPUB Fixer started for selected book"
-msgstr "Editer les livres sélectionnés"
+msgstr "EPUB Fixer a été lancé pour le livre sélectionné"
 
 #: cps/templates/cwa_epub_fixer.html:200
-#, fuzzy
 msgid "Error starting EPUB Fixer"
-msgstr "Erreur de planification EPUB Fixer"
+msgstr "Erreur lors du démarrage d'EPUB Fixer"
 
 #: cps/templates/cwa_settings.html:136
 msgid "Enable/Disable Calibre-Web Automated Services"
@@ -4665,9 +4661,8 @@ msgstr ""
 "github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
-#, fuzzy
 msgid "Enable KOReader Sync (CWA Plugin)"
-msgstr "Plugin KOReader Sync"
+msgstr "Activer la synchronisation KOReader (plugin CWA)"
 
 #: cps/templates/cwa_settings.html:183
 msgid ""
@@ -4675,6 +4670,10 @@ msgid ""
 "compatible checksums in metadata.db for progress syncing. Requires the "
 "KOReader plugin on your device."
 msgstr ""
+"Lorsque cette option est activée, CWA expose les points de terminaison "
+"/kosync et enregistre dans metadata.db des sommes de contrôle compatibles"
+" KOReader pour la synchronisation de la progression. Nécessite le plugin "
+"KOReader sur votre appareil."
 
 #: cps/templates/cwa_settings.html:185
 msgid ""
@@ -4682,6 +4681,10 @@ msgid ""
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
+"Remarque : l'activation de cette option lance au démarrage un service de "
+"calcul rétroactif des sommes de contrôle, susceptible de verrouiller "
+"temporairement metadata.db. Pour arrêter un calcul en cours, désactivez "
+"l'option puis redémarrez le conteneur."
 
 #: cps/templates/cwa_settings.html:192
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
@@ -4900,18 +4903,20 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:403
 msgid "Cover File Max Size (MB):"
-msgstr ""
+msgstr "Taille maximale du fichier de couverture (Mo) :"
 
 #: cps/templates/cwa_settings.html:416
-#, fuzzy
 msgid "Range: 1-200 MB (default: 15)"
-msgstr "Plage: 5-120 minutes (par défaut: 15)"
+msgstr "Plage : 1-200 Mo (par défaut : 15)"
 
 #: cps/templates/cwa_settings.html:419
 msgid ""
 "Limits the maximum size of cover images downloaded from metadata providers "
 "or URLs to prevent slow or stalled saves."
 msgstr ""
+"Limite la taille maximale des images de couverture téléchargées depuis "
+"les fournisseurs de métadonnées ou des URL, afin d'éviter des "
+"enregistrements lents ou bloqués."
 
 #: cps/templates/cwa_settings.html:428
 msgid "Ingest Processing Timeout"
@@ -5718,14 +5723,12 @@ msgid "Mark As Read"
 msgstr "Marquer comme lu"
 
 #: cps/templates/detail.html:539
-#, fuzzy
 msgid "Marked as read"
-msgstr "Marquer comme non lu"
+msgstr "Marqué comme lu"
 
 #: cps/templates/detail.html:540
-#, fuzzy
 msgid "Marked as unread"
-msgstr "Marquer comme non lu"
+msgstr "Marqué comme non lu"
 
 #: cps/templates/detail.html:545 cps/templates/detail.html:546
 #: cps/templates/detail.html:851 cps/templates/listenmp3.html:166
@@ -5742,9 +5745,8 @@ msgid "Archived"
 msgstr "Archivé"
 
 #: cps/templates/detail.html:548
-#, fuzzy
 msgid "Restored from archive"
-msgstr "Restaurer à partir de l'archive"
+msgstr "Restauré depuis l'archive"
 
 #: cps/templates/detail.html:579 cps/templates/detail.html:773
 #: cps/templates/detail.html:774 cps/templates/detail.html:1288
@@ -5762,19 +5764,16 @@ msgid "(Public)"
 msgstr "(Public)"
 
 #: cps/templates/detail.html:602 cps/templates/detail.html:767
-#, fuzzy
 msgid "Remove from shelf"
-msgstr "Restaurer à partir de l'archive"
+msgstr "Retirer de l'étagère"
 
 #: cps/templates/detail.html:640
-#, fuzzy
 msgid "Rating updated"
-msgstr "La configuration de la base de données a été mise à jour"
+msgstr "Évaluation mise à jour"
 
 #: cps/templates/detail.html:641
-#, fuzzy
 msgid "Rating cleared"
-msgstr "Évaluation supérieure à"
+msgstr "Évaluation supprimée"
 
 #: cps/templates/detail.html:659 cps/templates/listenmp3.html:62
 #, python-format
@@ -5783,64 +5782,60 @@ msgstr "Livre %(index)s sur %(range)s"
 
 #: cps/templates/detail.html:664
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: cps/templates/detail.html:669
 msgid "UUID"
-msgstr ""
+msgstr "UUID"
 
 #: cps/templates/detail.html:672
 msgid "UUID copied to clipboard"
-msgstr ""
+msgstr "UUID copié dans le presse-papiers"
 
 #: cps/templates/detail.html:673
 msgid "Unable to copy UUID"
-msgstr ""
+msgstr "Impossible de copier l'UUID"
 
 #: cps/templates/detail.html:674 cps/templates/detail.html:675
 msgid "Copy UUID"
-msgstr ""
+msgstr "Copier l'UUID"
 
 #: cps/templates/detail.html:680
 msgid "Date added"
-msgstr ""
+msgstr "Date d'ajout"
 
 #: cps/templates/detail.html:684
 msgid "Last modified"
-msgstr ""
+msgstr "Dernière modification"
 
 #: cps/templates/detail.html:689
-#, fuzzy
 msgid "File sizes"
-msgstr "Taille de police"
+msgstr "Tailles de fichier"
 
 #: cps/templates/detail.html:733
-#, fuzzy
 msgid "Remove tag"
-msgstr "Supprimer"
+msgstr "Supprimer l'étiquette"
 
 #: cps/templates/detail.html:741 cps/templates/detail.html:742
 #: cps/templates/detail.html:1166
 msgid "Add tag"
-msgstr ""
+msgstr "Ajouter une étiquette"
 
 #: cps/templates/detail.html:787 cps/templates/listenmp3.html:111
 msgid "Published"
 msgstr "Publié"
 
 #: cps/templates/detail.html:793
-#, fuzzy
 msgid "KOReader Progress"
-msgstr "Avancement"
+msgstr "Progression KOReader"
 
 #: cps/templates/detail.html:863 cps/templates/listenmp3.html:177
 msgid "Description:"
 msgstr "Description :"
 
 #: cps/templates/detail.html:880
-#, fuzzy
 msgid "Select eReader Email Addresses"
-msgstr "Envoyer vers une adresse mail Kindle"
+msgstr "Sélectionner les adresses e-mail des liseuses"
 
 #: cps/templates/detail.html:893
 msgid "Choose email addresses:"
@@ -5851,22 +5846,22 @@ msgid "Select All"
 msgstr "Sélectionner tout"
 
 #: cps/templates/detail.html:917
-#, fuzzy
 msgid "Additional email addresses:"
-msgstr "Choisissez l'adresse de courriel:"
+msgstr "Adresses e-mail supplémentaires :"
 
 #: cps/templates/detail.html:918
-#, fuzzy
 msgid "Enter additional email addresses (separated by commas):"
-msgstr "Choisissez l'adresse de courriel:"
+msgstr ""
+"Saisissez des adresses e-mail supplémentaires (séparées par des virgules)"
+" :"
 
 #: cps/templates/detail.html:919
 msgid "example@domain.com, another@domain.com"
-msgstr ""
+msgstr "exemple@domaine.com, autre@domaine.com"
 
 #: cps/templates/detail.html:920
 msgid "Enter one or more email addresses separated by commas"
-msgstr ""
+msgstr "Saisissez une ou plusieurs adresses e-mail séparées par des virgules"
 
 #: cps/templates/detail.html:925
 msgid "Select format:"
@@ -5877,14 +5872,12 @@ msgid "Send"
 msgstr "Envoyer"
 
 #: cps/templates/detail.html:1144
-#, fuzzy
 msgid "Failed to update tags"
-msgstr "Impossible d’ignorer la correspondance"
+msgstr "Échec de la mise à jour des étiquettes"
 
 #: cps/templates/detail.html:1252
-#, fuzzy
 msgid "Failed to update shelves"
-msgstr "Impossible d’ignorer la correspondance"
+msgstr "Échec de la mise à jour des étagères"
 
 #: cps/templates/duplicates.html:497
 msgid "CWA Duplicates Manager"
@@ -5899,9 +5892,8 @@ msgstr ""
 "différentes langues ne sont pas considérés comme des doublons."
 
 #: cps/templates/duplicates.html:507
-#, fuzzy
 msgid "Run Full Duplicate Scan"
-msgstr "Scan en double"
+msgstr "Lancer un scan complet des doublons"
 
 #: cps/templates/duplicates.html:509
 msgid "Scan for Duplicates Now"
@@ -5921,7 +5913,7 @@ msgstr "Effacer la sélection"
 
 #: cps/templates/duplicates.html:529
 msgid "Duplicate scanning needs a one-time full scan."
-msgstr ""
+msgstr "La détection des doublons nécessite un scan complet initial."
 
 #: cps/templates/duplicates.html:531
 msgid ""
@@ -5929,30 +5921,35 @@ msgid ""
 "and metadata changes. Before incremental scans can run, the index needs an "
 "initial baseline."
 msgstr ""
+"CWA utilise désormais un index des doublons pour accélérer les "
+"vérifications lors des importations et des modifications de métadonnées. "
+"Avant que les scans incrémentaux puissent s'exécuter, cet index doit être"
+" initialisé."
 
 #: cps/templates/duplicates.html:534
 msgid ""
 "Click \"Run Full Duplicate Scan\" to build it. This may take several minutes "
 "on large libraries, and you can keep using CWA while it runs."
 msgstr ""
+"Cliquez sur « Lancer un scan complet des doublons » pour le construire. "
+"Cela peut prendre plusieurs minutes sur les grandes bibliothèques, et "
+"vous pouvez continuer à utiliser CWA pendant l'opération."
 
 #: cps/templates/duplicates.html:541
-#, fuzzy
 msgid "Duplicate scan is running."
-msgstr "Scan en double"
+msgstr "Un scan des doublons est en cours."
 
 #: cps/templates/duplicates.html:542
 msgid "You can keep using CWA while it runs."
-msgstr ""
+msgstr "Vous pouvez continuer à utiliser CWA pendant l'opération."
 
 #: cps/templates/duplicates.html:545 cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Avancement"
 
 #: cps/templates/duplicates.html:554
-#, fuzzy
 msgid "View Background Tasks"
-msgstr "Présentation des tâches en arrière-plan"
+msgstr "Voir les tâches en arrière-plan"
 
 #: cps/templates/duplicates.html:565
 msgid "Auto-Resolve Duplicates"
@@ -6065,20 +6062,20 @@ msgstr ""
 "éviter les faux-positifs."
 
 #: cps/templates/duplicates.html:685
-#, fuzzy
 msgid "Execute Auto-Resolution"
-msgstr "Exécuter la résolution"
+msgstr "Exécuter la résolution automatique"
 
 #: cps/templates/duplicates.html:688
 msgid ""
 "CWA will resolve duplicate groups using the selected strategy and "
 "permanently delete duplicate books."
 msgstr ""
+"CWA va résoudre les groupes de doublons selon la stratégie sélectionnée "
+"et supprimer définitivement les livres en double."
 
 #: cps/templates/duplicates.html:690
-#, fuzzy
 msgid "Selected strategy:"
-msgstr "Sélectionner le format:"
+msgstr "Stratégie sélectionnée :"
 
 #: cps/templates/duplicates.html:692 cps/templates/duplicates.html:715
 msgid "This action cannot be undone!"
@@ -6189,7 +6186,7 @@ msgstr "Suivant"
 
 #: cps/templates/feed.xml:83
 msgid "(Magic)"
-msgstr ""
+msgstr "(Magique)"
 
 #: cps/templates/generate_kobo_auth_url.html:6
 msgid ""
@@ -6257,12 +6254,10 @@ msgstr ""
 "automatiquement ; celles-ci nécessitent une vérification manuelle."
 
 #: cps/templates/hardcover_review_matches.html:81
-#, fuzzy
 msgid "Reject All Pending"
-msgstr "Sélectionner tout"
+msgstr "Rejeter toutes les correspondances en attente"
 
 #: cps/templates/hardcover_review_matches.html:94
-#, fuzzy
 msgid "Search Query"
 msgstr "Requête de recherche"
 
@@ -6286,18 +6281,16 @@ msgid "Match Reason"
 msgstr "Raison de la correspondance"
 
 #: cps/templates/hardcover_review_matches.html:160
-#, fuzzy
 msgid "View on Hardcover"
-msgstr "Voir la version reliée"
+msgstr "Voir sur Hardcover"
 
 #: cps/templates/hardcover_review_matches.html:168
 msgid "Select This Match"
 msgstr "Sélectionner cette correspondance"
 
 #: cps/templates/hardcover_review_matches.html:180
-#, fuzzy
 msgid "Reject All"
-msgstr "Refuser tout"
+msgstr "Tout rejeter"
 
 #: cps/templates/hardcover_review_matches.html:185
 msgid "Skip for Now"
@@ -6307,9 +6300,8 @@ msgstr "Ignorer pour l'instant"
 #: cps/templates/hardcover_review_matches.html:303
 #: cps/templates/hardcover_review_matches.html:346
 #: cps/templates/hardcover_review_matches.html:380
-#, fuzzy
 msgid "Processing..."
-msgstr "En cours..."
+msgstr "Traitement en cours..."
 
 #: cps/templates/hardcover_review_matches.html:280
 #: cps/templates/hardcover_review_matches.html:289
@@ -6321,7 +6313,6 @@ msgid "Failed to apply match"
 msgstr "Échec de l'application de la correspondance"
 
 #: cps/templates/hardcover_review_matches.html:299
-#, fuzzy
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
@@ -6335,28 +6326,24 @@ msgid "✗ Reject All Matches"
 msgstr "✗ Rejeter toutes les correspondances"
 
 #: cps/templates/hardcover_review_matches.html:328
-#, fuzzy
 msgid "Failed to reject match"
 msgstr "Échec du rejet de la correspondance"
 
 #: cps/templates/hardcover_review_matches.html:342
-#, fuzzy
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
 msgstr ""
-"Voulez-vous vraiment modifier le rôle sélectionné pour le ou les "
-"utilisateurs sélectionnés ?"
+"Voulez-vous vraiment rejeter toutes les correspondances en attente ? "
+"Cette action est irréversible."
 
 #: cps/templates/hardcover_review_matches.html:361
 #: cps/templates/hardcover_review_matches.html:370
-#, fuzzy
 msgid "✗ Reject All Pending"
-msgstr "Sélectionner tout"
+msgstr "✗ Rejeter toutes les correspondances en attente"
 
 #: cps/templates/hardcover_review_matches.html:365
-#, fuzzy
 msgid "Failed to reject all pending matches"
-msgstr "Impossible de créer le chemin pour la couverture"
+msgstr "Échec du rejet de toutes les correspondances en attente"
 
 #: cps/templates/hardcover_review_matches.html:401
 #: cps/templates/hardcover_review_matches.html:410
@@ -6452,24 +6439,26 @@ msgid "Sort descending according to series index"
 msgstr "Trier par ordre décroissant en fonction de l’index de série"
 
 #: cps/templates/kosync_plugin.html:112
-#, fuzzy
 msgid "KOReader Sync is disabled."
-msgstr "La connexion standard est désactivée."
+msgstr "La synchronisation KOReader est désactivée."
 
 #: cps/templates/kosync_plugin.html:113
 msgid ""
 "Enable it in CWA Settings to activate the /kosync endpoints and checksum "
 "generation."
 msgstr ""
+"Activez-la dans les paramètres de CWA pour activer les points de "
+"terminaison /kosync et la génération des sommes de contrôle."
 
 #: cps/templates/kosync_plugin.html:115
-#, fuzzy
 msgid "Open CWA Settings"
-msgstr "Paramètres de CWA"
+msgstr "Ouvrir les paramètres de CWA"
 
 #: cps/templates/kosync_plugin.html:139
 msgid "Download is available after enabling KOReader Sync in CWA Settings."
 msgstr ""
+"Le téléchargement sera disponible après avoir activé la synchronisation "
+"KOReader dans les paramètres de CWA."
 
 #: cps/templates/layout.html:93 cps/templates/login.html:51
 msgid "Home"
@@ -6510,9 +6499,8 @@ msgid "See Changelog"
 msgstr "Voir le Changelog"
 
 #: cps/templates/layout.html:219
-#, fuzzy
 msgid "Open Duplicates"
-msgstr "Doubles"
+msgstr "Ouvrir les doublons"
 
 #: cps/templates/layout.html:241
 msgid "Contribute here!"
@@ -7241,12 +7229,10 @@ msgid "Error cancelling scheduled item"
 msgstr "Erreur lors de l'annulation d'un élément planifié"
 
 #: cps/templates/user_edit.html:173
-#, fuzzy
 msgid "Your Profile"
 msgstr "Votre profil"
 
 #: cps/templates/user_edit.html:173
-#, fuzzy
 msgid "User Settings"
 msgstr "Paramètres de l'utilisateur"
 
@@ -7266,14 +7252,12 @@ msgid "Reset user Password"
 msgstr "Réinitialiser le mot de passe de l’utilisateur"
 
 #: cps/templates/user_edit.html:212
-#, fuzzy
 msgid "eReader Configuration"
 msgstr "Configuration de la liseuse électronique"
 
 #: cps/templates/user_edit.html:215
-#, fuzzy
 msgid "Send to eReader Email Address"
-msgstr "Envoyer à l'adresse e-mail de l'eReader"
+msgstr "Adresse e-mail pour l'envoi vers la liseuse"
 
 #: cps/templates/user_edit.html:216
 msgid "Use comma to separate multiple addresses"
@@ -7289,7 +7273,7 @@ msgstr ""
 
 #: cps/templates/user_edit.html:228
 msgid "Enable Send-to-eReader Pop-up Modal"
-msgstr ""
+msgstr "Activer la fenêtre contextuelle « Envoyer à l'eReader »"
 
 #: cps/templates/user_edit.html:230
 msgid ""
@@ -7297,16 +7281,17 @@ msgid ""
 "enter extra email addresses and only send to a selection of saved addresses "
 "when sending to eReader."
 msgstr ""
+"Active ou désactive la fenêtre contextuelle « Envoyer à l'eReader », qui "
+"permet de saisir des adresses e-mail supplémentaires et de n'envoyer qu'à"
+" une sélection d'adresses enregistrées."
 
 #: cps/templates/user_edit.html:232
-#, fuzzy
 msgid ""
 "When disabled, emails will be sent to all configured eReader addresses "
 "without prompting."
 msgstr ""
-"Lorsque cette option est activée, les nouveaux livres importés seront "
-"automatiquement envoyés à toutes les adresses e-mail des liseuses "
-"configurées ci-dessus."
+"Lorsque cette option est désactivée, les e-mails sont envoyés à toutes "
+"les adresses de liseuses configurées sans demander de confirmation."
 
 #: cps/templates/user_edit.html:240
 msgid "Automatically send new books to my eReader(s)"
@@ -7328,7 +7313,6 @@ msgid "Language & Theme Preferences"
 msgstr "Préférences linguistiques et thématiques"
 
 #: cps/templates/user_edit.html:252
-#, fuzzy
 msgid "Interface Language"
 msgstr "Langue de l'interface"
 
@@ -7343,9 +7327,8 @@ msgstr ""
 "spécifique."
 
 #: cps/templates/user_edit.html:280
-#, fuzzy
 msgid "Book Language Filter"
-msgstr "Filtre de langue du livre"
+msgstr "Filtre par langue des livres"
 
 #: cps/templates/user_edit.html:298
 msgid "OAuth & API Integrations"
@@ -7364,9 +7347,8 @@ msgid "Unlink"
 msgstr "Dissocier"
 
 #: cps/templates/user_edit.html:315
-#, fuzzy
 msgid "Hardcover API Token"
-msgstr "Jeton API à couverture rigide"
+msgstr "Jeton d'API Hardcover"
 
 #: cps/templates/user_edit.html:317
 msgid "API token for Hardcover metadata provider integration."
@@ -7390,7 +7372,6 @@ msgstr ""
 "Synchroniser uniquement les livres dans les étagères sélectionnées avec Kobo"
 
 #: cps/templates/user_edit.html:346
-#, fuzzy
 msgid "Sidebar Display Settings"
 msgstr "Paramètres d'affichage de la barre latérale"
 
@@ -7405,90 +7386,94 @@ msgstr "Ajouter les valeurs de colonnes personnalisées autorisées/refusées"
 
 #: cps/templates/user_edit.html:380
 msgid "OPDS Catalog Order"
-msgstr ""
+msgstr "Ordre du catalogue OPDS"
 
 #: cps/templates/user_edit.html:381
 msgid ""
 "Reorder the OPDS root catalog by listing entry IDs in the order you want. "
 "Unknown IDs are ignored and missing entries are appended automatically."
 msgstr ""
+"Réorganisez le catalogue racine OPDS en listant les identifiants "
+"d'entrées dans l'ordre souhaité. Les identifiants inconnus sont ignorés "
+"et les entrées manquantes sont ajoutées automatiquement à la fin."
 
 #: cps/templates/user_edit.html:389
 msgid ""
 "Drag to reorder OPDS root entries. Missing entries are appended "
 "automatically."
 msgstr ""
+"Faites glisser pour réorganiser les entrées racine OPDS. Les entrées "
+"manquantes sont ajoutées automatiquement à la fin."
 
 #: cps/templates/user_edit.html:398
-#, fuzzy
 msgid "User Permissions"
-msgstr "Permissions"
+msgstr "Permissions de l'utilisateur"
 
 #: cps/templates/user_edit.html:399
 msgid "Configure what actions this user is allowed to perform."
-msgstr ""
+msgstr "Configurez les actions que cet utilisateur est autorisé à effectuer."
 
 #: cps/templates/user_edit.html:454
-#, fuzzy
 msgid "Magic Shelves Order"
-msgstr "Étagères magiques ✨"
+msgstr "Ordre des étagères magiques"
 
 #: cps/templates/user_edit.html:455
 msgid "Choose how your magic shelves are ordered in the sidebar."
 msgstr ""
+"Choisissez l'ordre d'affichage de vos étagères magiques dans la barre "
+"latérale."
 
 #: cps/templates/user_edit.html:459
 msgid "Order Mode"
-msgstr ""
+msgstr "Mode de tri"
 
 #: cps/templates/user_edit.html:461
 msgid "Manual (drag to reorder)"
-msgstr ""
+msgstr "Manuel (faites glisser pour réorganiser)"
 
 #: cps/templates/user_edit.html:462
 msgid "Name (A-Z)"
-msgstr ""
+msgstr "Nom (A-Z)"
 
 #: cps/templates/user_edit.html:463
 msgid "Name (Z-A)"
-msgstr ""
+msgstr "Nom (Z-A)"
 
 #: cps/templates/user_edit.html:464
 msgid "Book count (high to low)"
-msgstr ""
+msgstr "Nombre de livres (décroissant)"
 
 #: cps/templates/user_edit.html:465
 msgid "Book count (low to high)"
-msgstr ""
+msgstr "Nombre de livres (croissant)"
 
 #: cps/templates/user_edit.html:466
 msgid "Created (newest first)"
-msgstr ""
+msgstr "Création (les plus récentes d'abord)"
 
 #: cps/templates/user_edit.html:467
 msgid "Created (oldest first)"
-msgstr ""
+msgstr "Création (les plus anciennes d'abord)"
 
 #: cps/templates/user_edit.html:468
-#, fuzzy
 msgid "Recently modified"
-msgstr "Livres récents ajoutés"
+msgstr "Modifiées récemment"
 
 #: cps/templates/user_edit.html:469
 msgid "Least recently modified"
-msgstr ""
+msgstr "Modifiées le moins récemment"
 
 #: cps/templates/user_edit.html:480
 msgid "Manual order is used only when the order mode is set to Manual."
 msgstr ""
+"L'ordre manuel n'est utilisé que lorsque le mode de tri est défini sur "
+"Manuel."
 
 #: cps/templates/user_edit.html:486
-#, fuzzy
 msgid "Magic Shelves Visibility"
-msgstr "Étagères magiques ✨"
+msgstr "Visibilité des étagères magiques"
 
 #: cps/templates/user_edit.html:487
-#, fuzzy
 msgid ""
 "Uncheck shelves you want to hide from your sidebar. System shelves cannot be "
 "deleted, only hidden. Public shelves from other users can also be hidden."
@@ -7502,7 +7487,6 @@ msgid "Default System Shelves:"
 msgstr "Étagères système par défaut :"
 
 #: cps/templates/user_edit.html:515
-#, fuzzy
 msgid "Public Shelves:"
 msgstr "Étagères publiques :"
 
@@ -7526,7 +7510,7 @@ msgstr "Générer l'URL d'authentification Kobo"
 
 #: cps/templates/user_edit.html:631
 msgid "Visible"
-msgstr ""
+msgstr "Visible"
 
 #: cps/templates/user_table.html:80 cps/templates/user_table.html:103
 msgid "Select..."


### PR DESCRIPTION
## Summary

Brings the French translation (`cps/translations/fr/LC_MESSAGES/messages.po`) to full coverage: **1537 / 1537 strings**, with no fuzzy entries left.

Before: 1386 translated, 89 fuzzy, 62 untranslated.
After: 1537 translated, 0 fuzzy, 0 untranslated.

Only `msgstr` values and `fuzzy` flags were modified. All 1600 `msgid` values are byte-identical and in the same order, and the 63 obsolete (`#~`) entries are untouched.

## What changed

| | Count |
|---|---|
| Newly translated (were empty) | 62 |
| Fuzzy entries with a wrong translation, rewritten | 64 |
| Fuzzy entries whose translation was already correct, flag cleared | 25 |
| Non-fuzzy entries with an inverted translation, fixed | 2 |

Most of the untranslated and fuzzy strings come from recent CWA features: the duplicate index and scan flow, the Calibre database restore path, the single-book EPUB Fixer, KOReader Sync, magic shelves ordering, OPDS catalog ordering, and the send-to-eReader modal.

## Notable fixes

The 89 fuzzy entries were excluded from the compiled `.mo`, so they rendered in English rather than in bad French. Most had been auto-matched to unrelated strings, so simply clearing the flags would have shipped visibly wrong text. Examples:

| msgid | Was | Now |
|---|---|---|
| `Book not found.` | Jeton non trouvé *(“token not found”)* | Livre introuvable. |
| `Hardcover API Token` | Jeton API à couverture rigide *(“hardback cover”)* | Jeton d'API Hardcover |
| `View on Hardcover` | Voir la version reliée *(“see the bound edition”)* | Voir sur Hardcover |
| `Remove from shelf` | Restaurer à partir de l'archive *(“restore from archive”)* | Retirer de l'étagère |
| `File sizes` | Taille de police *(“font size”)* | Tailles de fichier |
| `Range: 1-200 MB (default: 15)` | Plage: 5-120 minutes | Plage : 1-200 Mo |

One of them would have crashed on render. `Restore failed: %(err)s` was translated as `Échec de la connexion : %(error)s` — the placeholder `%(error)s` does not exist in the `msgid`, so clearing that fuzzy flag without fixing the text would have raised a `KeyError` during interpolation. It now correctly uses `%(err)s`.

Separately, two **non-fuzzy** entries were live in the UI with inverted meanings, and are fixed here:

- `Mark as read` was “Marquer comme non lu” (*mark as unread*) → now “Marquer comme lu”
- `Marked as read` was “Marquer comme non lu” → now “Marqué comme lu”

## Conventions followed

Matched the file's existing majority style rather than imposing a new one: straight apostrophes (392 occurrences vs 143 curly), regular space before `:` and `?`, and `MB` rendered as `Mo`.

Terminology aligned with the translations already in the file: *shelf* → étagère, *tag* → étiquette, *ingest* → ingestion, *duplicate* → doublon, *rating* → évaluation, *reject* → rejeter. Product and service names are left untranslated: CWA, EPUB Fixer, KOReader, Hardcover, OPDS.

## Verification

- `msgfmt --check` passes, reporting `1537 translated messages`
- All `msgid` values verified unchanged, in the same order
- All 120 `python-format` flags preserved
- Placeholders compared between every `msgid` and its new `msgstr`

## Notes for the maintainer

- The header was deliberately left alone: `Last-Translator` still credits the previous translator and `PO-Revision-Date` is unchanged. Happy to update either if you prefer.
- The file still contains a few pre-existing inconsistencies in non-fuzzy strings that were out of scope here — for instance `Duplicates` → "Doubles" alongside "doublons" elsewhere, and a couple of places where *Hardcover* is translated as if it meant a hardback book. I can send a follow-up PR for those if useful.
