### PR TITLE
Feature/calibre content server

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -2437,10 +2437,17 @@ def _configuration_update_helper():
         reboot_required |= _config_string(to_save, "config_limiter_options")
 
         # Calibre content server configuration
+        server_username = to_save.get("config_calibre_server_username", config.config_calibre_server_username)
+        server_password = to_save.get("config_calibre_server_password_e") or config.config_calibre_server_password_e
+        if (to_save.get("config_calibre_server_enabled") == "on"
+                and to_save.get("config_calibre_server_anonymous_writes") != "on"
+                and not (server_username and server_password)):
+            return _configuration_result(_('Please enter a content server username and password, or allow anonymous writes'))
         content_server_changed |= _config_checkbox(to_save, "config_calibre_server_enabled")
         content_server_changed |= _config_int(to_save, "config_calibre_server_port")
+        content_server_changed |= _config_checkbox(to_save, "config_calibre_server_anonymous_writes")
         content_server_changed |= _config_string(to_save, "config_calibre_server_username")
-        if to_save.get("config_calibre_server_password_e"):
+        if to_save.get("config_calibre_server_password_e") and not config.config_calibre_server_password_e:
             content_server_changed |= _config_string(to_save, "config_calibre_server_password_e")
 
         # Rarfile Content configuration
@@ -2468,6 +2475,17 @@ def _configuration_update_helper():
     return _configuration_result(None, reboot_required, " ".join(filter(None, [unrar_warning, arch_warning])))
 
 
+@admi.route("/admin/config/clear_calibre_server_password", methods=['POST'])
+@user_login_required
+@admin_required
+def clear_calibre_server_password():
+    config.config_calibre_server_password_e = ""
+    config.save()
+    if config.config_calibre_server_enabled:
+        content_server.start()
+    return _configuration_result()
+
+
 def _configuration_result(error_flash=None, reboot=False, warning_flash=None):
     resp = {}
     if error_flash:
@@ -2482,6 +2500,8 @@ def _configuration_result(error_flash=None, reboot=False, warning_flash=None):
             resp['result'].append({'type': "warning", 'message': warning_flash})
     resp['reboot'] = reboot
     resp['config_upload'] = config.config_upload_formats
+    resp['calibre_server_password_set'] = bool(config.config_calibre_server_password_e)
+    resp['calibre_server_password_env'] = config.config_calibre_server_env['password']
     return Response(json.dumps(resp), mimetype='application/json')
 
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -44,6 +44,7 @@ from .services.worker import WorkerThread
 from .usermanagement import user_login_required
 from .cw_babel import get_available_translations, get_available_locale, get_user_locale_language
 from . import debug_info
+from . import content_server
 from .string_helper import strip_whitespaces
 
 log = logger.create()
@@ -2286,6 +2287,7 @@ def _db_configuration_update_helper():
 
 def _configuration_update_helper():
     reboot_required = False
+    content_server_changed = False
     to_save = request.form.to_dict()
     try:
         reboot_required |= _config_string(to_save, "config_trustedhosts")
@@ -2434,6 +2436,13 @@ def _configuration_update_helper():
         reboot_required |= _config_string(to_save, "config_limiter_uri")
         reboot_required |= _config_string(to_save, "config_limiter_options")
 
+        # Calibre content server configuration
+        content_server_changed |= _config_checkbox(to_save, "config_calibre_server_enabled")
+        content_server_changed |= _config_int(to_save, "config_calibre_server_port")
+        content_server_changed |= _config_string(to_save, "config_calibre_server_username")
+        if to_save.get("config_calibre_server_password_e"):
+            content_server_changed |= _config_string(to_save, "config_calibre_server_password_e")
+
         # Rarfile Content configuration
         _config_string(to_save, "config_rarfile_location")
         unrar_warning = None
@@ -2448,6 +2457,11 @@ def _configuration_update_helper():
         _configuration_result(_("Oops! Database Error: %(error)s.", error=e.orig))
 
     config.save()
+    if content_server_changed:
+        if config.config_calibre_server_enabled:
+            content_server.start()
+        else:
+            content_server.stop()
     if reboot_required:
         web_server.stop(True)
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -178,6 +178,11 @@ class _Settings(_Base):
     config_limiter_options = Column(String, default="")
     config_check_extensions = Column(Boolean, default=True)
 
