### PR TITLE
Fix split library paths in CWA workflows

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -38,6 +38,7 @@ from . import db, calibre_db, ub, web_server, config, updater_thread, gdriveutil
 from .helper import check_valid_domain, send_test_mail, reset_password, generate_password_hash, check_email, \
     valid_email, check_username
 from .embed_helper import get_calibre_binarypath
+from .calibre_cli import get_calibre_cli_context
 from .gdriveutils import is_gdrive_ready, gdrive_support
 from .render_template import render_title_template, get_sidebar_config
 from .services.worker import WorkerThread
@@ -3033,11 +3034,18 @@ def restore_calibre_db():
 
         # 2. Run calibredb check_library (pre)
         calibredb_binary = get_calibre_binarypath("calibredb") or "/app/calibre/calibredb"
+        calibre_library_path, calibre_env = get_calibre_cli_context(config)
         check_cmd = [
             calibredb_binary, "check_library",
-            "--with-library", config.config_calibre_dir
+            "--with-library", calibre_library_path
         ]
-        check_result = subprocess.run(check_cmd, capture_output=True, text=True, timeout=300)
+        check_result = subprocess.run(
+            check_cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=calibre_env,
+        )
         log.info("calibredb check_library (pre) output: %s\n%s", check_result.stdout, check_result.stderr)
         if check_result.returncode != 0:
             log.warning("calibredb check_library (pre) returned code %s", check_result.returncode)
@@ -3049,10 +3057,16 @@ def restore_calibre_db():
         # 3. Run calibredb restore_database
         restore_cmd = [
             calibredb_binary, "restore_database",
-            "--with-library", config.config_calibre_dir,
+            "--with-library", calibre_library_path,
             "--really-do-it"
         ]
-        result = subprocess.run(restore_cmd, capture_output=True, text=True, timeout=1200)
+        result = subprocess.run(
+            restore_cmd,
+            capture_output=True,
+            text=True,
+            timeout=1200,
+            env=calibre_env,
+        )
         log.info("calibredb restore_database output: %s\n%s", result.stdout, result.stderr)
         with open(log_path, "a", encoding="utf-8") as log_file:
             log_file.write("\n[restore_database]\n")
@@ -3080,7 +3094,13 @@ def restore_calibre_db():
             return redirect(url_for("admin.db_configuration"))
 
         # 5. Run calibredb check_library (post)
-        check_result_post = subprocess.run(check_cmd, capture_output=True, text=True, timeout=300)
+        check_result_post = subprocess.run(
+            check_cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=calibre_env,
+        )
         log.info("calibredb check_library (post) output: %s\n%s", check_result_post.stdout, check_result_post.stderr)
         if check_result_post.returncode != 0:
             log.warning("calibredb check_library (post) returned code %s", check_result_post.returncode)

--- a/cps/calibre_cli.py
+++ b/cps/calibre_cli.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2025 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+import os
+
+
+def get_calibre_cli_context(config):
+    """Return the book root and environment for Calibre CLI commands.
+
+    Calibre expects ``--with-library`` to point at the book-files root. In a
+    split library, ``metadata.db`` lives elsewhere and must be supplied via
+    ``CALIBRE_OVERRIDE_DATABASE_PATH``.
+    """
+    library_path = config.get_book_path()
+    calibre_env = os.environ.copy()
+    if config.config_calibre_split:
+        calibre_env["CALIBRE_OVERRIDE_DATABASE_PATH"] = os.path.join(
+            config.config_calibre_dir,
+            "metadata.db",
+        )
+    return library_path, calibre_env

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -1726,7 +1726,7 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                         print(f"[cwa-duplicates-auto] Starting deletion of book {book.id}...", flush=True)
                         
                         # Backup book files
-                        book_path = os.path.join(config.config_calibre_dir, book.path)
+                        book_path = os.path.join(config.get_book_path(), book.path)
                         if os.path.exists(book_path):
                             backup_path = os.path.join(backup_dir, f"book_{book.id}")
                             print(f"[cwa-duplicates-auto] Backing up book {book.id} to {backup_path}...", flush=True)

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1264,7 +1264,10 @@ class NewBookProcessor:
             sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
             from cps.progress_syncing.checksums import calculate_koreader_partial_md5, store_checksum, CHECKSUM_VERSION
 
-            calibre_db_path = os.path.join(self.library_dir, 'metadata.db')
+            # self.library_dir points at the book-files root in split-library
+            # mode. self.metadata_db is captured before that switch and always
+            # points at the configured Calibre database.
+            calibre_db_path = self.metadata_db
 
             with sqlite3.connect(calibre_db_path, timeout=30) as con:
                 cur = con.cursor()

--- a/tests/unit/test_calibre_cli.py
+++ b/tests/unit/test_calibre_cli.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from cps.calibre_cli import get_calibre_cli_context
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_split_library_uses_books_root_and_database_override(monkeypatch):
+    config = SimpleNamespace(
+        get_book_path=lambda: "/books",
+        config_calibre_split=True,
+        config_calibre_dir="/calibre-library",
+    )
+    monkeypatch.setenv("CWA_TEST_ENV", "preserved")
+
+    library_path, calibre_env = get_calibre_cli_context(config)
+
+    assert library_path == "/books"
+    assert calibre_env["CALIBRE_OVERRIDE_DATABASE_PATH"] == "/calibre-library/metadata.db"
+    assert calibre_env["CWA_TEST_ENV"] == "preserved"
+    assert calibre_env is not os.environ
+
+
+def test_combined_library_does_not_override_database_path(monkeypatch):
+    config = SimpleNamespace(
+        get_book_path=lambda: "/calibre-library",
+        config_calibre_split=False,
+        config_calibre_dir="/calibre-library",
+    )
+    monkeypatch.delenv("CALIBRE_OVERRIDE_DATABASE_PATH", raising=False)
+
+    library_path, calibre_env = get_calibre_cli_context(config)
+
+    assert library_path == "/calibre-library"
+    assert "CALIBRE_OVERRIDE_DATABASE_PATH" not in calibre_env

--- a/tests/unit/test_duplicate_delete_index_maintenance.py
+++ b/tests/unit/test_duplicate_delete_index_maintenance.py
@@ -5,6 +5,8 @@ import importlib.util
 import pathlib
 import sys
 
+import pytest
+
 
 def _install_stub(name, attrs=None):
     module = ModuleType(name)
@@ -383,6 +385,54 @@ def test_auto_resolve_duplicates_deletes_duplicate_keys_and_refreshes_cache():
     assert delete_key_calls == [[2]]
     assert _CwaDB.instances[-1].cache_updates == [([], 0, 1)]
     assert _CwaDB.instances[-1].invalidated is False
+
+
+@pytest.mark.unit
+def test_auto_resolve_duplicates_checks_split_book_path_for_backup():
+    _CwaDB.instances = []
+    delete_key_calls = []
+    module, calibre_books, _calls = _load_duplicates_module(delete_key_calls)
+    module.config.config_calibre_dir = "/calibre-library"
+    module.config.get_book_path = lambda: "/books"
+
+    kept = SimpleNamespace(
+        id=1,
+        title="Dune",
+        timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        data=[],
+        path="Dune",
+    )
+    deleted = SimpleNamespace(
+        id=2,
+        title="Dune",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        data=[],
+        path="Dune Copy",
+    )
+    calibre_books[1] = kept
+    calibre_books[2] = deleted
+    checked_paths = []
+
+    def record_exists(path):
+        checked_paths.append(path)
+        return False
+
+    with patch("os.path.exists", side_effect=record_exists), patch("os.makedirs"):
+        result = module.auto_resolve_duplicates(
+            strategy="newest",
+            duplicate_groups=[
+                {
+                    "group_hash": "abc123",
+                    "title": "Dune",
+                    "author": "Frank Herbert",
+                    "books": [kept, deleted],
+                }
+            ],
+        )
+
+    assert result["success"] is True
+    assert "/books/Dune Copy" in checked_paths
+    assert "/calibre-library/Dune Copy" not in checked_paths
 
 
 def test_auto_resolve_dry_run_does_not_invalidate_duplicate_cache():