+    config_calibre_server_enabled = Column(Boolean, default=False)
+    config_calibre_server_port = Column(Integer, default=8080)
+    config_calibre_server_username = Column(String, default="")
+    config_calibre_server_password_e = Column(String)
+
     def __repr__(self):
         return self.__class__.__name__
 
@@ -371,6 +376,19 @@ class ConfigSQL(object):
                         setattr(self, k, "")
                 else:
                     setattr(self, k, v)
+
+        env_port = os.environ.get("CALIBRE_SERVER_PORT")
+        env_username = os.environ.get("CALIBRE_SERVER_USERNAME")
+        env_password = os.environ.get("CALIBRE_SERVER_PASSWORD")
+        if env_port and env_port.isdigit():
+            self.config_calibre_server_port = int(env_port)
+        if env_username:
+            self.config_calibre_server_username = env_username
+        if env_password:
+            self.config_calibre_server_password_e = env_password
+        self.config_calibre_server_env = {"port": bool(env_port),
+                                          "username": bool(env_username),
+                                          "password": bool(env_password)}
 
         # Enforce unified logging to stdout for Docker deployments
         if self.config_logfile not in (logger.LOG_TO_STDOUT, logger.LOG_TO_STDERR):

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -180,6 +180,7 @@ class _Settings(_Base):
 
     config_calibre_server_enabled = Column(Boolean, default=False)
     config_calibre_server_port = Column(Integer, default=8080)
+    config_calibre_server_anonymous_writes = Column(Boolean, default=False)
     config_calibre_server_username = Column(String, default="")
     config_calibre_server_password_e = Column(String)
 

--- a/cps/content_server.py
+++ b/cps/content_server.py
@@ -38,7 +38,9 @@ def start():
         log.error("calibre-server binary not found: %s", binary)
         return
     args = [binary, "--port", str(config.config_calibre_server_port)]
-    if config.config_calibre_server_username and config.config_calibre_server_password_e:
+    if config.config_calibre_server_anonymous_writes:
+        args += ["--enable-local-write", "--trusted-ips", "0.0.0.0/0,::/0"]
+    elif config.config_calibre_server_username and config.config_calibre_server_password_e:
         userdb = os.path.join(constants.CONFIG_DIR, "content_server_users.sqlite")
         try:
             os.remove(userdb)
@@ -51,7 +53,7 @@ def start():
         if result.returncode != 0:
             log.error("Failed to create calibre content server user: %s", result.stderr)
             return
-        args += ["--enable-auth", "--userdb", userdb]
+        args += ["--enable-auth", "--auth-mode", "basic", "--userdb", userdb]
     args.append(config.config_calibre_dir)
     try:
         _process = subprocess.Popen(args)

--- a/cps/content_server.py
+++ b/cps/content_server.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+#   This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#     Copyright (C) 2026 OzzieIsaacs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import sys
+
+from . import config, constants, logger
+
+log = logger.create()
+
+_process = None
+
+
+def start():
+    global _process
+    stop()
+    if not config.config_calibre_server_enabled or not config.config_calibre_dir:
+        return
+    binary = os.path.join(config.config_binariesdir or "",
+                          "calibre-server.exe" if sys.platform == "win32" else "calibre-server")
+    if not os.path.isfile(binary):
+        log.error("calibre-server binary not found: %s", binary)
+        return
+    args = [binary, "--port", str(config.config_calibre_server_port)]
+    if config.config_calibre_server_username and config.config_calibre_server_password_e:
+        userdb = os.path.join(constants.CONFIG_DIR, "content_server_users.sqlite")
+        try:
+            os.remove(userdb)
+        except OSError:
+            pass
+        result = subprocess.run([binary, "--userdb", userdb, "--manage-users", "--", "add",
+                                 config.config_calibre_server_username,
+                                 config.config_calibre_server_password_e],
+                                capture_output=True, text=True)
+        if result.returncode != 0:
+            log.error("Failed to create calibre content server user: %s", result.stderr)
+            return
+        args += ["--enable-auth", "--userdb", userdb]
+    args.append(config.config_calibre_dir)
+    try:
+        _process = subprocess.Popen(args)
+    except OSError as ex:
+        log.error("Failed to start calibre content server: %s", ex)
+        _process = None
+        return
+    log.info("Calibre content server started on port %s", config.config_calibre_server_port)
+
+
+def stop():
+    global _process
+    if _process is not None and _process.poll() is None:
+        _process.terminate()
+        try:
+            _process.wait(10)
+        except subprocess.TimeoutExpired:
+            _process.kill()
+        log.info("Calibre content server stopped")
+    _process = None