--- a/tests/unit/test_ingest_batch_dirty.py
+++ b/tests/unit/test_ingest_batch_dirty.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
+import sqlite3
 import subprocess
 from pathlib import Path
 from unittest import mock
@@ -134,3 +135,49 @@ def test_successful_add_format_marks_batch_dirty(monkeypatch, tmp_path):
 
     assert run_mock.call_args.args[0][:3] == ["calibredb", "add_format", "7"]
     assert (tmp_path / "batch_dirty").exists()
+
+
+def test_split_library_checksum_uses_metadata_db_not_books_root(monkeypatch, tmp_path):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+
+    import ingest_processor
+
+    processor = build_processor(ingest_processor, tmp_path)
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    processor.metadata_db = str(metadata_dir / "metadata.db")
+
+    book_path = "Author/Book (7)"
+    format_name = "Book - Author"
+    book_dir = Path(processor.library_dir) / book_path
+    book_dir.mkdir(parents=True)
+    ebook_path = book_dir / f"{format_name}.epub"
+    ebook_path.write_bytes(b"epub")
+
+    with sqlite3.connect(processor.metadata_db) as con:
+        con.execute(
+            "CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, path TEXT, timestamp TEXT)"
+        )
+        con.execute("CREATE TABLE data (book INTEGER, format TEXT, name TEXT)")
+        con.execute(
+            "INSERT INTO books (id, title, path, timestamp) VALUES (?, ?, ?, ?)",
+            (7, "Book", book_path, "2026-01-01"),
+        )
+        con.execute(
+            "INSERT INTO data (book, format, name) VALUES (?, ?, ?)",
+            (7, "EPUB", format_name),
+        )
+
+    with mock.patch(
+        "cps.progress_syncing.checksums.calculate_koreader_partial_md5",
+        return_value="a" * 32,
+    ) as calculate_mock, mock.patch(
+        "cps.progress_syncing.checksums.store_checksum",
+        return_value=True,
+    ) as store_mock:
+        processor.generate_book_checksums("Book", book_id=7)
+
+    calculate_mock.assert_called_once_with(str(ebook_path))
+    store_mock.assert_called_once()
+    assert not (Path(processor.library_dir) / "metadata.db").exists()


### PR DESCRIPTION
Summary

- generate post-ingest KOReader checksums against the configured `metadata.db`, not the split book-files root
- back up automatically resolved duplicate books from `config.get_book_path()`
- run `calibredb check_library` and `restore_database` with the book-files root plus `CALIBRE_OVERRIDE_DATABASE_PATH` in split-library mode
- preserve the existing behavior for non-split libraries

## Problem

When **Separate Book Files from Library** is enabled, CWA keeps `metadata.db` in `config_calibre_dir` and stores book files in `config_calibre_split_dir`. A few workflows still treated `config_calibre_dir` and the book-files root as the same directory. This caused checksum generation to open a non-existent database under the books directory, duplicate resolution to look for backup sources under the database directory, and Calibre database check/restore commands to receive the wrong library context.

## Tests

```text
pytest -q -m unit \
  tests/unit/test_calibre_cli.py \
  tests/unit/test_ingest_batch_dirty.py \
  tests/unit/test_duplicate_delete_index_maintenance.py

7 passed, 4 deselected
```

Additional checks:

- `git diff --check`
- Python `compileall` for all changed Python files
- Ruff `E4,E7,E9,F` checks for the new helper and its tests