--- a/cps/main.py
+++ b/cps/main.py
@@ -91,5 +91,8 @@ def main():
         app.register_blueprint(readingservices_userstorage)
     if oauth_available:
         app.register_blueprint(oauth)
+    from . import content_server
+    content_server.start()
     success = web_server.start()
+    content_server.stop()
     sys.exit(0 if success else 1)

--- a/cps/server.py
+++ b/cps/server.py
@@ -288,6 +288,8 @@ class WebServer(object):
             return True
 
         log.info("Performing restart of Calibre-Web Automated")
+        from . import content_server
+        content_server.stop()
         args = self._get_args_for_reloading()
         os.execv(args[0].lstrip('"').rstrip('"'), args)
 

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -63,6 +63,17 @@ $(document).on("change", "input[type=\"checkbox\"][data-control]", function () {
     });
 });
 
+// Same as above, but hides the related fields when the checkbox is checked
+$(document).on("change", "input[type=\"checkbox\"][data-control-invert]", function () {
+    var $this = $(this);
+    var name = $this.data("control-invert");
+    var showOrHide = !$this.prop("checked");
+
+    $("[data-related=\"" + name + "\"]").each(function () {
+        $(this).toggle(showOrHide);
+    });
+});
+
 // Generic control/related handler to show/hide fields based on a select' value
 $(document).on("change", "select[data-control]", function() {
     var $this = $(this);
@@ -749,6 +760,7 @@ $(function() {
 
     // Init all data control handlers to default
     $("input[data-control]").trigger("change");
+    $("input[data-control-invert]").trigger("change");
     $("select[data-control]").trigger("change");
     $("select[data-controlall]").trigger("change");
 
@@ -948,6 +960,11 @@ $(function() {
         $("#flash_danger").remove();
         $.post(getPath() + request_path, $(this).closest("form").serialize(), function(data) {
             $('#config_upload_formats').val(data.config_upload);
+            $("#config_calibre_server_password_e").val("")
+                .prop("disabled", data.calibre_server_password_set)
+                .attr("placeholder", data.calibre_server_password_set ? "********" : "");
+            $("#calibre_server_password_clear_group")
+                .toggle(data.calibre_server_password_set && !data.calibre_server_password_env);
             if(data.reboot) {
                 $("#spinning_success").show();
                 var rebootInterval = setInterval(function(){
@@ -968,6 +985,14 @@ $(function() {
             } else {
                 handle_response(data.result);
             }
+        });
+    });
+
+    $("#config_calibre_server_password_clear").click(function() {
+        $.post(getPath() + "/admin/config/clear_calibre_server_password", function(data) {
+            $("#config_calibre_server_password_e").val("").prop("disabled", false).removeAttr("placeholder");
+            $("#calibre_server_password_clear_group").hide();
+            handle_response(data.result);
         });
     });
 

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -222,6 +222,24 @@
       </div>
     </div>
     {% endif %}
+    <div class="form-group">
+      <input type="checkbox" id="config_calibre_server_enabled" name="config_calibre_server_enabled" data-control="calibre-server-settings" {% if config.config_calibre_server_enabled %}checked{% endif %}>
+      <label for="config_calibre_server_enabled">{{_('Enable Calibre Content Server')}}</label>
+    </div>
+    <div data-related="calibre-server-settings">
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_calibre_server_port">{{_('Content Server Port')}}</label>
+        <input type="number" min="1" max="65535" class="form-control" name="config_calibre_server_port" id="config_calibre_server_port" value="{% if config.config_calibre_server_port != None %}{{ config.config_calibre_server_port }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['port'] %}disabled{% endif %}>
+      </div>
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_calibre_server_username">{{_('Content Server Username')}}</label>
+        <input type="text" class="form-control" name="config_calibre_server_username" id="config_calibre_server_username" value="{% if config.config_calibre_server_username != None %}{{ config.config_calibre_server_username }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['username'] %}disabled{% endif %}>
+      </div>
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_calibre_server_password_e">{{_('Content Server Password')}}</label>
+        <input type="password" class="form-control" name="config_calibre_server_password_e" id="config_calibre_server_password_e" value="{% if config.config_calibre_server_env['password'] %}********{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['password'] %}disabled{% endif %}>
+      </div>
+    </div>
     {% if feature_support['goodreads'] %}
     <div class="form-group">
       <input type="checkbox" id="config_use_goodreads" name="config_use_goodreads" data-control="goodreads-settings" {% if config.config_use_goodreads %}checked{% endif %}>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -232,12 +232,21 @@
         <input type="number" min="1" max="65535" class="form-control" name="config_calibre_server_port" id="config_calibre_server_port" value="{% if config.config_calibre_server_port != None %}{{ config.config_calibre_server_port }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['port'] %}disabled{% endif %}>
       </div>
       <div class="form-group" style="margin-left:10px;">
-        <label for="config_calibre_server_username">{{_('Content Server Username')}}</label>
-        <input type="text" class="form-control" name="config_calibre_server_username" id="config_calibre_server_username" value="{% if config.config_calibre_server_username != None %}{{ config.config_calibre_server_username }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['username'] %}disabled{% endif %}>
+        <input type="checkbox" id="config_calibre_server_anonymous_writes" name="config_calibre_server_anonymous_writes" data-control-invert="calibre-server-auth" {% if config.config_calibre_server_anonymous_writes %}checked{% endif %}>
+        <label for="config_calibre_server_anonymous_writes">{{_('Allow Anonymous Writes (no username or password required)')}}</label>
       </div>
-      <div class="form-group" style="margin-left:10px;">
-        <label for="config_calibre_server_password_e">{{_('Content Server Password')}}</label>
-        <input type="password" class="form-control" name="config_calibre_server_password_e" id="config_calibre_server_password_e" value="{% if config.config_calibre_server_env['password'] %}********{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['password'] %}disabled{% endif %}>
+      <div data-related="calibre-server-auth">
+        <div class="form-group" style="margin-left:10px;">
+          <label for="config_calibre_server_username">{{_('Content Server Username')}}</label>
+          <input type="text" class="form-control" name="config_calibre_server_username" id="config_calibre_server_username" value="{% if config.config_calibre_server_username != None %}{{ config.config_calibre_server_username }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['username'] %}disabled{% endif %}>
+        </div>
+        <div class="form-group" style="margin-left:10px;">
+          <label for="config_calibre_server_password_e">{{_('Content Server Password')}}</label>
+          <input type="password" class="form-control" name="config_calibre_server_password_e" id="config_calibre_server_password_e" value="" autocomplete="off" {% if config.config_calibre_server_password_e %}placeholder="********" disabled{% endif %} {% if config.config_calibre_server_env['password'] %}disabled{% endif %}>
+        </div>
+        <div class="form-group" id="calibre_server_password_clear_group" style="margin-left:10px;{% if not config.config_calibre_server_password_e or config.config_calibre_server_env['password'] %}display:none;{% endif %}">
+          <button type="button" id="config_calibre_server_password_clear" class="btn btn-default">{{_('Reset Password')}}</button>
+        </div>
       </div>
     </div>
     {% if feature_support['goodreads'] %}


### PR DESCRIPTION
NOTE: I created a PR in Calibre-Web and Calibre-Web-Automated, the implementation is the same across all three.

Been meaning to do this for awhile. Calibre-Web already knows where the library and the calibre binaries are, but there's no way to run calibre's own content server from it.

## What this adds

Calibre-Web runs `calibre-server` as a child process, configured under Basic
Configuration → Feature Configuration:

- "Enable Calibre Content Server" checkbox, with port/username/password appearing once
  it's ticked — same `data-control`/`data-related` pattern as the Kobo and upload settings.
- "Allow Anonymous Writes" hides the credential fields and starts the server with
  `--enable-local-write --trusted-ips 0.0.0.0/0,::/0`.
- With credentials it starts with `--enable-auth --auth-mode basic` and a generated user
  db, so ordinary HTTP clients can authenticate.
- Starts on boot when enabled, restarts on save only if one of its own settings changed,
  and stops on shutdown and before the `os.execv` restart so the new process doesn't hit
  a port conflict.

Port, username and password can also come from `CALIBRE_SERVER_PORT`,
`CALIBRE_SERVER_USERNAME` and `CALIBRE_SERVER_PASSWORD` for docker setups. Env values win,
never get written to the db, and their fields render disabled.